### PR TITLE
Use different SendKeys

### DIFF
--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -22,10 +22,7 @@ import pythoncom
 import threading
 import win32api
 import win32con
-from pywinauto.SendKeysCtypes import SendKeys as _SendKeys
-
-def SendKeys(s):
-    _SendKeys(s, with_spaces=True, pause=0)
+import win32com.client
 
 # For the purposes of this class, we'll only report key presses that
 # result in these outputs in order to exclude special key combos.
@@ -163,13 +160,15 @@ class KeyboardEmulation:
     }
 
     SPECIAL_CHARS_PATTERN = re.compile(r'([]{}()+^%~[])')
+
+    shell = win32com.client.Dispatch('WScript.Shell')
     
     def send_backspaces(self, number_of_backspaces):
         for _ in xrange(number_of_backspaces):
-            SendKeys(self.keymap_single['BackSpace'])
+            self.shell.SendKeys(self.keymap_single['BackSpace'])
 
     def send_string(self, s):
-        SendKeys(re.sub(self.SPECIAL_CHARS_PATTERN, r'{\1}', s))
+        self.shell.SendKeys(re.sub(self.SPECIAL_CHARS_PATTERN, r'{\1}', s))
 
     def send_key_combination(self, s):
         combo = []
@@ -183,7 +182,7 @@ class KeyboardEmulation:
                 pass
             else:
                 combo.append(token)
-        SendKeys(''.join(combo))
+        self.shell.SendKeys(''.join(combo))
 
 
 class KeyboardEvent(object):


### PR DESCRIPTION
When I was setting up a Windows development environment, I had trouble installing and configuring pywinauto. It only installs successfully on 64-bit Windows after some modification, and even after I got it installed, I could not send any keys from the application.

Since pywinauto is only used for sending keys, it can actually be eliminated as a dependency if pywin32 is used as an alternative.

One issue I noticed after making this change is that when I toggle Plover on (but not off), the command's stroke is not correctly backspaced. I'm not sure what's causing this, or even if it's being caused by my change; I was totally unable to use Plover (except using the release binary) before switching to pywin32 for sending keys, so I can't tell if this was already a problem with the version of the code I'm running (along with my environment).

If there's some justification for using pywinauto over pywin32 for this (efficiency, threading, suppressed keystrokes like I've pointed out), feel free to reject my pull request. I only made this change because pywinauto doesn't seem to work on my computer, and I figured it doesn't really need to be there anyway.
