### PR TITLE
Allow engine to be passed to GUI on initialization.

### DIFF
--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -37,8 +37,9 @@ from plover import __license__
 class PloverGUI(wx.App):
     """The main entry point for the Plover application."""
 
-    def __init__(self, config):
+    def __init__(self, config, engine=None):
         self.config = config
+        self.engine = engine
         # Override sys.argv[0] so X11 windows class is correctly set.
         argv = sys.argv
         try:
@@ -51,7 +52,7 @@ class PloverGUI(wx.App):
         """Called just before the application starts."""
         # Enable GUI logging.
         from plover.gui import log as gui_log
-        frame = MainFrame(self.config)
+        frame = MainFrame(self.config, engine=self.engine)
         self.SetTopWindow(frame)
         frame.Show()
         return True
@@ -87,7 +88,7 @@ class MainFrame(wx.Frame):
     COMMAND_FOCUS = 'FOCUS'
     COMMAND_QUIT = 'QUIT'
 
-    def __init__(self, config):
+    def __init__(self, config, engine=None):
         self.config = config
 
         # Note: don't set position from config, since it's not yet loaded.
@@ -185,7 +186,10 @@ class MainFrame(wx.Frame):
         rect = wx.Rect(config.get_main_frame_x(), config.get_main_frame_y(), *self.GetSize())
         self.SetRect(AdjustRectToScreen(rect))
 
-        self.steno_engine = app.StenoEngine()
+        if engine is None:
+            self.steno_engine = app.StenoEngine()
+        else:
+            self.steno_engine = engine
         self.steno_engine.add_callback(
             lambda s: wx.CallAfter(self._update_status, s))
         self.steno_engine.set_output(


### PR DESCRIPTION
This is so that the engine can be customized from outside the GUI.
Using this one can make use of the plover GUI stuff, but use a modified engine, without creating a fork of the project.
I'm using it at https://github.com/benreynwar/stenoprog/blob/73e8c4423dcf228d039ee0bee73f1ac8e044d4ab/launch.py#L142

There's quite likely a more elegant way of doing this, but this one works.