### PR TITLE
Fix stentura tests

### DIFF
--- a/plover/machine/stentura.py
+++ b/plover/machine/stentura.py
@@ -426,7 +426,6 @@ def _validate_response(packet):
     return True
 
 
-# Timeout is in seconds, can be a float.
 def _read_data(port, stop, buf, offset, num_bytes):
     """Read data off the serial port and into port at offset.
 


### PR DESCRIPTION
Fix the tests that got broken with the recent changes to timeout handling.

I don't have a Stentura, but only added some sanity check to the read code, so hopefully it still works with a real machine.