### PR TITLE
Reduce Tréal CPU usage

### DIFF
--- a/plover/machine/treal.py
+++ b/plover/machine/treal.py
@@ -89,7 +89,7 @@ class Stenotype(StenotypeBase):
                     self._machine.open(VENDOR_ID, 1)
                 else:
                     self._machine = hid.device(VENDOR_ID, 1)
-                self._machine.set_nonblocking(1)
+                self._machine.set_nonblocking(0)
             except IOError as e:
                 log.info('Treal device not found: %s', str(e))
                 log.warning('Treal is not connected')


### PR DESCRIPTION
The Tréal file was set to use non-blocking reads from the hidapi. But that code was in a while loop, and so it was called infinitely, causing very high CPU usage. I've switched over to a blocking version of the call, which actually gives Plover a break in the while loop.

The effects have only been positive so far. I feel a little silly for not noticing this high CPU usage before in the months using Plover with the Tréal 😕