### PR TITLE
Fix process lock to be released no matter how plover exits

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -32,7 +32,7 @@ These installation notes are for Debian-like Linux systems. From the
 directory in which this README file is located, run the following
 commands:
 
-sudo apt-get install python-xlib python-serial python-wxgtk2.8 python-lockfile appdirs
+sudo apt-get install python-xlib python-serial python-wxgtk2.8 appdirs
 sudo python setup.py install
 
 

--- a/application/plover
+++ b/application/plover
@@ -1,49 +1,17 @@
 #!/usr/bin/env python
 
 import sys
-import lockfile
+
 import plover.gui.main
-import os
-import tempfile
+import plover.oslayer.processlock
 
-# Ensure only one instance of Plover is running at a time.
-# Check the environment for items to make the lockfile unique
-# fallback if not found
-if 'USER' in os.environ:
-    user = os.environ['USER']
-else:
-    user = "UNKNOWN"
-    
-if 'DISPLAY' in os.environ:
-    display = os.environ['DISPLAY'][-1:]
-else:
-    display = "0"
-
-if hasattr(os, "uname"):
-    hostname = os.uname()[1]
-else:
-    import socket
-    hostname = socket.gethostname()
-        
-LOCK_FILE = os.path.join(tempfile.gettempdir(), '.plover-%s-%s-%s' %(hostname,user,display))
-lock = lockfile.FileLock(LOCK_FILE)
 try:
-    lock.acquire(0)
-except lockfile.AlreadyLocked:
-    print "Another instance of Plover is already running. Close it or delete %s" % (LOCK_FILE)
-    sys.exit(1)
-except lockfile.LockFailed:
-    print "The lock file %s cannot be locked." % LOCK_FILE
-    sys.exit(2)
-    
-# Create and start the user interface. Clean up the lock file afterward.
-try:
-    print "If Plover is quit using Ctrl-c, the %s file must \
-be removed before Plover can be run again." % (LOCK_FILE)
-    gui = plover.gui.main.PloverGUI()
-    gui.MainLoop()
+    # Ensure only one instance of Plover is running at a time.
+    with plover.oslayer.processlock.PloverLock():
+        gui = plover.gui.main.PloverGUI()
+        gui.MainLoop()
+except plover.oslayer.processlock.LockNotAcquiredException:
+    print 'Another instance of Plover is already running.'
 except:
     print "Unexpected error:", sys.exc_info()[0]
     raise
-finally:
-    lock.release()

--- a/plover/oslayer/__init__.py
+++ b/plover/oslayer/__init__.py
@@ -3,4 +3,4 @@
 
 """This package abstracts os details for plover."""
 
-__all__ = ['comscan', 'keyboardcontrol']
+__all__ = ['comscan', 'keyboardcontrol', 'processlock']

--- a/plover/oslayer/processlock.py
+++ b/plover/oslayer/processlock.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# Copyright (c) 2012 Hesky Fisher
+# See LICENSE.txt for details.
+#
+# processlock.py - Cross platform global lock to ensure plover only runs once.
+
+"""Global lock to ensure plover only runs once."""
+
+import sys
+
+class LockNotAcquiredException(Exception):
+    pass
+
+if sys.platform.startswith('win32'):
+    import win32event
+    import win32api
+    import winerror
+    
+    class PloverLock(object):
+        # A GUID from http://createguid.com/
+        guid='plover_{F8C06652-2C51-410B-8D15-C94DF96FC1F9}'
+        
+        def __init__(self):
+            pass
+            
+        def acquire(self):
+            self.mutex = win32event.CreateMutex(None, False, self.guid)
+            if win32api.GetLastError() == winerror.ERROR_ALREADY_EXISTS:
+                raise LockNotAcquiredException()
+            
+        def release(self):
+            if hasattr(self, 'mutex'):
+                win32api.CloseHandle(self.mutex)
+                del self.mutex
+                
+        def __del__(self):
+            self.release() 
+
+        def __enter__(self):
+            self.acquire()
+
+        def __exit__(self, type, value, traceback):
+            self.release()
+
+else:
+    import fcntl
+    import os
+    import tempfile
+    
+    class PloverLock(object):
+        def __init__(self):
+            # Check the environment for items to make the lockfile unique
+            # fallback if not found
+            if 'USER' in os.environ:
+                user = os.environ['USER']
+            else:
+                user = "UNKNOWN"
+
+            if 'DISPLAY' in os.environ:
+                display = os.environ['DISPLAY'][-1:]
+            else:
+                display = "0"
+
+            if hasattr(os, "uname"):
+                hostname = os.uname()[1]
+            else:
+                import socket
+                hostname = socket.gethostname()
+
+            lock_file_name = os.path.join(tempfile.gettempdir(), 
+                '.plover-%s-%s-%s' %(hostname,user,display))
+            self.fd = open(lock_file_name, 'w')
+                
+        def acquire(self):
+            try:
+                fcntl.flock(self.fd, fcntl.LOCK_EX|fcntl.LOCK_NB)
+            except IOError as e:
+                raise LockNotAcquiredException(str(e))
+                
+        def release(self):
+            try:
+                fcntl.flock(self.fd, fcntl.LOCK_UN)
+            except:
+                pass
+                
+        def __del__(self):
+            self.release()
+            try:
+                self.fd.close()
+            except:
+                pass
+                
+        def __enter__(self):
+            self.acquire()
+            
+        def __exit__(self, type, value, traceback):
+            self.release()
+            
+if __name__ == "__main__":
+    import time
+    with PloverLock():
+        print 'lock acquired'
+        time.sleep(30)
+        print 'locl released'
+            


### PR DESCRIPTION
Before this change, users who used Ctrl-C or other unusual means to exit plover would be unable to restart plover without manually finding a lock file and deleting it.
