### PR TITLE
Add Mac Notification Center support

### DIFF
--- a/plover/gui/log.py
+++ b/plover/gui/log.py
@@ -1,4 +1,3 @@
-
 import sys
 from plover import log
 
@@ -9,6 +8,9 @@ try:
     if sys.platform.startswith('linux'):
         from plover.gui.log_dbus import DbusNotificationHandler
         handler = DbusNotificationHandler
+    elif sys.platform.startswith('darwin'):
+        from plover.gui.log_osx import OSXNotificationHandler
+        handler = OSXNotificationHandler
 except Exception as e:
     log.info('could not import platform gui log', exc_info=e)
 
@@ -17,4 +19,3 @@ if handler is None:
     handler = WxNotificationHandler
 
 log.add_handler(handler())
-

--- a/plover/gui/log_osx.py
+++ b/plover/gui/log_osx.py
@@ -1,0 +1,43 @@
+import objc
+NSUserNotification = objc.lookUpClass('NSUserNotification')
+NSUserNotificationCenter = objc.lookUpClass('NSUserNotificationCenter')
+NSObject = objc.lookUpClass('NSObject')
+
+from plover import log, __name__ as __software_name__
+import logging
+
+
+class OSXNotificationHandler(logging.Handler):
+    """ Handler using OS X Notification Center to show messages. """
+
+    def __init__(self):
+        super(OSXNotificationHandler, self).__init__()
+        self.setLevel(log.WARNING)
+        self.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+
+    def emit(self, record):
+        # Notification Center has no levels or timeouts.
+        notification = NSUserNotification.alloc().init()
+
+        notification.setTitle_(__software_name__.capitalize())
+        notification.setSubtitle_(record.levelname.title())
+        notification.setInformativeText_(record.message)
+
+        ns = NSUserNotificationCenter.defaultUserNotificationCenter()
+        ns.setDelegate_(always_present_delegator)
+        ns.deliverNotification_(notification)
+
+
+class AlwaysPresentNSDelegator(NSObject):
+    """
+    Custom delegator to force presenting even if Plover is in the foreground.
+    """
+    def userNotificationCenter_didActivateNotification_(self, ns, note):
+        # Do nothing
+        return
+
+    def userNotificationCenter_shouldPresentNotification_(self, ns, note):
+        # Force notification, even if frontmost application.
+        return True
+
+always_present_delegator = AlwaysPresentNSDelegator.alloc().init()


### PR DESCRIPTION
Use Notification Center if available on Mac.

Instead of the wx notifications, which are pretty awful looking on OSX, I changed to notification center, which acts like other applications. The biggest limitation is that we can't expire notifications, but OSX users should be used to that. Here is the hover view and the history view for the notification:

<img width="353" alt="screen shot 2016-02-10 at 12 37 00 pm" src="https://cloud.githubusercontent.com/assets/5840970/12956240/f6ac68d4-cff4-11e5-8738-b8fb59e23b06.png">

<img width="320" alt="screen shot 2016-02-10 at 12 47 54 pm" src="https://cloud.githubusercontent.com/assets/5840970/12956243/fb8c0fc6-cff4-11e5-9b0a-49fadd6153ee.png">
