### PR TITLE
Improve X11 keyboard emulation.

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -209,6 +209,7 @@ class KeyboardEmulation(object):
         backspace_keysym = XK.string_to_keysym('BackSpace')
         self.backspace_keycode, mods = self._keysym_to_keycode_and_modifiers(
                                                 backspace_keysym)
+        self.time = 0
 
     def send_backspaces(self, number_of_backspaces):
         """Emulate the given number of backspaces.
@@ -348,8 +349,11 @@ class KeyboardEmulation(object):
 
         """
         target_window = self.display.get_input_focus().focus
+        # Make sure every event time is different than the previous one, to
+        # avoid an application thinking its an auto-repeat.
+        self.time += 1
         key_event = event_class(detail=keycode,
-                                 time=X.CurrentTime,
+                                 time=self.time,
                                  root=self.display.screen().root,
                                  window=target_window,
                                  child=X.NONE,


### PR DESCRIPTION
Using LibreOffice, a lot of words are jumbled, e.g. 'sometimes' will appear as 'ssommeeti' or 'sommeetis', 'understand' as 'unnddersta' or 'unnderstad'. Notice how its always a repetition of some keys. My own problems with IBus and auto-repeated events got me thinking: older applications don't use XkbSetDetectableAutoRepeat to detect them, but use a hack similar to the first answer here:

http://stackoverflow.com/questions/2100654/ignore-auto-repeat-in-x11-applications

And in the code we actually send all simulated key press/release events with a time of 0. So this patch makes sure every key event time is different than the previous one, to
avoid some applications thinking its an auto-repeat.
