### PR TITLE
Set formater default output mode for spaces.

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -40,6 +40,7 @@ class Formatter(object):
 
     def __init__(self):
         self.set_output(None)
+        self.spaces_after = False
 
     def set_output(self, output):
         """Set the output class."""


### PR DESCRIPTION
Default to "spaces before words" output in initialization, so code using
Plover 2.5.8 API is still compatible without the need to call
set_space_placement.
