### PR TITLE
fix traceback in sidewinder when arpeggiation is enabled

### DIFF
--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -117,8 +117,8 @@ class Stenotype(StenotypeBase):
 
         # A stroke is complete if all pressed keys have been released.
         # If we are in arpeggiate mode then only send stroke when spacebar is pressed.
-        send_strokes = (self._down_keys and 
-                        self._down_keys == self._released_keys)
+        send_strokes = bool(self._down_keys and 
+                            self._down_keys == self._released_keys)
         if self.arpeggiate:
             send_strokes &= event.keystring == ' '
         if send_strokes:


### PR DESCRIPTION
Was getting a traceback with arpeggiation enabled in sidewinder.py.  In line 120, in the case of an empty set for self._down_keys, the set([]) was stored in send_strokes due to the short-circuiting of python's 'and' operator.  The subsequent 'send_strokes &= ...' in line 123 failed due to mismatched types (set and bool).  The fix is to ensure a boolean value is always stored in send_strokes.
