### PR TITLE
Better normalize number strokes to insert dash, fixes #276

### DIFF
--- a/plover/steno.py
+++ b/plover/steno.py
@@ -16,6 +16,7 @@ import re
 STROKE_DELIMITER = '/'
 IMPLICIT_HYPHENS = set('AOEU*50')
 
+
 def normalize_steno(strokes_string):
     """Convert steno strings to one common form."""
     strokes = strokes_string.split(STROKE_DELIMITER)
@@ -25,6 +26,10 @@ def normalize_steno(strokes_string):
             stroke = stroke.replace('#', '')
             if not re.search('[0-9]', stroke):
                 stroke = '#' + stroke
+        # Insert dash when dealing with 'explicit' numbers
+        if re.search('[1-4][6-9]', stroke):
+            start = re.search('[6-9]', stroke).start()
+            stroke = stroke[:start] + '-' + stroke[start:]
         has_implicit_dash = bool(set(stroke) & IMPLICIT_HYPHENS)
         if has_implicit_dash:
             stroke = stroke.replace('-', '')

--- a/plover/test_steno.py
+++ b/plover/test_steno.py
@@ -18,6 +18,13 @@ class StenoTestCase(unittest.TestCase):
         ('-ES', 'ES'),
         ('TW-EPBL', 'TWEPBL'),
         ('TWEPBL', 'TWEPBL'),
+        ('19', '1-9'),
+        ('14', '14'),
+        ('146', '14-6'),
+        ('67', '67'),
+        ('46', '4-6'),
+        ('456', '456'),
+        ('S46', 'S4-6'),
         )
         
         for arg, expected in cases:
@@ -29,6 +36,7 @@ class StenoTestCase(unittest.TestCase):
         self.assertEqual(Stroke(['T-', 'S-']).rtfcre, 'ST')
         self.assertEqual(Stroke(['-P', '-P']).rtfcre, '-P')
         self.assertEqual(Stroke(['-P', 'X-']).rtfcre, 'X-P')
+        self.assertEqual(Stroke(['#', 'S-', '-T']).rtfcre, '1-9')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Interpret number strokes so that an entry like 18 gets read as 1-8. I don't think that users should have to think about explicit dashes when dealing with numeric entries.

Additionally, this change makes it so that the Plover add translation dialogue correctly inserts "1-8" into the dictionary. The regex string for this kind of stroke is [1-4][6-9]. That means that numbers on opposite sides of the keyboard in the middle this stroke effectively count as an implicit asterisk.

The only issue I can think of would be that the user could have duplicate strokes in their dictionary if they have both "19" and "1-9" defined, for example. But is that a big enough issue compared to not being able to define strokes with numbers in them? I don't think it is, but you, the reviewer, can weigh in.