### PR TITLE
fix stentura high CPU usage

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -241,6 +241,9 @@ class KeyboardEmulation(object):
                 self._send_keycode(keycode, modifiers)
                 self.display.sync()
 
+        # prevent screensaver from activating.
+        self.send_key_combination('Shift_L')
+
     def send_key_combination(self, combo_string):
         """Emulate a sequence of key combinations.
 


### PR DESCRIPTION
This patch is a fix for high CPU usage in stentura.py.  It sets a small default timeout on the serial port (0.05 seconds) for reading data.  That timeout becomes the granularity for interrupting the process of reading data in _read_data().  _read_data() attempts to read as much data as it can within that small timeout period.  I moved the check for the overall timeout up to _read_packet().

Verified it functions with low CPU usage on Ubuntu 13.04.