### PR TITLE
Toggle steno input with the Sidewinder calculator button

### DIFF
--- a/plover/assets/dict.json
+++ b/plover/assets/dict.json
@@ -1,4 +1,5 @@
 { 
+"{calc}": "{PLOVER:TOGGLE}",
 "KH-FG": " {#grave}",
 "-FPLT": "{.}",
 "STPH": "{?}",

--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -44,6 +44,7 @@ KEYSTRING_TO_STENO_KEY = {"a": "S-",
                           "0": "#",
                           "-": "#",
                           "=": "#",
+                          "{148}": "{calc}", # Calculator button (sidewinder-specific)
                          }
 
 
@@ -85,17 +86,18 @@ class Stenotype(StenotypeBase):
             and event.keystring is not None
             and not self._keyboard_capture.is_keyboard_suppressed()):
             self._keyboard_emulation.send_backspaces(1)
-        if event.keystring in KEYSTRING_TO_STENO_KEY:
-            self._down_keys.add(event.keystring)
+        if event.keystring in KEYSTRING_TO_STENO_KEY or ("{%d}" % event.keycode) in KEYSTRING_TO_STENO_KEY:
+            self._down_keys.add(event.keystring or ("{%d}" % event.keycode))
 
     def _key_up(self, event):
-        if not event.keystring in KEYSTRING_TO_STENO_KEY:
+        if not (event.keystring in KEYSTRING_TO_STENO_KEY
+                or ("{%d}" % event.keycode) in KEYSTRING_TO_STENO_KEY):
             return
         # Called when a key is released.
         # Remove invalid released keys.
         self._released_keys = self._released_keys.intersection(self._down_keys)
         # Process the newly released key.
-        self._released_keys.add(event.keystring)
+        self._released_keys.add(event.keystring or "{%d}"%event.keycode)
         # A stroke is complete if all pressed keys have been released.
         if self._down_keys == self._released_keys:
             steno_keys = [KEYSTRING_TO_STENO_KEY[k] for k in self._down_keys

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -73,7 +73,10 @@ STENO_KEY_ORDER = {"#": -1,
                    "-T": 21,
                    "-S": 22,
                    "-D": 23,
-                   "-Z": 24}
+                   "-Z": 24,
+
+                   "{calc}": 25, # Calculator button (sidewinder-specific)
+}
 
 IMPLICIT_HYPHEN = set(('A-', 'O-', '5-', '0-', '-E', '-U', '*'))
 
@@ -119,8 +122,8 @@ class Stroke:
         if steno_keys_set & IMPLICIT_HYPHEN:
             self.rtfcre = ''.join(key.strip('-') for key in steno_keys)
         else:
-            pre = ''.join(k.strip('-') for k in steno_keys if k[-1] == '-' or 
-                          k == '#')
+            pre = ''.join(k.strip('-') for k in steno_keys if k[-1] == '-' or
+                          k == '#' or "{" in k) # special keys
             post = ''.join(k.strip('-') for k in steno_keys if k[0] == '-')
             self.rtfcre = '-'.join([pre, post]) if post else pre
 


### PR DESCRIPTION
This change allows users to toggle Plover by pressing the calculator button.

My Sidewinder keyboard has this awesome little "Calculator" button in the upper right hand corner. With this patch, the calculator button becomes a first-class steno stroke, which means I can map it to `{PLOVER:TOGGLE}`, or any other key combination in `dict.json`. This is more convenient than mapping an actual steno stroke to `{PLOVER:TOGGLE}` because the calc button doesn't cause any on-screen input, so there's no need to press backspace to clean the gibberish up.

A better patch would add support for dedicated {f1}...{f12} keys or perhaps allow for modifiers {shift+calc}, etc.

This patch probably isn't a great way of doing this, but it scratches my itch, so I thought I'd share.