### PR TITLE
Fix keyboardcontrol script

### DIFF
--- a/plover/oslayer/keyboardcontrol.py
+++ b/plover/oslayer/keyboardcontrol.py
@@ -51,7 +51,7 @@ class KeyboardEmulation(keyboardcontrol.KeyboardEmulation):
 if __name__ == '__main__':
     import time
 
-    kc = KeyboardCapture(KeyboardCapture.SUPPORTED_KEYS)
+    kc = KeyboardCapture()
     ke = KeyboardEmulation()
 
     pressed = set()
@@ -72,7 +72,6 @@ if __name__ == '__main__':
 
     kc.key_down = lambda k: test(k, 'pressed')
     kc.key_up = lambda k: test(k, 'released')
-    kc.suppress_keyboard(True)
     kc.start()
     print 'Press CTRL-c to quit.'
     try:


### PR DESCRIPTION
Updated in wake of #341.

The code run when running the module directly was still trying to pass suppressed keys to the `KeyboardControl` initializer, which led to a "you gave me 2 args but I only take 1" error. It also tried to turn suppression on, except that API now takes a set of keys to suppress, so that bombed out griping that Bools are not iterable.