### PR TITLE
Allow Windows keys behavior, and other passthrough keys enhancements.

### DIFF
--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -45,7 +45,8 @@ class KeyboardCapture():
     CONTROL_KEYS = set(('Lcontrol', 'Rcontrol'))
     SHIFT_KEYS = set(('Lshift', 'Rshift'))
     ALT_KEYS = set(('Lmenu', 'Rmenu'))
-    PASSTHROUGH_KEYS = CONTROL_KEYS | SHIFT_KEYS | ALT_KEYS
+    WIN_KEYS = set(('Lwin', 'Rwin'))
+    PASSTHROUGH_KEYS = CONTROL_KEYS | SHIFT_KEYS | ALT_KEYS | WIN_KEYS
     
     def __init__(self):
 


### PR DESCRIPTION
This pull request contains two commits.

The first is a simplification and correction, whereby meta keys are monitored as a group, rather than individually (since no behavior is determined based on the particular key in question), and also now their down state is properly monitored. See commit message for details.

The second commit adds Windows key commands to the list of actions that will act as usual and be ignored by plover.