### PR TITLE
Simplify OS X dev setup

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -1,34 +1,50 @@
 # Plover Development on OS X
 
+## Getting Started
+- Run `./bootstrap.sh`.
+- Run `make app` to produce `../dist/Plover.app`.
+  - If you want a disk image instead, use: `make dmg`
+  - Standard development practice is to use `make clean app` to produce
+    a clean rebuild of the app.
+
+
+## Gotcha: Granting Assistive Device Permission
+After each build, you need to approve Plover as an Assistive Device:
+
+- Open System Preferences
+- Open the Security & Privacy pane
+- Select the Privacy tab
+- Select "Accessibility" from the source list on the left
+- Click the "+" button below the list off apps
+- Use the file picker to select the Plover.app that you just built
+
+Now you can run the app by double-clicking on it
+or by using open(1):
+
+    open ../dist/Plover.app
+
+### Dev Workaround: Run as Root
+Root doesn't need permission to use event taps,
+so during development, you can avoid this rigmarole by running Plover via:
+
+```
+sudo python launch.py
+```
+
+
 ## Dependencies
+The bootstrap script takes care of these for you, but in case you're curious:
 
-### Python
+- Python2.7: `brew install python --framework`
+- wxPython: `brew install wxpython`
+- Various Python libraries, for which see
+  [requirements.txt](./requirements.txt).
 
-You need Python 2.7. We build with brewed Python, as Apple's Python will cause you a few unexpected issues. `brew install python --framework`
 
-### XCode Tools
+### Xcode Tools
+You need the Xcode command-line tools.
+The bootstrap script will walk you through this.
 
-You need XCode commandline tools. Check by running `gcc` in the terminal. You will receive a prompt if they are not installed.
-
-### wxPython
-
-Get wxPython 3+. `brew install wxpython`
-
-### Pip
-
-Pip dependencies can be grabbed with:
-
-`pip install appdirs pyserial simplejson py2app Cython mock hidapi pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz`
-
-### Running
-
-To run in development, you need access to Assistive Devices. We can circumvent this by running as sudo. To run Plover in development, use:
-
-`sudo python launch.py`
-
-### Building
-
-In the `/osx` folder, you can run `make app` to build `/dist/Plover.app`. To package into a `dmg` instead, use `make dmg`. There is also `make clean` in order to clear out the build and dist folders.
-
-After each build, you need to approve Plover as an Assistive Device. Do `System Preferences / Security & Privacy / Privacy / Accessiblity / + Plover.app`, and then you can launch the `.app` (`open ../dist/Plover.app`).
-
+If you want to check for yourself, try running `clang` in Terminal.app.
+You will receive a prompt if the tools are not installed
+with instructions for how to install them.

--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright (c) 2016 Jeremy W. Sherman, distributed under GPLv2+ WITHOUT ANY
+# WARRANTY.
+#
+# Environment setup script for OS X Plover dev.
+
+# Exit Statuses
+EX_FAILURE_NO_CCTOOLS=1
+EX_FAILURE_NO_64BIT_PYTHON=2
+EX_FAILURE_NO_64BIT_WXPYTHON=3
+
+PYTHON=${PYTHON:=$(which python)}
+PIP=${PIP:=$(which pip)}
+
+REAL_PYTHON=$("$PYTHON" -c 'import sys; print sys.executable')
+
+echo "$0: using python: $PYTHON (executable: $REAL_PYTHON)"
+echo "$0: using pip: $PIP (version: $($PIP --version))"
+
+
+has_cli_tools() {
+    echo "$0: checking for functioning cli tools by trying clang"
+    if clang --version; then
+      "true"
+    else
+      "false"
+    fi
+}
+
+
+has_x86_64_python() {
+    echo "$0: checking $REAL_PYTHON for 64-bit slice"
+    if otool -vf "$REAL_PYTHON" | grep x86_64 >/dev/null; then
+        "true"
+    else
+        "false"
+    fi
+}
+
+
+has_x86_64_wx() {
+    echo "$0: checking for working x86_64 wxPython"
+    if arch -64 $REAL_PYTHON -c 'import wx' 2>&1 >/dev/null; then
+        "true"
+    else
+        "false"
+    fi
+}
+
+
+main() {
+    if ! has_cli_tools; then
+        cat 1>&2 <<EOT
+CLI tools are not installed. Install Homebrew and do what it says. :)
+Double-click the URL to visit: http://brew.sh/ for install instructions.
+EOT
+        exit $EX_FAILURE_NO_CCTOOLS
+    else
+        echo "$0: found clang, continuing"
+    fi
+
+
+    if ! has_x86_64_python; then
+        cat 1>&2 <<EOT
+$0: 64-bit Python is required, but
+$PYTHON
+doesn't have an x86_64 slice. Please run:
+
+    brew uninstall python
+    brew install python --framework
+
+or use a different Python by setting the PYTHON env var.
+EOT
+        exit $EX_FAILURE_NO_64BIT_PYTHON
+    else
+        echo "$0: 64-bit slice found"
+    fi
+
+
+    if ! has_x86_64_wx; then
+        cat 1>&2 <<EOT
+$0: 64-bit wxPython is required, but |import wx| when running
+64-bit $PYTHON failed. Please run:
+
+    brew uninstall wxpython
+    brew install wxpython
+EOT
+        exit $EX_FAILURE_NO_64BIT_WXPYTHON
+    else
+        echo "$0: successfully imported wx into 64-bit Python"
+    fi
+
+
+    echo "$0: installing required libraries using pip"
+    pip install -r requirements.txt
+}
+
+main

--- a/osx/requirements.txt
+++ b/osx/requirements.txt
@@ -1,0 +1,16 @@
+# General requirements
+appdirs  # locating platform-varying libraries like Documents
+pyserial  # connecting to steno machines that use a serial protocol
+mock  # unittest.mock for Python 2.6 through 3.2; in stdlib with 3.3+
+
+
+# Darwin-specific requirements
+hidapi; sys_platform == 'darwin'  # supporting the Treal's USB protocol
+pyobjc-core; sys_platform == 'darwin'  # Notification Center
+pyobjc-framework-quartz; sys_platform == 'darwin'  # accessing the CGEvent API
+py2app; sys_platform == 'darwin'  # building the Plover.app bundle
+
+# Later versions of setuptools appear to lead to `py2app` not bundling
+# the required `six` package with the app. Pinning to 19.2 fixes this.
+# We should revisit this periodically by unpinning and checking in Travis.
+setuptools == 19.2; sys_platform == 'darwin'


### PR DESCRIPTION
- Replace manual instructions to `pip install` a list of packages with requirements.txt
- Replace manual setup instructions with a bootstrap script
- Rewrite the README to point people at the bootstrap script first and supply additional information as a "For the More Curious" section.

The largest change in the README is to discourage people from using a virtual environment for developing Plover. It ends up not being all that virtual in the end anyway thanks to wxPython.

This is an improvement, but it's not sufficent; I still don't have a functional dev environment myself. I can build an app bundle, but it fails during launch. Running from the commandline with `arch -32 /usr/local/bin/python -m plover.app` runs afoul of the `objc` package not having a 32-bit slice.

32-bit apps under OS X are going the way of the dodo, and the whole toolchain has moved to reflect that, unfortunately. :\