### PR TITLE
adding preliminary support for the kinesis advantage keyboard

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -23,6 +23,7 @@ import plover.oslayer.keyboardcontrol as keyboardcontrol
 import plover.steno as steno
 import plover.machine.base
 import plover.machine.sidewinder
+import plover.machine.kinesis
 import plover.steno_dictionary as steno_dictionary
 import plover.steno as steno
 import plover.translation as translation
@@ -202,7 +203,8 @@ class StenoEngine(object):
         else:
             self.translator.clear_state()
             self.formatter.set_output(self.command_only_output)
-        if isinstance(self.machine, plover.machine.sidewinder.Stenotype):
+        if (isinstance(self.machine, plover.machine.sidewinder.Stenotype)
+            or isinstance(self.machine, plover.machine.kinesis.Stenotype)):
             self.machine.suppress_keyboard(self.is_running)
         for callback in self.subscribers:
             callback(None)

--- a/plover/machine/kinesis.py
+++ b/plover/machine/kinesis.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2010 Joshua Harlan Lifton.
+# See LICENSE.txt for details.
+
+# TODO: add options to remap keys
+# TODO: look into programmatically pasting into other applications
+
+"For use with a Kinesis Advantage keyboard used as stenotype machine."
+
+# TODO: Change name to NKRO Keyboard.
+
+from plover.machine.base import StenotypeBase
+from plover.oslayer import keyboardcontrol
+
+KEYCODE_TO_STENO_KEY = {38: "S-",
+                        24: "S-",
+                        25: "T-",
+                        39: "K-",
+                        26: "P-",
+                        40: "W-",
+                        27: "H-",
+                        41: "R-",
+                        55: "A-", # key V, should be 22 backspace
+                        56: "O-", # key B, should be 119 delete
+                        28: "*",
+                        42: "*",
+                        29: "*",
+                        43: "*",
+                        57: "-E", # key N, should be 36 enter
+                        58: "-U", # key M, should be 56 space
+                        30: "-F",
+                        44: "-R",
+                        31: "-P",
+                        45: "-B",
+                        32: "-L",
+                        46: "-G",
+                        33: "-T",
+                        47: "-S",
+                        51: "-D",
+                        48: "-Z",
+                        10: "#",
+                        11: "#",
+                        12: "#",
+                        13: "#",
+                        14: "#",
+                        15: "#",
+                        16: "#",
+                        17: "#",
+                        18: "#",
+                        19: "#",
+                        20: "#",
+                        21: "#",
+                    }
+
+
+class Stenotype(StenotypeBase):
+    """Standard stenotype interface for a Kinesis Advantage keyboard.
+
+    This class implements the three methods necessary for a standard
+    stenotype interface: start_capture, stop_capture, and
+    add_callback.
+
+    """
+
+    def __init__(self, params):
+        """Monitor a Kinesis Advantage keyboard via X events."""
+        StenotypeBase.__init__(self)
+        self._keyboard_emulation = keyboardcontrol.KeyboardEmulation()
+        self._keyboard_capture = keyboardcontrol.KeyboardCapture()
+        self._keyboard_capture.key_down = self._key_down
+        self._keyboard_capture.key_up = self._key_up
+        self.suppress_keyboard(True)
+        self._down_keys = set()
+        self._released_keys = set()
+        self.arpeggiate = params['arpeggiate']
+
+    def start_capture(self):
+        """Begin listening for output from the stenotype machine."""
+        self._keyboard_capture.start()
+        self._ready()
+
+    def stop_capture(self):
+        """Stop listening for output from the stenotype machine."""
+        self._keyboard_capture.cancel()
+        self._stopped()
+
+    def suppress_keyboard(self, suppress):
+        self._is_keyboard_suppressed = suppress
+        self._keyboard_capture.suppress_keyboard(suppress)
+
+    def _key_down(self, event):
+        """Called when a key is pressed."""
+        if (self._is_keyboard_suppressed
+            and event.keycode is not None
+            and not self._keyboard_capture.is_keyboard_suppressed()):
+            self._keyboard_emulation.send_backspaces(1)
+        if event.keycode in KEYCODE_TO_STENO_KEY:
+            self._down_keys.add(event.keycode)
+
+    def _post_suppress(self, suppress, steno_keys):
+        """Backspace the last stroke since it matched a command.
+        
+        The suppress function is passed in to prevent threading issues with the 
+        gui.
+        """
+        n = len(steno_keys)
+        if self.arpeggiate:
+            n += 1
+        suppress(n)
+
+    def _key_up(self, event):
+        """Called when a key is released."""
+        if event.keycode in KEYCODE_TO_STENO_KEY:            
+            # Process the newly released key.
+            self._released_keys.add(event.keycode)
+            # Remove invalid released keys.
+            self._released_keys = self._released_keys.intersection(self._down_keys)
+
+        # A stroke is complete if all pressed keys have been released.
+        # If we are in arpeggiate mode then only send stroke when spacebar is pressed.
+        send_strokes = bool(self._down_keys and 
+                            self._down_keys == self._released_keys)
+        # if self.arpeggiate:
+        #     send_strokes &= event.keystring == ' '
+        if send_strokes:
+            steno_keys = [KEYCODE_TO_STENO_KEY[k] for k in self._down_keys
+                          if k in KEYCODE_TO_STENO_KEY]
+            if steno_keys:
+                self._down_keys.clear()
+                self._released_keys.clear()
+                self._notify(steno_keys)
+
+    @staticmethod
+    def get_option_info():
+        bool_converter = lambda s: s == 'True'
+        return {
+            'arpeggiate': (False, bool_converter),
+        }

--- a/plover/machine/registry.py
+++ b/plover/machine/registry.py
@@ -6,6 +6,7 @@
 from plover.machine.geminipr import Stenotype as geminipr
 from plover.machine.txbolt import Stenotype as txbolt
 from plover.machine.sidewinder import Stenotype as sidewinder
+from plover.machine.kinesis import Stenotype as kinesis
 from plover.machine.stentura import Stenotype as stentura
 from plover.machine.passport import Stenotype as passport
 
@@ -49,6 +50,7 @@ class Registry(object):
 
 machine_registry = Registry()
 machine_registry.register('NKRO Keyboard', sidewinder)
+machine_registry.register('Kinesis Advantage', kinesis)
 machine_registry.register('Gemini PR', geminipr)
 machine_registry.register('TX Bolt', txbolt)
 machine_registry.register('Stentura', stentura)


### PR DESCRIPTION
This adds a copy of sidewinder.py which matches on keycodes instead of keystrings (which are a bad idea anyway, as they depend on your keyboard layout...).
However, this does *not* use the thumb keys, but instead uses V/B and N/M. To support the thumb keys, changes in plover internals would be necessary, as they are all special characters (backspace, delete, return and space), which are not handled correctly right now.