### PR TITLE
Add different output modes: Caps, Title, Lowercase, Snake, Camel

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -11,16 +11,18 @@ from os.path import commonprefix
 from collections import namedtuple
 from plover import orthography
 import re
+import string
+
 
 class Formatter(object):
     """Convert translations into output.
 
     The main entry point for this class is format, which takes in translations
     to format. Output is sent via an output class passed in through set_output.
-    Other than setting the output, the formatter class is stateless. 
+    Other than setting the output, the formatter class is stateless.
 
-    The output class can define the following functions, which will be called if
-    available:
+    The output class can define the following functions, which will be called
+    if available:
 
     send_backspaces -- Takes a number and deletes back that many characters.
 
@@ -35,7 +37,7 @@ class Formatter(object):
     """
 
     output_type = namedtuple(
-        'output', ['send_backspaces', 'send_string', 'send_key_combination', 
+        'output', ['send_backspaces', 'send_string', 'send_key_combination',
                    'send_engine_command'])
 
     def __init__(self):
@@ -67,7 +69,8 @@ class Formatter(object):
         self._output = output_type(*[getattr(output, f, noop) for f in fields])
 
     def set_space_placement(self, s):
-        """Set whether spaces will be inserted before the output or after the output"""
+        # Set whether spaces will be inserted
+        # before the output or after the output
         if s == 'After Output':
             self.spaces_after = True
         else:
@@ -78,12 +81,12 @@ class Formatter(object):
 
         Arguments:
 
-        undo -- A sequence of translations that should be undone. The formatting
-        parameter of the translations will be used to undo the actions that were
-        taken, if possible.
+        undo -- A sequence of translations that should be undone. The
+        formatting parameter of the translations will be used to undo the
+        actions that were taken, if possible.
 
-        do -- The new actions to format. The formatting attribute will be filled
-        in with the result.
+        do -- The new actions to format. The formatting attribute will be
+        filled in with the result.
 
         prev -- The last translation before the new actions in do. This
         translation's formatting attribute provides the context for the new
@@ -93,14 +96,16 @@ class Formatter(object):
         for t in do:
             last_action = _get_last_action(prev.formatting if prev else None)
             if t.english:
-                t.formatting = _translation_to_actions(t.english, last_action, self.spaces_after)
+                t.formatting = _translation_to_actions(t.english, last_action,
+                                                       self.spaces_after)
             else:
-                t.formatting = _raw_to_actions(t.rtfcre[0], last_action, self.spaces_after)
+                t.formatting = _raw_to_actions(t.rtfcre[0], last_action,
+                                               self.spaces_after)
             prev = t
 
         old = [a for t in undo for a in t.formatting]
         new = [a for t in do for a in t.formatting]
-        
+
         min_length = min(len(old), len(new))
         for i in xrange(min_length):
             if old[i] != new[i]:
@@ -113,6 +118,7 @@ class Formatter(object):
 
         OutputHelper(self._output).render(old[i:], new[i:])
 
+
 class OutputHelper(object):
     """A helper class for minimizing the amount of change on output.
 
@@ -124,7 +130,7 @@ class OutputHelper(object):
         self.before = ''
         self.after = ''
         self.output = output
-        
+
     def commit(self):
         # Python narrow Unicode is useless for long characters
         # UTF-32 is a good container to count characters
@@ -151,17 +157,18 @@ class OutputHelper(object):
                 self.before += a.text
 
         self.after = self.before
-        
+
         for a in reversed(undo):
             if a.text:
                 self.after = self.after[:-len(a.text)]
             if a.replace:
                 self.after += a.replace
-        
+
         for a in do:
             if a.replace:
                 if len(a.replace) > len(self.after):
-                    self.before = a.replace[:len(a.replace)-len(self.after)] + self.before
+                    self.before = a.replace[
+                        :len(a.replace)-len(self.after)] + self.before
                     self.after = ''
                 else:
                     self.after = self.after[:-len(a.replace)]
@@ -175,9 +182,11 @@ class OutputHelper(object):
                 self.output.send_engine_command(a.command)
         self.commit()
 
+
 def _get_last_action(actions):
     """Return last action in actions if possible or return a blank action."""
     return actions[-1] if actions else _Action()
+
 
 class _Action(object):
     """A hybrid class that stores instructions and resulting state.
@@ -187,8 +196,13 @@ class _Action(object):
     context to render future translations.
 
     """
-    def __init__(self, attach=False, glue=False, word='', capitalize=False, 
-                 lower=False, upper=False, upper_carry=False, orthography=True, text='', replace='', combo='',
+
+    CASE_NONE, CASE_UPPER, CASE_LOWER, CASE_TITLE = range(4)
+
+    def __init__(self, attach=False, glue=False, word='', capitalize=False,
+                 lower=False, orthography=True, space_char=' ',
+                 upper=False, upper_carry=False,
+                 case=CASE_NONE, text='', replace='', combo='',
                  command=''):
         """Initialize a new action.
 
@@ -214,6 +228,11 @@ class _Action(object):
         othography -- True if orthography rules should be applies when adding
         a suffix to this action.
 
+        space_char -- this character will replace spaces after all other
+        formatting has been applied
+
+        case -- an integer to determine which case to output after formatting
+
         text -- The text that should be rendered for this action.
 
         replace -- Text that should be deleted for this action.
@@ -221,7 +240,7 @@ class _Action(object):
         combo -- The key combo, in plover's key combo language, that should be
         executed for this action.
 
-        command -- The command that should be executed for this actions.
+        command -- The command that should be executed for this action.
 
         """
         # State variables
@@ -233,13 +252,17 @@ class _Action(object):
         self.upper = upper
         self.upper_carry = upper_carry
         self.orthography = orthography
-                
+
+        # Persistent state variables
+        self.space_char = space_char
+        self.case = case
+
         # Instruction variables
         self.text = text
         self.replace = replace
         self.combo = combo
         self.command = command
-        
+
     def copy_state(self):
         """Clone this action but only clone the state variables."""
         a = _Action()
@@ -251,8 +274,10 @@ class _Action(object):
         a.upper = self.upper
         a.upper_carry = self.upper_carry
         a.orthography = self.orthography
+        a.case = self.case
+        a.space_char = self.space_char
         return a
-        
+
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
@@ -264,7 +289,6 @@ class _Action(object):
 
     def __repr__(self):
         return str(self)
-
 
 META_ESCAPE = '\\'
 RE_META_ESCAPE = '\\\\'
@@ -300,9 +324,10 @@ META_RE = re.compile(r"""(?:%s%s|%s%s|[^%s%s])+ # One or more of anything
 #                                   # doesn't contain unescaped { or }
 #             """, re.VERBOSE)
 
+
 def _translation_to_actions(translation, last_action, spaces_after):
     """Create actions for a translation.
-    
+
     Arguments:
 
     translation -- A string with the translation to render.
@@ -347,6 +372,17 @@ META_GLUE_FLAG = '&'
 META_ATTACH_FLAG = '^'
 META_KEY_COMBINATION = '#'
 META_COMMAND = 'PLOVER:'
+META_MODE = 'MODE:'
+MODE_CAPS = 'CAPS'
+MODE_TITLE = 'TITLE'
+MODE_LOWER = 'LOWER'
+MODE_SNAKE = 'SNAKE'
+MODE_SET_SPACE = 'SET_SPACE:'
+MODE_RESET_SPACE = 'RESET_SPACE'
+MODE_RESET_CASE = 'RESET_CASE'
+MODE_CAMEL = 'CAMEL'
+MODE_RESET = 'RESET'
+
 
 def _raw_to_actions(stroke, last_action, spaces_after):
     """Turn a raw stroke into actions.
@@ -360,17 +396,20 @@ def _raw_to_actions(stroke, last_action, spaces_after):
     Returns: A list of actions.
 
     """
-    # If a raw stroke is composed of digits then remove the dash (if 
-    # present) and glue it to any neighboring digits. Otherwise, just 
+    # If a raw stroke is composed of digits then remove the dash (if
+    # present) and glue it to any neighboring digits. Otherwise, just
     # output the raw stroke as is.
     no_dash = stroke.replace('-', '', 1)
     if no_dash.isdigit():
         return _translation_to_actions(no_dash, last_action, spaces_after)
     else:
         if spaces_after:
-            return [_Action(text=(stroke + SPACE), word=stroke)]
+            return [_Action(text=(stroke + SPACE), word=stroke, case=last_action.case,
+                            space_char=last_action.space_char)]
         else:
-            return [_Action(text=(SPACE + stroke), word=stroke)]
+            return [_Action(text=(SPACE + stroke), word=stroke, case=last_action.case,
+                            space_char=last_action.space_char)]
+
 
 def _atom_to_action(atom, last_action, spaces_after):
     """Convert an atom into an action.
@@ -386,11 +425,13 @@ def _atom_to_action(atom, last_action, spaces_after):
     Returns: An action for the atom.
 
     """
+
     if spaces_after:
         return _atom_to_action_spaces_after(atom, last_action)
     else:
         return _atom_to_action_spaces_before(atom, last_action)
-    
+
+
 def _atom_to_action_spaces_before(atom, last_action):
     """Convert an atom into an action.
 
@@ -405,8 +446,8 @@ def _atom_to_action_spaces_before(atom, last_action):
     Returns: An action for the atom.
 
     """
-    
-    action = _Action()
+
+    action = _Action(space_char=last_action.space_char, case=last_action.case)
     last_word = last_action.word
     last_glue = last_action.glue
     last_attach = last_action.attach
@@ -415,6 +456,7 @@ def _atom_to_action_spaces_before(atom, last_action):
     last_upper = last_action.upper
     last_upper_carry = last_action.upper_carry
     last_orthography = last_action.orthography
+    begin = False  # for meta attach
     meta = _get_meta(atom)
     if meta is not None:
         meta = _unescape_atom(meta)
@@ -492,6 +534,9 @@ def _atom_to_action_spaces_before(atom, last_action):
         elif meta.startswith(META_COMMAND):
             action = last_action.copy_state()
             action.command = meta[len(META_COMMAND):]
+        elif meta.startswith(META_MODE):
+            action = last_action.copy_state()
+            action = _change_mode(meta[len(META_MODE):], action)
         elif meta.startswith(META_GLUE_FLAG):
             action.glue = True
             glue = last_glue or last_attach
@@ -503,7 +548,7 @@ def _atom_to_action_spaces_before(atom, last_action):
                 text = _lower(text)
             action.text = space + text
             action.word = _rightmost_word(last_word + action.text)
-        elif (meta.startswith(META_ATTACH_FLAG) or 
+        elif (meta.startswith(META_ATTACH_FLAG) or
               meta.endswith(META_ATTACH_FLAG)):
             begin = meta.startswith(META_ATTACH_FLAG)
             end = meta.endswith(META_ATTACH_FLAG)
@@ -515,12 +560,12 @@ def _atom_to_action_spaces_before(atom, last_action):
             if end:
                 action.attach = True
             if begin and end and meta == '':
-                # We use an empty connection to indicate a "break" in the 
-                # application of orthography rules. This allows the stenographer 
-                # to tell plover not to auto-correct a word.
+                # We use an empty connection to indicate a "break" in the
+                # application of orthography rules. This allows the
+                # stenographer to tell plover not to auto-correct a word.
                 action.orthography = False
-            if (((begin and not end) or (begin and end and ' ' in meta)) and 
-                last_orthography):
+            if (((begin and not end) or (begin and end and ' ' in meta)) and
+                    last_orthography):
                 new = orthography.add_suffix(last_word.lower(), meta)
                 common = commonprefix([last_word.lower(), new])
                 action.replace = last_word[len(common):]
@@ -550,7 +595,13 @@ def _atom_to_action_spaces_before(atom, last_action):
         space = NO_SPACE if last_attach else SPACE
         action.text = space + text
         action.word = _rightmost_word(text)
+
+    action.text = _apply_mode(action.text, action.case, action.space_char,
+                              begin, last_attach, last_glue,
+                              last_capitalize, last_upper, last_lower)
+
     return action
+
 
 def _atom_to_action_spaces_after(atom, last_action):
     """Convert an atom into an action.
@@ -566,8 +617,8 @@ def _atom_to_action_spaces_after(atom, last_action):
     Returns: An action for the atom.
 
     """
-    
-    action = _Action()
+
+    action = _Action(space_char=last_action.space_char, case=last_action.case)
     last_word = last_action.word
     last_glue = last_action.glue
     last_attach = last_action.attach
@@ -577,13 +628,18 @@ def _atom_to_action_spaces_after(atom, last_action):
     last_upper_carry = last_action.upper_carry
     last_orthography = last_action.orthography
     last_space = SPACE if last_action.text.endswith(SPACE) else NO_SPACE
+    was_space = len(last_space) is not 0
+    begin = False  # for meta attach
     meta = _get_meta(atom)
     if meta is not None:
         meta = _unescape_atom(meta)
         if meta in META_COMMAS:
             action.text = meta + SPACE
             if last_action.text != '':
-                action.replace = SPACE
+                if was_space:
+                    action.replace = SPACE
+                else:
+                    action.replace = NO_SPACE
             if last_attach:
                 action.replace = NO_SPACE
         elif meta in META_STOPS:
@@ -591,7 +647,10 @@ def _atom_to_action_spaces_after(atom, last_action):
             action.capitalize = True
             action.lower = False
             if last_action.text != '':
-                action.replace = SPACE
+                if was_space:
+                    action.replace = SPACE
+                else:
+                    action.replace = NO_SPACE
             if last_attach:
                 action.replace = NO_SPACE
         elif meta == META_CAPITALIZE:
@@ -659,6 +718,9 @@ def _atom_to_action_spaces_after(atom, last_action):
         elif meta.startswith(META_COMMAND):
             action = last_action.copy_state()
             action.command = meta[len(META_COMMAND):]
+        elif meta.startswith(META_MODE):
+            action = last_action.copy_state()
+            action = _change_mode(meta[len(META_MODE):], action)
         elif meta.startswith(META_GLUE_FLAG):
             action.glue = True
             text = meta[len(META_GLUE_FLAG):]
@@ -669,12 +731,15 @@ def _atom_to_action_spaces_after(atom, last_action):
             action.text = text + SPACE
             action.word = _rightmost_word(text)
             if last_glue:
-                action.replace = SPACE
+                if was_space:
+                    action.replace = SPACE
+                else:
+                    action.replace = NO_SPACE
                 action.word = _rightmost_word(last_word + text)
             if last_attach:
                 action.replace = NO_SPACE
                 action.word = _rightmost_word(last_word + text)
-        elif (meta.startswith(META_ATTACH_FLAG) or 
+        elif (meta.startswith(META_ATTACH_FLAG) or
               meta.endswith(META_ATTACH_FLAG)):
             begin = meta.startswith(META_ATTACH_FLAG)
             end = meta.endswith(META_ATTACH_FLAG)
@@ -682,21 +747,21 @@ def _atom_to_action_spaces_after(atom, last_action):
                 meta = meta[len(META_ATTACH_FLAG):]
             if end and len(meta) >= len(META_ATTACH_FLAG):
                 meta = meta[:-len(META_ATTACH_FLAG)]
-                
+
             space = NO_SPACE if end else SPACE
             replace_space = NO_SPACE if last_attach else SPACE
-            
+
             if end:
                 action.attach = True
             if begin and end and meta == '':
-                # We use an empty connection to indicate a "break" in the 
-                # application of orthography rules. This allows the stenographer 
-                # to tell plover not to auto-correct a word.
+                # We use an empty connection to indicate a "break" in the
+                # application of orthography rules. This allows the
+                # stenographer to tell plover not to auto-correct a word.
                 action.orthography = False
                 if last_action.text != '':
                     action.replace = replace_space
-            if (((begin and not end) or (begin and end and ' ' in meta)) and 
-                last_orthography):
+            if (((begin and not end) or (begin and end and ' ' in meta)) and
+                    last_orthography):
                 new = orthography.add_suffix(last_word.lower(), meta)
                 common = commonprefix([last_word.lower(), new])
                 if last_action.text == '':
@@ -715,7 +780,8 @@ def _atom_to_action_spaces_after(atom, last_action):
                 action.upper_carry = True
             action.text = meta + space
             action.word = _rightmost_word(
-                last_word[:len(last_word + last_space)-len(action.replace)] + meta)
+                last_word[:len(last_word + last_space)-len(action.replace)]
+                + meta)
             if end and not begin and last_space == SPACE:
                 action.word = _rightmost_word(meta)
         elif meta.startswith(META_KEY_COMBINATION):
@@ -730,10 +796,107 @@ def _atom_to_action_spaces_after(atom, last_action):
         if last_upper:
             text = _upper(text)
             action.upper_carry = True
-            
+
         action.text = text + SPACE
         action.word = _rightmost_word(text)
+
+    action.text = _apply_mode(action.text, action.case, action.space_char,
+                              begin, last_attach, last_glue,
+                              last_capitalize, last_upper, last_lower)
     return action
+
+
+def _apply_mode(text, case, space_char, begin, last_attach,
+                last_glue, last_capitalize, last_upper, last_lower):
+    # Should title case be applied to the beginning of the next string?
+    lower_title_case = ((begin or
+                         last_attach or
+                         last_glue) and not
+                        (last_capitalize or
+                         last_upper))
+    # Apply case, then replace space character
+    text = _apply_case(text, case, lower_title_case)
+    text = _apply_space_char(text, space_char)
+
+    # Title case is sensitive to lower flag
+    if last_lower and len(text) > 0:  # Check for text
+            if (case is _Action.CASE_TITLE):
+                text = _lower(text)
+
+    return text
+
+
+def _change_mode(command, action):
+
+    """
+    command should be:
+        CAPS, LOWER, TITLE, CAMEL, SNAKE, RESET_SPACE,
+            RESET_CASE, SET_SPACE or RESET
+
+        CAPS: UPPERCASE
+        LOWER: lowercase
+        TITLE: Title Case
+        CAMEL: titleCase, no space, initial lowercase
+        SNAKE: Underscore_space
+        RESET_SPACE: Space resets to ' '
+        RESET_CASE: Reset to normal case
+        SET_SPACE:xy: Set space to xy
+        RESET: Reset to normal case, space resets to ' '
+    """
+
+    if command == MODE_CAPS:
+        action.case = _Action.CASE_UPPER
+
+    elif command == MODE_TITLE:
+        action.case = _Action.CASE_TITLE
+
+    elif command == MODE_LOWER:
+        action.case = _Action.CASE_LOWER
+
+    elif command == MODE_SNAKE:
+        action.space_char = '_'
+    elif command == MODE_CAMEL:
+        action.case = _Action.CASE_TITLE
+        action.space_char = ''
+        action.lower = True
+
+    elif command == MODE_RESET:
+        action.space_char = SPACE
+        action.case = _Action.CASE_NONE
+
+    elif command == MODE_RESET_SPACE:
+        action.space_char = SPACE
+
+    elif command == MODE_RESET_CASE:
+        action.case = _Action.CASE_NONE
+
+    elif command.startswith(MODE_SET_SPACE):
+        action.space_char = command[len(MODE_SET_SPACE):]
+
+    return action
+
+
+def _apply_case(input_text, case, appended):
+    text = input_text
+    action = _Action()
+    if case is _Action.CASE_LOWER:
+        text = text.lower()
+    elif case is _Action.CASE_UPPER:
+        text = text.upper()
+    elif case is _Action.CASE_TITLE:
+        # Do nothing to appended output
+        if not appended:
+            text = string.capwords(text, " ")
+
+    return text
+
+
+def _apply_space_char(text, space_char):
+    if space_char != ' ':
+        return text.replace(' ', space_char)
+    else:
+        return text
+
 
 def _get_meta(atom):
     """Return the meta command, if any, without surrounding meta markups."""
@@ -743,14 +906,17 @@ def _get_meta(atom):
         return atom[len(META_START):-len(META_END)]
     return None
 
+
 def _apply_glue(s):
     """Mark the given string as a glue stroke."""
     return META_START + META_GLUE_FLAG + s + META_END
+
 
 def _unescape_atom(atom):
     """Replace escaped meta markups with unescaped meta markups."""
     return atom.replace(META_ESC_START, META_START).replace(META_ESC_END,
                                                             META_END)
+
 
 def _get_engine_command(atom):
     """Return the steno engine command, if any, represented by the atom."""
@@ -760,13 +926,16 @@ def _get_engine_command(atom):
         return atom[len(META_START) + len(META_COMMAND):-len(META_END)]
     return None
 
+
 def _capitalize(s):
     """Capitalize the first letter of s."""
     return s[0:1].upper() + s[1:]
 
+
 def _lower(s):
     """Lowercase the first letter of s."""
     return s[0:1].lower() + s[1:]
+
 
 def _capitalize_nowhitespace(s):
     """Capitalize the first letter of s (ignoring spaces)."""
@@ -775,11 +944,12 @@ def _capitalize_nowhitespace(s):
     first_word = True
     for word in word_list:
         if len(word) > 0:
-            if first_word == True:
+            if first_word is True:
                 word = word[0:1].upper() + word[1:]
                 first_word = False
         final_list.append(word)
     return ' '.join(final_list)
+
 
 def _lower_nowhitespace(s):
     """Lowercase the first letter of s (ignoring spaces)."""
@@ -788,16 +958,17 @@ def _lower_nowhitespace(s):
     first_word = True
     for word in word_list:
         if len(word) > 0:
-            if first_word == True:
+            if first_word is True:
                 word = word[0:1].lower() + word[1:]
                 first_word = False
         final_list.append(word)
     return ' '.join(final_list)
-    #return s[0:1].lower() + s[1:]
+
 
 def _upper(s):
     """Uppercase the entire s."""
     return s.upper()
+
 
 def _rightmost_word(s):
     """Get the rightmost word in s."""

--- a/plover/test_formatting.py
+++ b/plover/test_formatting.py
@@ -114,7 +114,7 @@ class FormatterTestCase(unittest.TestCase):
          ([action(text=' driving', word='driving')],),
          [('b', 1), ('s', 'ing')]
         ),
-        
+
         (
          ([translation(formatting=[action(text=' drive')])],
          [translation(english='{#c}driving')],
@@ -524,6 +524,7 @@ class FormatterTestCase(unittest.TestCase):
         self.check_arglist(formatting._raw_to_actions, cases)
 
     def test_atom_to_action_spaces_before(self):
+        an_action = action()
         cases = [
         (('{^ed}', action(word='test')), 
          action(text='ed', replace='', word='tested')),
@@ -621,42 +622,76 @@ class FormatterTestCase(unittest.TestCase):
         (('some text', action(word='test')), 
          action(text=' some text', word='text')),
 
+        (('some text', action(word='test',
+                              case=an_action.CASE_TITLE,
+                              space_char='')),
+            action(text='SomeText', word='text',
+                   case=an_action.CASE_TITLE,
+                   space_char='')),
+
+        (('some text', action(word='test', # This is camel case
+                              case=an_action.CASE_TITLE,
+                              space_char='', lower=True)),
+            action(text='someText', word='text',
+                   case=an_action.CASE_TITLE,
+                   space_char='')),
+
+        (('some text', action(word='test', space_char='_')),
+         action(text='_some_text', word='text', space_char='_')),
+
+        (('some text', action(word='test', case=an_action.CASE_UPPER)),
+         action(text=' SOME TEXT', word='text', case=an_action.CASE_UPPER)),
+
+        (('sOme TexT', action(word='test', case=an_action.CASE_LOWER)),
+         action(text=' some text', word='TexT', case=an_action.CASE_LOWER)),
+
+        (('sOme TexT', action(word='test', case=an_action.CASE_TITLE)),
+         action(text=' Some Text', word='TexT', case=an_action.CASE_TITLE)),
+
+        (('{MODE:CAPS}', action(word='test')),
+         action(word='test', case=an_action.CASE_UPPER)),
+
+        (('{MODE:LOWER}', action(word='test')),
+         action(word='test', case=an_action.CASE_LOWER)),
+
         ]
+
         self.check_arglist(formatting._atom_to_action_spaces_before, cases)
 
     def test_atom_to_action_spaces_after(self):
+        an_action = action()
         cases = [
-        (('{^ed}', action(word='test', text='test ')), 
+        (('{^ed}', action(word='test', text='test ')),
          action(text='ed ', replace=' ', word='tested')),
 
-        (('{^ed}', action(word='carry', text='carry ')), 
+        (('{^ed}', action(word='carry', text='carry ')),
          action(text='ied ', replace='y ', word='carried')),
 
-        (('{^er}', action(word='test', text='test ')), 
+        (('{^er}', action(word='test', text='test ')),
          action(text='er ', replace=' ', word='tester')),
 
-        (('{^er}', action(word='carry', text='carry ')), 
+        (('{^er}', action(word='carry', text='carry ')),
          action(text='ier ', replace='y ', word='carrier')),
 
-        (('{^ing}', action(word='test', text='test ')), 
+        (('{^ing}', action(word='test', text='test ')),
          action(text='ing ', replace=' ', word='testing')),
 
-        (('{^ing}', action(word='begin', text='begin ')), 
+        (('{^ing}', action(word='begin', text='begin ')),
          action(text='ning ', replace=' ', word='beginning')),
 
-        (('{^ing}', action(word='parade', text='parade ')), 
+        (('{^ing}', action(word='parade', text='parade ')),
          action(text='ing ', replace='e ', word='parading')),
 
-        (('{^s}', action(word='test', text='test ')), 
+        (('{^s}', action(word='test', text='test ')),
          action(text='s ', replace=' ', word='tests')),
 
         (('{,}', action(word='test', text='test ')), action(text=', ', replace=' ')),
 
         (('{:}', action(word='test', text='test ')), action(text=': ', replace=' ')),
-         
+
         (('{;}', action(word='test', text='test ')), action(text='; ', replace=' ')),
 
-        (('{.}', action(word='test', text='test ')), 
+        (('{.}', action(word='test', text='test ')),
          action(text='. ', replace=' ', capitalize=True)),
 
         (('{?}', action(word='test', text='test ')),
@@ -685,13 +720,13 @@ class FormatterTestCase(unittest.TestCase):
 
         (('{PLOVER:test_command}', action(word='test', text='test ')),
          action(word='test', command='test_command')),
-        
+
         (('{&glue_text}', action(word='test', text='test ')),
          action(text='glue_text ', word='glue_text', glue=True)),
-        
+
         (('{&glue_text}', action(word='test', text='test ', glue=True)),
          action(text='glue_text ', word='testglue_text', replace=' ', glue=True)),
-        
+
         (('{&glue_text}', action(word='test', text='test', attach=True)),
          action(text='glue_text ', word='testglue_text', glue=True)),
 
@@ -704,26 +739,134 @@ class FormatterTestCase(unittest.TestCase):
         (('{attach_text^}', action(word='test', text='test ')),
          action(text='attach_text', word='attach_text', attach=True)),
 
-        (('{#ALT_L(A)}', action(word='test', text='test ')), 
+        (('{#ALT_L(A)}', action(word='test', text='test ')),
          action(combo='ALT_L(A)', word='test')),
 
-        (('text', action(word='test', text='test ')), 
+        (('text', action(word='test', text='test ')),
          action(text='text ', word='text')),
 
-        (('text', action(word='test', text='test ', glue=True)), 
+        (('text', action(word='test', text='test ', glue=True)),
          action(text='text ', word='text')),
 
-        (('text2', action(word='test2', text='test2', attach=True)), 
+        (('text2', action(word='test2', text='test2', attach=True)),
          action(text='text2 ', word='text2', replace='')),
 
-        (('text', action(word='test', text='test ', capitalize=True)), 
+        (('text', action(word='test', text='test ', capitalize=True)),
          action(text='Text ', word='Text')),
 
-        (('some text', action(word='test', text='test ')), 
+        (('some text', action(word='test', text='test ')),
          action(text='some text ', word='text')),
+
+        (('some text', action(word='test',
+                              case=an_action.CASE_TITLE,
+                              space_char='')),
+            action(text='SomeText', word='text',
+                   case=an_action.CASE_TITLE,
+                   space_char='')),
+
+        (('some text', action(word='test', # This is camel case
+                              case=an_action.CASE_TITLE,
+                              space_char='', lower=True)),
+            action(text='someText', word='text',
+                   case=an_action.CASE_TITLE,
+                   space_char='')),
+
+        (('some text', action(word='test', space_char='_')),
+         action(text='some_text_', word='text', space_char='_')),
+
+        (('some text', action(word='test', case=an_action.CASE_UPPER)),
+         action(text='SOME TEXT ', word='text', case=an_action.CASE_UPPER)),
+
+        (('sOme TexT', action(word='test', case=an_action.CASE_LOWER)),
+         action(text='some text ', word='TexT', case=an_action.CASE_LOWER)),
+
+        (('sOme TexT', action(word='test', case=an_action.CASE_TITLE)),
+         action(text='Some Text ', word='TexT', case=an_action.CASE_TITLE)),
+
+        (('{MODE:CAPS}', action(word='test')),
+         action(word='test', case=an_action.CASE_UPPER)),
+
+        (('{MODE:LOWER}', action(word='test')),
+         action(word='test', case=an_action.CASE_LOWER)),
+
         ]
-        self.check_arglist(formatting._atom_to_action_spaces_after, cases)        
-    
+        self.check_arglist(formatting._atom_to_action_spaces_after, cases)
+
+    def test_change_mode(self):
+        an_action = action()
+        cases = [
+            # Undefined
+            (('', action()), (action())),
+            (('ABCD', action()), (action())),
+            # CAPS: Uppercase
+            (('CAPS', action()), (action(case=an_action.CASE_UPPER))),
+            # LOWER: Lowercase
+            (('LOWER', action()), (action(case=an_action.CASE_LOWER))),
+            # TITLE: Titlecase
+            (('TITLE', action()), (action(case=an_action.CASE_TITLE))),
+            # CAMEL: Titlecase without space
+            (('CAMEL', action()), (
+                action(case=an_action.CASE_TITLE, space_char='',
+                       lower=True)
+                )),
+            # SNAKE: Underscore space
+            (('SNAKE', action()), (action(space_char='_'))),
+            # RESET_SPACE: Default space
+            (('RESET_SPACE', action(space_char='ABCD')), (action())),
+            # RESET_CASE: No case
+            (('RESET_CASE', action(
+                case=an_action.CASE_UPPER)), (action())),
+            # SET_SPACE:xy: Set space to xy
+            (('SET_SPACE:', action(space_char='test')),
+                (action(space_char=''))),
+            (('SET_SPACE:-', action(space_char='test')),
+                (action(space_char='-'))),
+            (('SET_SPACE:123 45', action(space_char='test')),
+                (action(space_char='123 45'))),
+            # RESET: No case, default space
+        ]
+
+        self.check_arglist(formatting._change_mode, cases)
+
+    def test_apply_case(self):
+        an_action = action()
+        # case, text, begin
+        test = ' some test '
+        test2 = 'test Me'
+        test3 = ' SOME TEST '
+        cases = [
+            # UNDEFINED
+            ((test, '', False), (test)),
+            ((test, 'TEST', False), (test)),
+            # TITLE
+            ((test, an_action.CASE_TITLE, False), (' Some Test ')),
+            # TITLE will not affect appended output
+            ((test, an_action.CASE_TITLE, True), (' some test ')),
+            ((test2, an_action.CASE_TITLE, True), ('test Me')),
+            # LOWER
+            ((test, an_action.CASE_LOWER, False), (' some test ')),
+            ((test3, an_action.CASE_LOWER, False), (' some test ')),
+            ((test2, an_action.CASE_LOWER, True), ('test me')),
+            # UPPER
+            ((test.upper(), an_action.CASE_UPPER, False), (' SOME TEST ')),
+            ((test3, an_action.CASE_UPPER, False), (' SOME TEST ')),
+            ((test2, an_action.CASE_UPPER, True), ('TEST ME')),
+        ]
+
+        self.check_arglist(formatting._apply_case, cases)
+
+    def test_apply_space_char(self):
+        # (text, space_char)
+        test = ' some text '
+        test2 = "don't"
+        cases = [
+            ((test, '_'), ('_some_text_')),
+            ((test, ''), ('sometext')),
+            ((test2, '_'), (test2)),
+            ((test2, ''), (test2)),
+        ]
+        self.check_arglist(formatting._apply_space_char, cases)
+
     def test_get_meta(self):
         cases = [('', None), ('{abc}', 'abc'), ('abc', None)]
         self.check(formatting._get_meta, cases)


### PR DESCRIPTION
This pull adds several different cases. Namely:

- CAPITAL CASE
- Title Case
- lower case
- snake_case
- CamelCase

They are controlled by "MODE" commands, similar to "PLOVER" commands. They can be toggled with CAPS, TITLE, LOWER, SNAKE, and CAMEL. They can all be turned off with CLEAR.

CAPS, Title case, and lower case are mutually exclusive, so turning on one will turn off the others. CamelCase is mutually exclusive to all other cases. Snake case is only exclusive with camel case.

This means CAPS, title, and lower case can be used with snake case. This functionality is useful for programmers and regular stenographers alike. The cases are useful for programmers while coding, such as in variable names. For regular stenographers, CAPS can represent yelling, or scene cues, for example. Title case is useful for journalism.

I've tried to keep some sanity while coding these. The initial implementation used global variables, but this wasn't testable. Now, a dict of the cases has been added as a variable to the Action class. Since the cases are persistent, the case is passed along on each stroke. The MODE command directly modifies the mode of the action.

Some sample strokes for testing:

    "KA*PS": "{MODE:CAPS}",
    "K-BGS": "{MODE:CAMEL}",
    "TAO*EULT": "{MODE:TITLE}",
    "STPHA*EUBG": "{MODE:SNAKE}",
    "HRO*ER": "{MODE:LOWER}",
    "KHRAO*ER": "{MODE:CLEAR}",

Hope the code is up to standard -- if not, I'd be happy to make it so.

Ted