### PR TITLE
Add command to run Plover in development on OS X

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -24,6 +24,12 @@ Pip dependencies can be grabbed with:
 
 `pip install appdirs pyserial simplejson py2app Cython mock pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz`
 
+### Running
+
+To run in development, you need access to Assistive Devices. We can circumvent this by running as sudo. To run Plover in development, use:
+
+`sudo arch -32 python launch.py`
+
 ### Building
 
 In the `/osx` folder, you can run `make app` to build `/dist/Plover.app`. To package into a `dmg` instead, use `make dmg`. There is also `make clean` in order to clear out the build and dist folders. I tend to use `make clean app` in development for testing builds.


### PR DESCRIPTION
Frustrated with having to build Plover between code changes, I finally took the time to figure it out. @jeremy-w, you pay be interested in this change.