### PR TITLE
Blackhole keyboard output on X11 using XGrabKeyboard, fixes #41

### DIFF
--- a/plover/gui/keyboard_config.py
+++ b/plover/gui/keyboard_config.py
@@ -3,12 +3,19 @@
 
 import wx
 from wx.lib.utils import AdjustRectToScreen
+import sys
 
 DIALOG_TITLE = 'Keyboard Configuration'
 ARPEGGIATE_LABEL = "Arpeggiate"
 ARPEGGIATE_INSTRUCTIONS = """Arpeggiate allows using non-NKRO keyboards.
 Each key can be pressed separately and the space bar
 is pressed to send the stroke."""
+GRAB_KEYBOARD_LABEL = "Grab keyboard"
+GRAB_KEYBOARD_INSTRUCTIONS = """On Linux, grab keyboard lets us capture keystrokes
+without outputting them first (and deleting them afterwards).  This can
+fix bugs on some applications which do not support delete.  However, for
+many text widgets this will cause the text cursor to become invisible while
+using Plover."""
 UI_BORDER = 4
 
 class KeyboardConfigDialog(wx.Dialog):
@@ -30,6 +37,17 @@ class KeyboardConfigDialog(wx.Dialog):
         self.arpeggiate_option.SetValue(options.arpeggiate)
         sizer.Add(self.arpeggiate_option, border=UI_BORDER, 
                   flag=wx.LEFT | wx.RIGHT | wx.BOTTOM)
+
+        # ToDo: arguably this is an abstraction boundary violation, and
+        # the set of available options should be handled by the oslayer
+        # itself, but for now, bake it into the keyboard.
+        if sys.platform.startswith('linux'):
+            sizer.Add(wx.StaticText(self, label=GRAB_KEYBOARD_INSTRUCTIONS),
+                    border=UI_BORDER, flag=wx.ALL)
+            self.grab_keyboard_option = wx.CheckBox(self, label=GRAB_KEYBOARD_LABEL)
+            self.grab_keyboard_option.SetValue(options.grab_keyboard)
+            sizer.Add(self.grab_keyboard_option, border=UI_BORDER,
+                      flag=wx.LEFT | wx.RIGHT | wx.BOTTOM)
         
         ok_button = wx.Button(self, id=wx.ID_OK)
         ok_button.SetDefault()
@@ -56,6 +74,7 @@ class KeyboardConfigDialog(wx.Dialog):
 
     def on_ok(self, event):
         self.options.arpeggiate = self.arpeggiate_option.GetValue()
+        self.options.grab_keyboard = self.grab_keyboard_option.GetValue()
         self.EndModal(wx.ID_OK)
     
     def on_cancel(self, event):

--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -65,7 +65,7 @@ class Stenotype(StenotypeBase):
         """Monitor a Microsoft Sidewinder X4 keyboard via X events."""
         StenotypeBase.__init__(self)
         self._keyboard_emulation = keyboardcontrol.KeyboardEmulation()
-        self._keyboard_capture = keyboardcontrol.KeyboardCapture()
+        self._keyboard_capture = keyboardcontrol.KeyboardCapture(params)
         self._keyboard_capture.key_down = self._key_down
         self._keyboard_capture.key_up = self._key_up
         self.suppress_keyboard(True)
@@ -134,4 +134,5 @@ class Stenotype(StenotypeBase):
         bool_converter = lambda s: s == 'True'
         return {
             'arpeggiate': (False, bool_converter),
+            'grab_keyboard': (False, bool_converter),
         }


### PR DESCRIPTION
The upside: delete emulation is no longer necessary!

The downside: GTK's default textbox seems to hide the cursor when
someone else has grabbed the keyboard (for example, when using gedit),
so the editing experience gets worse for many situations.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>