### PR TITLE
Fix counting and output of long Unicode characters

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -106,11 +106,17 @@ class OutputHelper(object):
         self.output = output
         
     def commit(self):
-        offset = len(commonprefix([self.before, self.after]))
-        if self.before[offset:]:
-            self.output.send_backspaces(len(self.before[offset:]))
-        if self.after[offset:]:
-            self.output.send_string(self.after[offset:])
+        # Python narrow Unicode is useless for long characters
+        # UTF-32 is a good container to count characters
+        before_32 = self.before.encode('utf-32-be')
+        after_32 = self.after.encode('utf-32-be')
+        # Get the closest multiple of 4 for length
+        offset = len(commonprefix([before_32, after_32]))/4*4
+        if before_32[offset:]:
+            self.output.send_backspaces(len(before_32[offset:])/4)
+        if after_32[offset:]:
+            # Convert back to Unicode for the send_string method
+            self.output.send_string(after_32[offset:].decode('utf-32-be'))
         self.before = ''
         self.after = ''
 


### PR DESCRIPTION
Addresses #216 by encoding into UTF-32 before calculating common prefix,then decoding back to Unicode for output through the OS layer.

It works because UTF-32 is fixed-width, so each character always takes 4 "lengths". That's why when we get common prefix, I divide then multiply by 4. That rounds the result to get you the right count. I've tested against the issues I mentioned in the issue.