### PR TITLE
Linux: fix SetTopApp crash

### DIFF
--- a/plover/gui/add_translation.py
+++ b/plover/gui/add_translation.py
@@ -130,12 +130,13 @@ class AddTranslationDialog(wx.Dialog):
 
     def on_close(self, event=None):
         self.engine.translator.set_state(self.previous_state)
+        self.other_instances.remove(self)
+        self.Destroy()
+        self.Update()
         try:
             util.SetForegroundWindow(self.last_window)
         except:
             pass
-        self.other_instances.remove(self)
-        self.Destroy()
 
     def on_strokes_change(self, event):
         key = self._normalized_strokes()
@@ -209,4 +210,4 @@ def Show(parent, engine, config):
     dialog_instance.Show()
     dialog_instance.Raise()
     dialog_instance.strokes_text.SetFocus()
-    util.SetTopApp()
+    util.SetTopApp(dialog_instance)

--- a/plover/gui/lookup.py
+++ b/plover/gui/lookup.py
@@ -97,12 +97,13 @@ class LookupDialog(wx.Dialog):
 
     def on_close(self, event=None):
         self.engine.translator.set_state(self.previous_state)
+        self.other_instances.remove(self)
+        self.Destroy()
+        self.Update() # confirm dialog is removed before setting fg window
         try:
             util.SetForegroundWindow(self.last_window)
         except:
             pass
-        self.other_instances.remove(self)
-        self.Destroy()
 
     def on_translation_change(self, event):
         # TODO: normalize dict entries to make reverse lookup more reliable with 
@@ -146,4 +147,4 @@ def Show(parent, engine, config):
     dialog_instance.Show()
     dialog_instance.Raise()
     dialog_instance.translation_text.SetFocus()
-    util.SetTopApp()
+    util.SetTopApp(dialog_instance)

--- a/plover/gui/util.py
+++ b/plover/gui/util.py
@@ -8,7 +8,7 @@ if sys.platform.startswith('win32'):
     GetForegroundWindow = win32gui.GetForegroundWindow
     SetForegroundWindow = win32gui.SetForegroundWindow
 
-    def SetTopApp():
+    def SetTopApp(w):
         # Nothing else is necessary for windows.
         pass
 
@@ -28,7 +28,7 @@ tell application "System Events"
     set the frontmost of first process whose unix id is %d to true
 end tell""" % pid).executeAndReturnError_(None)
 
-    def SetTopApp():
+    def SetTopApp(w):
         NSApplication.sharedApplication()
         NSApp().activateIgnoringOtherApps_(True)
 
@@ -43,14 +43,18 @@ elif sys.platform.startswith('linux'):
             return None
 
     def SetForegroundWindow(w):
+        """Returns focus to previous application."""
         try:
             call(['wmctrl', '-i', '-a', w])
         except CalledProcessError:
             pass
 
-    def SetTopApp():
+    def SetTopApp(w):
+        """Forces the new dialog to the front."""
+        
+        w.Update() # make sure the dialog has drawn before using wmctrl
         try:
-            call(['wmctrl', '-a', TITLE])
+           call(['wmctrl', '-a', w.Title])
         except CalledProcessError:
             pass
 
@@ -63,5 +67,5 @@ else:
     def SetForegroundWindow(w):
         pass
 
-    def SetTopApp():
+    def SetTopApp(w):
         pass


### PR DESCRIPTION
It looks like when the LOOKUP feature was added and O/S-specific utilities were refactored out into plover.gui.util, the Linux version of SetTopApp was still using the TITLE global (now defined in both lookup.py and add_translation_py).

Modified the SetTopApp function in plover.gui.util to require a dialog object, confirms it has rendered, and passes the title to wmctrl to bring it to front. Also modified plover.gui.lookup and plover.gui.add_translation
to accommodate the util change.

For the problem of returning focus, it seems as though calling Destroy() on a child window returns focus to the parent. The original on_close handlers called SetForegroundWindow before Destroy. Reversed that order, and it also seemed to require a call to Update after Destroy to make sure the dialog has un-drawn and the default focus change happened before returning focus to the original application.

This is all working as I would expect, but I do notice that if I run plover from the command line and open, then close either dialog, the first stroke entered into the original application prints an error on the console:
```
<class 'Xlib.error.BadWindow'>: code = 3, resource_id = Xlib.xobject.resource.Resource(0x042001ab), sequence_number = 69, major_opcode = 25, minor_opcode = 0
```
The dialogs behave as expected, and the stroke prints correctly, but the message still appears, but only for the first stroke after closing the dialog.

I'm really new to the codebase (and any kind of desktop app development), nor do I totally have my head wrapped around the guts of Plover, so I don't really know whether this is a serious problem. Any advice on running it down?
