### PR TITLE
Create lockfile in ~

### DIFF
--- a/plover/oslayer/processlock.py
+++ b/plover/oslayer/processlock.py
@@ -71,8 +71,8 @@ else:
                 import socket
                 hostname = socket.gethostname()
 
-            lock_file_name = os.path.join(tempfile.gettempdir(),
-                '.plover-%s-%s-%s' % (hostname, user, display))
+            lock_file_name = os.path.expanduser(
+                '~/.plover-lock-%s-%s' % (hostname, display))
             self.fd = open(lock_file_name, 'w')
 
         def acquire(self):


### PR DESCRIPTION
This fixes a potential denial-of-service attack,
where another user can prevent you running Plover
by creating a file in /tmp with your name in the
filename.

This patch was requested by Paul Wise in
http://bugs.debian.org/710989 as part of the
preparations for including Plover in Debian.
