### PR TITLE
Rework keyboard suppression

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -22,7 +22,6 @@ import plover.config as conf
 import plover.formatting as formatting
 import plover.steno as steno
 import plover.machine.base
-import plover.machine.sidewinder
 import plover.translation as translation
 from plover.exception import InvalidConfigurationError,DictionaryLoaderException
 from plover.machine.registry import machine_registry, NoSuchMachineException
@@ -163,14 +162,14 @@ class StenoEngine(object):
         self.set_is_running(False)
 
     def set_machine(self, machine):
-        if self.machine:
+        if self.machine is not None:
             self.machine.remove_state_callback(self._machine_state_callback)
             self.machine.remove_stroke_callback(
                 self._translator_machine_callback)
             self.machine.remove_stroke_callback(log.stroke)
             self.machine.stop_capture()
         self.machine = machine
-        if self.machine:
+        if self.machine is not None:
             self.machine.add_state_callback(self._machine_state_callback)
             self.machine.add_stroke_callback(log.stroke)
             self.machine.add_stroke_callback(self._translator_machine_callback)
@@ -193,8 +192,8 @@ class StenoEngine(object):
         else:
             self.translator.clear_state()
             self.formatter.set_output(self.command_only_output)
-        if isinstance(self.machine, plover.machine.sidewinder.Stenotype):
-            self.machine.suppress_keyboard(self.is_running)
+        if self.machine is not None:
+            self.machine.set_suppression(self.is_running)
         for callback in self.subscribers:
             callback(None)
 

--- a/plover/gui/keyboard_config.py
+++ b/plover/gui/keyboard_config.py
@@ -30,18 +30,18 @@ class EditKeysDialog(wx.Dialog):
         self.action = action
         self.keys = set(keys)
         self.original_keys = self.keys.copy()
-        self.capture = KeyboardCapture(KeyboardCapture.SUPPORTED_KEYS)
+        self.capture = KeyboardCapture()
         self.capture.key_down = lambda key: wx.CallAfter(self.on_capture_key, key)
 
     def ShowModal(self):
         self.update_message()
         self.capture.start()
-        self.capture.suppress_keyboard(True)
         try:
+            # Prevent dialog from stealing space key events.
+            self.capture.suppress_keyboard(('space',))
             code = super(EditKeysDialog, self).ShowModal()
         finally:
-            self.capture.suppress_keyboard(False)
-        self.capture.cancel()
+            self.capture.cancel()
         return code
 
     def update_message(self):

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -346,4 +346,4 @@ class Output(object):
     def send_engine_command(self, c):
         result = self.engine_command_callback(c)
         if result and not self.engine.is_running:
-            self.engine.machine.suppress = self.send_backspaces
+            self.engine.machine.suppress_last_stroke(self.send_backspaces)

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -23,7 +23,6 @@ class StenotypeBase(object):
         self.stroke_subscribers = []
         self.state_subscribers = []
         self.state = STATE_STOPPED
-        self.suppress = None
 
     def start_capture(self):
         """Begin listening for output from the stenotype machine."""
@@ -62,22 +61,27 @@ class StenotypeBase(object):
 
     def _notify(self, steno_keys):
         """Invoke the callback of each subscriber with the given argument."""
-        # If the stroke matches a command while the keyboard is not suppressed 
-        # then the stroke needs to be suppressed after the fact. One of the 
-        # handlers will set the suppress function. This function is passed in to 
-        # prevent threading issues with the gui.
-        self.suppress = None
         for callback in self.stroke_subscribers:
             callback(steno_keys)
-        if self.suppress:
-            self._post_suppress(self.suppress)
-            
-    def _post_suppress(self, suppress):
-        """This is a complicated way for the application to tell the machine to 
-        suppress this stroke after the fact. This only currently has meaning for 
-        the keyboard machine so it can backspace over the last stroke when used 
-        to issue a command when plover is 'off'.
-        """
+
+    def set_suppression(self, enabled):
+        '''Enable keyboard suppression.
+
+        This is only of use for the keyboard machine,
+        to suppress the keyboard when then engine is running.
+        '''
+        pass
+
+    def suppress_last_stroke(self, send_backspaces):
+        '''Suppress the last stroke key events after the fact.
+
+        This is only of use for the keyboard machine,
+        and the engine is resumed with a command stroke.
+
+        Argument:
+
+        send_backspaces -- The function to use to send backspaces.
+        '''
         pass
 
     def _set_state(self, state):

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -70,9 +70,9 @@ class StenotypeBase(object):
         for callback in self.stroke_subscribers:
             callback(steno_keys)
         if self.suppress:
-            self._post_suppress(self.suppress, steno_keys)
+            self._post_suppress(self.suppress)
             
-    def _post_suppress(self, suppress, steno_keys):
+    def _post_suppress(self, suppress):
         """This is a complicated way for the application to tell the machine to 
         suppress this stroke after the fact. This only currently has meaning for 
         the keyboard machine so it can backspace over the last stroke when used 

--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -43,7 +43,6 @@ class Stenotype(StenotypeBase):
         self._keyboard_capture.key_down = self._key_down
         self._keyboard_capture.key_up = self._key_up
         self._last_stroke_key_down_count = 0
-        self.suppress_keyboard(True)
 
     def start_capture(self):
         """Begin listening for output from the stenotype machine."""
@@ -55,8 +54,11 @@ class Stenotype(StenotypeBase):
         self._keyboard_capture.cancel()
         self._stopped()
 
-    def suppress_keyboard(self, suppress):
-        self._keyboard_capture.suppress_keyboard(suppress)
+    def set_suppression(self, enabled):
+        self._keyboard_capture.suppress_keyboard(enabled)
+
+    def suppress_last_stroke(self, send_backspaces):
+        send_backspaces(self._last_stroke_key_down_count)
 
     def _key_down(self, key):
         """Called when a key is pressed."""
@@ -66,14 +68,6 @@ class Stenotype(StenotypeBase):
         steno_key = self.keymap.get(key)
         if steno_key is not None:
             self._down_keys.add(steno_key)
-
-    def _post_suppress(self, suppress):
-        """Backspace the last stroke since it matched a command.
-        
-        The suppress function is passed in to prevent threading issues with the 
-        gui.
-        """
-        suppress(self._last_stroke_key_down_count)
 
     def _key_up(self, key):
         """Called when a key is released."""

--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -61,11 +61,11 @@ class Stenotype(StenotypeBase):
 
     def _key_down(self, key):
         """Called when a key is pressed."""
+        assert key is not None
         if (self._is_keyboard_suppressed
-            and key is not None
             and not self._keyboard_capture.is_keyboard_suppressed()):
             self._keyboard_emulation.send_backspaces(1)
-        steno_key = self.keymap.get(key, None)
+        steno_key = self.keymap.get(key)
         if steno_key is not None:
             self._down_keys.add(steno_key)
 
@@ -82,7 +82,8 @@ class Stenotype(StenotypeBase):
 
     def _key_up(self, key):
         """Called when a key is released."""
-        steno_key = self.keymap.get(key, None)
+        assert key is not None
+        steno_key = self.keymap.get(key)
         if steno_key is not None:
             # Process the newly released key.
             self._released_keys.add(steno_key)

--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -9,7 +9,7 @@
 
 from plover.machine.base import StenotypeBase
 from plover.machine.keymap import Keymap
-from plover.oslayer import keyboardcontrol
+from plover.oslayer.keyboardcontrol import KeyboardCapture
 
 
 class Stenotype(StenotypeBase):
@@ -39,8 +39,7 @@ class Stenotype(StenotypeBase):
                     del self.keymap[key]
         self._down_keys = set()
         self._released_keys = set()
-        self._keyboard_emulation = keyboardcontrol.KeyboardEmulation()
-        self._keyboard_capture = keyboardcontrol.KeyboardCapture(self.keymap.keys())
+        self._keyboard_capture = KeyboardCapture(self.keymap.keys())
         self._keyboard_capture.key_down = self._key_down
         self._keyboard_capture.key_up = self._key_up
         self.suppress_keyboard(True)
@@ -56,15 +55,11 @@ class Stenotype(StenotypeBase):
         self._stopped()
 
     def suppress_keyboard(self, suppress):
-        self._is_keyboard_suppressed = suppress
         self._keyboard_capture.suppress_keyboard(suppress)
 
     def _key_down(self, key):
         """Called when a key is pressed."""
         assert key is not None
-        if (self._is_keyboard_suppressed
-            and not self._keyboard_capture.is_keyboard_suppressed()):
-            self._keyboard_emulation.send_backspaces(1)
         steno_key = self.keymap.get(key)
         if steno_key is not None:
             self._down_keys.add(steno_key)

--- a/plover/machine/sidewinder.py
+++ b/plover/machine/sidewinder.py
@@ -39,7 +39,7 @@ class Stenotype(StenotypeBase):
                     del self.keymap[key]
         self._down_keys = set()
         self._released_keys = set()
-        self._keyboard_capture = KeyboardCapture(self.keymap.keys())
+        self._keyboard_capture = KeyboardCapture()
         self._keyboard_capture.key_down = self._key_down
         self._keyboard_capture.key_up = self._key_up
         self._last_stroke_key_down_count = 0
@@ -55,7 +55,8 @@ class Stenotype(StenotypeBase):
         self._stopped()
 
     def set_suppression(self, enabled):
-        self._keyboard_capture.suppress_keyboard(enabled)
+        suppressed_keys = self.keymap.keys() if enabled else ()
+        self._keyboard_capture.suppress_keyboard(suppressed_keys)
 
     def suppress_last_stroke(self, send_backspaces):
         send_backspaces(self._last_stroke_key_down_count)

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -224,11 +224,12 @@ class KeyboardCapture(threading.Thread):
 
     _KEYBOARD_EVENTS = set([kCGEventKeyDown, kCGEventKeyUp])
 
-    def __init__(self, suppressed_keys):
+    def __init__(self):
         threading.Thread.__init__(self)
         self._running_thread = None
-        self.suppress_keyboard(True)
-        self.suppressed_keys = suppressed_keys
+        self._suppressed_keys = set()
+        self.key_down = lambda key: None
+        self.key_up = lambda key: None
 
         # Returning the event means that it is passed on for further processing by others. 
         # Returning None means that the event is intercepted.
@@ -244,12 +245,11 @@ class KeyboardCapture(threading.Thread):
             if CGEventGetFlags(event) & ~kCGEventFlagMaskNonCoalesced:
                 return event
             keycode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode)
-            key = KEYCODE_TO_KEY.get(keycode, None)
-            if key in self.suppressed_keys:
-                handler_name = 'key_up' if event_type == kCGEventKeyUp else 'key_down'
-                handler = getattr(self, handler_name, lambda event: None)
+            key = KEYCODE_TO_KEY.get(keycode)
+            if key is not None:
+                handler = self.key_up if event_type == kCGEventKeyUp else self.key_down
                 handler(key)
-                if self.is_keyboard_suppressed():
+                if key in self._suppressed_keys:
                     # Supress event.
                     event = None
             return event
@@ -278,11 +278,8 @@ class KeyboardCapture(threading.Thread):
         CGEventTapEnable(self._tap, False)
         CFRunLoopStop(self._running_thread)
 
-    def suppress_keyboard(self, suppress):
-        self._suppress_keyboard = suppress
-
-    def is_keyboard_suppressed(self):
-        return self._suppress_keyboard
+    def suppress_keyboard(self, suppressed_keys=()):
+        self._suppressed_keys = set(suppressed_keys)
 
 
 # "Narrow python" unicode objects store chracters in UTF-16 so we 

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -278,9 +278,6 @@ class KeyboardCapture(threading.Thread):
         CGEventTapEnable(self._tap, False)
         CFRunLoopStop(self._running_thread)
 
-    def can_suppress_keyboard(self):
-        return True
-
     def suppress_keyboard(self, suppress):
         self._suppress_keyboard = suppress
 

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -104,25 +104,25 @@ class KeyboardCapture(object):
     WIN_KEYS = set(('Lwin', 'Rwin'))
     PASSTHROUGH_KEYS = CONTROL_KEYS | SHIFT_KEYS | ALT_KEYS | WIN_KEYS
 
-    def __init__(self, suppressed_keys):
-
-        self._suppress_keyboard = False
+    def __init__(self):
         self._passthrough_down_keys = set()
         self._alive = False
-        self._suppressed_keys = suppressed_keys
+        self._suppressed_keys = set()
+        self.key_down = lambda key: None
+        self.key_up = lambda key: None
 
         # NOTE(hesky): Does this need to be more efficient and less
         # general if it will be called for every keystroke?
         def on_key_event(func_name, event):
-            key = SCANCODE_TO_KEY.get(event.ScanCode, None)
             if event.Key in self.PASSTHROUGH_KEYS:
                 if func_name == 'key_down':
                     self._passthrough_down_keys.add(event.Key)
                 elif func_name == 'key_up':
                     self._passthrough_down_keys.discard(event.Key)
-            if key in self._suppressed_keys and not self._passthrough_down_keys:
-                getattr(self, func_name, lambda key: None)(key)
-                return not self._suppress_keyboard
+            key = SCANCODE_TO_KEY.get(event.ScanCode)
+            if key is not None and not self._passthrough_down_keys:
+                getattr(self, func_name)(key)
+                return key not in self._suppressed_keys
             return True
 
         self._on_key_up = functools.partial(on_key_event, 'key_up')
@@ -142,11 +142,8 @@ class KeyboardCapture(object):
         self._passthrough_down_keys.clear()
         self._alive = False
 
-    def suppress_keyboard(self, suppress):
-        self._suppress_keyboard = suppress
-
-    def is_keyboard_suppressed(self):
-        return self._suppress_keyboard
+    def suppress_keyboard(self, suppressed_keys=()):
+        self._suppressed_keys = set(suppressed_keys)
 
 
 class KeyboardEmulation:

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -142,9 +142,6 @@ class KeyboardCapture(object):
         self._passthrough_down_keys.clear()
         self._alive = False
 
-    def can_suppress_keyboard(self):
-        return True
-
     def suppress_keyboard(self, suppress):
         self._suppress_keyboard = suppress
 

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -175,9 +175,6 @@ class KeyboardCapture(threading.Thread):
         for modifiers in (0, X.Mod2Mask):
             self.grab_window.ungrab_key(keycode, modifiers)
 
-    def can_suppress_keyboard(self):
-        return True
-
     def suppress_keyboard(self, suppress):
         if self.is_suppressed == suppress:
             return

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -108,22 +108,19 @@ KEY_TO_KEYCODE = dict(zip(KEYCODE_TO_KEY.values(), KEYCODE_TO_KEY.keys()))
 class KeyboardCapture(threading.Thread):
     """Listen to keyboard press and release events."""
 
-    def __init__(self, suppressed_keys):
+    def __init__(self):
         """Prepare to listen for keyboard events."""
         threading.Thread.__init__(self)
         self.context = None
         self.key_events_to_ignore = []
-        self.suppressed_keys = suppressed_keys
-
-        # Assign default callback functions.
-        self.key_down = lambda x: True
-        self.key_up = lambda x: True
+        self._suppressed_keys = set()
+        self.key_down = lambda key: None
+        self.key_up = lambda key: None
 
         # Get references to the display.
         self.local_display = display.Display()
         self.record_display = display.Display()
 
-        self.is_suppressed = False
         self.grab_window = self.local_display.screen().root
 
     def run(self):
@@ -161,6 +158,7 @@ class KeyboardCapture(threading.Thread):
 
     def cancel(self):
         """Stop listening for keyboard events."""
+        self.suppress_keyboard()
         if self.context is not None:
             self.local_display.record_disable_context(self.context)
         self.local_display.flush()
@@ -175,20 +173,18 @@ class KeyboardCapture(threading.Thread):
         for modifiers in (0, X.Mod2Mask):
             self.grab_window.ungrab_key(keycode, modifiers)
 
-    def suppress_keyboard(self, suppress):
-        if self.is_suppressed == suppress:
+    def suppress_keyboard(self, suppressed_keys=()):
+        suppressed_keys = set(suppressed_keys)
+        if self._suppressed_keys == suppressed_keys:
             return
-        if suppress:
-            fn = self.grab_key
-        else:
-            fn = self.ungrab_key
-        for key in self.suppressed_keys:
-            fn(KEY_TO_KEYCODE[key])
+        for key in self._suppressed_keys - suppressed_keys:
+            self.ungrab_key(KEY_TO_KEYCODE[key])
+            self._suppressed_keys.remove(key)
+        for key in suppressed_keys - self._suppressed_keys:
+            self.grab_key(KEY_TO_KEYCODE[key])
+            self._suppressed_keys.add(key)
+        assert self._suppressed_keys == suppressed_keys
         self.local_display.sync()
-        self.is_suppressed = suppress
-
-    def is_keyboard_suppressed(self):
-        return self.is_suppressed
 
     def process_events(self, reply):
         """Handle keyboard events.
@@ -219,10 +215,10 @@ class KeyboardCapture(threading.Thread):
             # Ignore event if a modifier is set.
             if modifiers != 0:
                 continue
-            key = KEYCODE_TO_KEY.get(keycode, None)
-            if not key in self.suppressed_keys:
-                # Not a supported/suppressed key, ignore...
-                continue
+            key = KEYCODE_TO_KEY.get(keycode)
+            if key is None:
+                # Not a supported key, ignore...
+                return
             # ...or pass it on to a callback method.
             if event.type == X.KeyPress:
                 self.key_down(key)


### PR DESCRIPTION
Cleanup the keyboard machine code, now that all `KeyboardCapture` implementations support suppression (which also mean we can get rid of the dependency on `KeyboadEmulation`).

Rework the way machines handle suppression to:
- avoid the need for testing for a particular class instance to know if suppression is needed
- suppress all the key down events when post-suppressing a stroke: previously, when toggling Plover on with a stroke, key auto-repeat events were not suppressed (those can happen when being a little heavy handed and/or configuring X11 with a low delay for triggering auto-repeating)

Also change the `KeyboardCapture` implementation so list of suppressed keys is not set once and for all at initialization, which will make it easier to share capture instances (e.g. in the keyboard config dialog) and will also be used with the upcoming rework of machine keymaps.

Note: tested on Linux and with a Windows 10 virtual machine.