### PR TITLE
Change wx version requirement for older Linux distros issue #316

### DIFF
--- a/plover/main.py
+++ b/plover/main.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 import traceback
 
-WXVER = '3.0'
+WXVER = '2.8'
 if not hasattr(sys, 'frozen'):
     import wxversion
     wxversion.ensureMinimal(WXVER)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
         ],
         ':"linux" in sys_platform': [
             'python-xlib>=0.14',
-            'wxPython>=3.0',
+            'wxPython>=2.8',
         ],
         ':"darwin" in sys_platform': [
             'pyobjc-core>=3.0.3',


### PR DESCRIPTION
This is really all it took to get things working in Mint 17. #316 I mentioned checking OS to only do this in Linux. Should unnecessary if it is true that setup-tools ensures 3.0 for Windows and OSX. If either manage to have 2.8 installed before the check everything should presumably still function as intended.