### PR TITLE
Fix the function signature for _post_suppress. After a resume _post_supp...

### DIFF
--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -72,7 +72,7 @@ class StenotypeBase(object):
         if self.suppress:
             self._post_suppress(self.suppress, steno_keys)
             
-    def _post_suppress(self, steno_keys):
+    def _post_suppress(self, suppress, steno_keys):
         """This is a complicated way for the application to tell the machine to 
         suppress this stroke after the fact. This only currently has meaning for 
         the keyboard machine so it can backspace over the last stroke when used 


### PR DESCRIPTION
...ress is called and since it had the wrong signature it caused an exception and the pipeline stopped working.

Fixes #152
