### PR TITLE
Add Appveyor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ nosetests.xml
 # deleted files
 \#*#
 .#*
+
+/windows/.wine/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+environment:
+
+  global:
+    PIP_ACCEL_LOG_FORMAT: "%(name)-18s %(levelname)s %(message)s"
+
+  matrix:
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+
+cache:
+  # Keep cache of downloaded pip packages.
+  - C:\Users\appveyor\AppData\Local\pip
+  # Keep downloaded packages.
+  - C:\Dist
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  - "python --version"
+
+  # Install wget module.
+  - "pip install --disable-pip-version-check --timeout 5 --retries 2 wget"
+
+  # Setup the rest of the environment.
+  - "python windows\\helper.py setup"
+
+  # Update PATH.
+  - "SET PATH=C:\\Prog\\7-Zip;%PATH%"
+
+build_script:
+  - "ECHO PATH=%PATH%"
+
+after_build:
+  - "python windows\\helper.py dist"
+
+test_script:
+  - "py.test-2.7 -v -ra plover"
+
+artifacts:
+  - path: dist\*.exe
+    name: Plover
+

--- a/plover/test_config.py
+++ b/plover/test_config.py
@@ -24,7 +24,8 @@ class ConfigTestCase(unittest.TestCase):
          config.MACHINE_TYPE_OPTION, config.DEFAULT_MACHINE_TYPE, 'foo', 'bar', 
          'blee'),
         ('log_file_name', config.LOGGING_CONFIG_SECTION, config.LOG_FILE_OPTION, 
-         os.path.realpath(os.path.join(CONFIG_DIR, config.DEFAULT_LOG_FILE)), '/l1', '/log', '/sawzall'),
+         os.path.realpath(os.path.join(CONFIG_DIR, config.DEFAULT_LOG_FILE)),
+         os.path.abspath('/l1'), os.path.abspath('/log'), os.path.abspath('/sawzall')),
         ('enable_stroke_logging', config.LOGGING_CONFIG_SECTION, 
          config.ENABLE_STROKE_LOGGING_OPTION, 
          config.DEFAULT_ENABLE_STROKE_LOGGING, False, True, False),
@@ -213,41 +214,43 @@ class ConfigTestCase(unittest.TestCase):
                           for name in config.DEFAULT_DICTIONARIES])
 
         # Relative paths as assumed to be relative to CONFIG_DIR.
-        names = ['b', 'a', 'd/c', 'e/f']
-        c.set_dictionary_file_names(names)
-        print c.get_dictionary_file_names()
-        print [os.path.join(config_dir, path) for path in names]
-        self.assertEqual(c.get_dictionary_file_names(),
-                         [os.path.join(config_dir, path) for path in names])
-        # Paths not bellow CONFIG_DIR must be unchanged...
-        names = ['/b', '/a', '/d', '/c']
-        c.set_dictionary_file_names(names)
-        self.assertEqual(c.get_dictionary_file_names(), names)
+        filenames = [os.path.abspath(os.path.join(config_dir, path))
+                     for path in ('b', 'a', 'd/c', 'e/f')]
+        c.set_dictionary_file_names(filenames)
+        self.assertEqual(c.get_dictionary_file_names(), filenames)
+        # Absolute paths must remain unchanged...
+        filenames = [os.path.abspath(path)
+                     for path in ('/b', '/a', '/d', '/c')]
+        c.set_dictionary_file_names(filenames)
+        self.assertEqual(c.get_dictionary_file_names(), filenames)
         # Load from a file encoded the old way...
-        f = StringIO('[%s]\n%s: %s' % (section, option, '/some_file'))
+        filename = os.path.abspath('/some_file')
+        f = StringIO('[%s]\n%s: %s' % (section, option, filename))
         c.load(f)
         # ..and make sure the right value is set.
-        self.assertEqual(c.get_dictionary_file_names(), ['/some_file'])
+        self.assertEqual(c.get_dictionary_file_names(), [filename])
         # Load from a file encoded the new way...
-        filenames = '\n'.join('%s%d: %s' % (option, d, v) 
-                              for d, v in enumerate(names, start=1))
-        f = StringIO('[%s]\n%s' % (section, filenames))
+        filenames = [os.path.abspath(path)
+                     for path in ('/b', '/a', '/d', '/c')]
+        value = '\n'.join('%s%d: %s' % (option, d, v) 
+                              for d, v in enumerate(filenames, start=1))
+        f = StringIO('[%s]\n%s' % (section, value))
         c.load(f)
         # ...and make sure the right value is set.
-        self.assertEqual(c.get_dictionary_file_names(), names)
+        self.assertEqual(c.get_dictionary_file_names(), filenames)
         
-        names.reverse()
+        filenames.reverse()
         
         # Set a value...
-        c.set_dictionary_file_names(names)
+        c.set_dictionary_file_names(filenames)
         f = StringIO()
         # ...save it...
         c.save(f)
         # ...and make sure it's right.
-        filenames = '\n'.join('%s%d = %s' % (option, d, v) 
-                              for d, v in enumerate(names, start=1))
+        value = '\n'.join('%s%d = %s' % (option, d, v) 
+                              for d, v in enumerate(filenames, start=1))
         self.assertEqual(f.getvalue(), 
-                         '[%s]\n%s\n\n' % (section, filenames))
+                         '[%s]\n%s\n\n' % (section, value))
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ from plover import (
     __copyright__,
 )
 
+import os
 import sys
 import setuptools
 
@@ -40,7 +41,7 @@ if sys.platform.startswith('darwin'):
 
 setuptools.setup(
     name=__software_name__.capitalize(),
-    version=__version__,
+    version=os.environ.get('PLOVER_VERSION', __version__),
     description=__description__,
     long_description=__long_description__,
     url=__url__,

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python2
+
+import argparse
+import glob
+import hashlib
+import inspect
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import traceback
+
+import wget
+
+
+SITE_DIR = r'C:\Python27\Lib\site-packages'
+WIN_DIR = os.path.dirname(os.path.abspath(__file__))
+TOP_DIR = os.path.dirname(WIN_DIR)
+NULL = open(os.devnull, 'r+b')
+TEMP_DIR = r'C:\Temp'
+PROG_DIR = r'C:\Progs'
+
+
+sys.path.insert(0, TOP_DIR)
+os.chdir(TOP_DIR)
+
+
+from plover import (
+    __name__ as __software_name__,
+    __version__,
+)
+
+APPNAME = __software_name__.capitalize()
+VERSION = __version__
+ICON = os.path.join(WIN_DIR, '%s.ico' % __software_name__)
+if os.path.exists(os.path.join(TOP_DIR, '.git')):
+    VERSION = subprocess.check_output('git describe --tag'.split()).strip()
+    m = re.match('^v(\d[\d.]*)(-\d+-g[a-f0-9]*)?$', VERSION)
+    assert m is not None
+    VERSION = m.group(1)
+    if m.group(2) is not None:
+        VERSION += '+' + m.group(2)[1:].replace('-', '.')
+    os.environ['PLOVER_VERSION'] = VERSION
+
+
+if sys.stdout.isatty():
+
+    def info(fmt, *args):
+        s = fmt % args
+        print '[34m' + s + '[0m'
+
+else:
+
+    def info(fmt, *args):
+        s = fmt % args
+        print s
+
+if sys.stderr.isatty():
+
+    def error(fmt, *args):
+        s = fmt % args
+        print >>sys.stderr, '[31m' + s + '[0m'
+
+else:
+
+    def error(fmt, *args):
+        s = fmt % args
+        print >>sys.stderr, s
+
+
+class CommandExecutionException(Exception):
+
+    def __init__(self, args, exitcode, stdout='', stderr=''):
+        self.args = args
+        self.exitcode = exitcode
+        self.stdout = stdout
+        self.stderr= stderr
+
+
+class Environment(object):
+
+    def __init__(self):
+        self.dry_run = False
+        self.verbose = False
+        self._env = {}
+        self._installed_path = 'installed.txt'
+        self._installed = None
+
+    def setup(self):
+        pass
+
+    def get_realpath(self, path):
+        return path
+
+    def get_installed(self):
+        if self._installed is None:
+            self._installed = {}
+            if os.path.exists(self._installed_path):
+                with open(self._installed_path, 'r') as fp:
+                    self._installed.update(json.load(fp))
+        return self._installed
+
+    def mark_installed(self, package, version):
+        self._installed[package] = version
+        if self.dry_run:
+            return
+        with open(self._installed_path, 'w') as fp:
+            json.dump(self._installed, fp, indent=2)
+
+    def get_distdir(self):
+        raise NotImplementedError
+
+    def add_to_path(self, directory):
+        raise NotImplementedError
+
+    def run(self, args, cwd=None, redirection='auto'):
+        if self.verbose:
+            print 'running', ' '.join(args)
+        if self.dry_run:
+            return 0, ''
+        env = self._get_env()
+        if 'auto' == redirection:
+            to_pipe = not self.verbose
+        elif 'never' == redirection:
+            to_pipe = False
+        elif 'always' == redirection:
+            to_pipe = True
+        else:
+            raise ValueError('invalid redirection mode: %s' % redirection)
+        if to_pipe:
+            stdout = stderr = subprocess.PIPE
+        else:
+            stdout = stderr = None
+        if cwd is None:
+            old_cwd = None
+        else:
+            old_cwd = os.getcwd()
+            os.chdir(cwd)
+        try:
+            proc = subprocess.Popen(args, env=env, stdout=stdout, stderr=stderr)
+            stdout, stderr = proc.communicate()
+            returncode = proc.wait()
+        finally:
+            if old_cwd is not None:
+                os.chdir(old_cwd)
+        if 0 != returncode:
+            raise CommandExecutionException(args, returncode, stdout, stderr)
+        return stdout
+
+    def _get_env(self):
+        env = dict(os.environ)
+        env.update(self._env)
+        return env
+
+
+class WineEnvironment(Environment):
+
+    def __init__(self, prefix):
+        super(WineEnvironment, self).__init__()
+        self._prefix = os.path.abspath(prefix)
+        self._env['WINEPREFIX'] = self._prefix
+        self._env['WINEARCH'] = 'win32'
+        self._env['WINEDEBUG'] = '-all'
+        self._env['WINETRICKS_OPT_SHAREDPREFIX'] = '1'
+        self._installed_path = os.path.join(self.get_realpath(PROG_DIR), 'installed.txt')
+
+    def setup(self):
+        if not os.path.exists(self._prefix):
+            info('intializing Wine prefix')
+            for cmd in (
+                'wineboot --init',
+                'winetricks --no-isolate --unattended corefonts vcrun2008',
+            ):
+                self.run(cmd.split())
+        if self.dry_run:
+            return
+        tempdir = self.get_realpath(TEMP_DIR)
+        progdir = self.get_realpath(PROG_DIR)
+        distdir = self.get_distdir()
+        for dir in (tempdir, progdir, distdir):
+            if not os.path.exists(dir):
+                os.makedirs(dir)
+
+    def get_realpath(self, path):
+        path = path.replace('\\', '/')
+        if path.startswith('C:'):
+            path = 'c:' + path[2:]
+        return os.path.join(self._prefix, 'dosdevices', path)
+
+    def get_distdir(self):
+        return os.path.expanduser('~/.cache/wine')
+
+    def add_to_path(self, directory):
+        if self.verbose:
+            print 'adding "%s" to PATH' % directory
+        if self.dry_run:
+            return
+        path = self.run(('wine', 'cmd.exe', '/c', 'echo', '%PATH%'), redirection='always')
+        path = path.strip().replace("\\", "\\\\")
+        directory = directory.replace("\\", "\\\\")
+        regfile = r'%s\path.reg' % TEMP_DIR
+        real_regfile = self.get_realpath(regfile)
+        with open(real_regfile, 'w') as fp:
+            fp.write('REGEDIT4\r\n')
+            fp.write('\r\n')
+            fp.write('[HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\Environment]\r\n')
+            fp.write('"PATH"="%s;%s"\r\n' % (directory, path))
+        try:
+            self.run(('regedit', regfile))
+        finally:
+            os.unlink(real_regfile)
+
+    def run(self, args, cwd=None, redirection='auto'):
+        exe = args[0]
+        if exe.endswith('.exe') or exe.endswith('.bat'):
+            cmd = ('wine',) + tuple(args)
+        else:
+            cmd = args
+        return super(WineEnvironment, self).run(cmd, cwd, redirection)
+
+    def _get_env(self):
+        env = super(WineEnvironment, self)._get_env()
+        for var in (
+            'PYTHONPATH',
+            # Make sure GTK environment variables don't spill over to the Wine environment.
+            'GDK_BACKEND',
+            'GDK_NATIVE_WINDOWS',
+            'GDK_PIXBUF_MODULE_FILE',
+            'GDK_RENDERING',
+            'GTK2_RC_FILES',
+            'GTK3_MODULES',
+            'GTK_DATA_PREFIX',
+            'GTK_EXE_PREFIX',
+            'GTK_IM_MODULE',
+            'GTK_IM_MODULE_FILE',
+            'GTK_MODULES',
+            'GTK_PATH',
+            'GTK_THEME',
+        ):
+            if var in env:
+                del env[var]
+            return env
+
+
+class Win32Environment(Environment):
+
+    def __init__(self):
+        super(Win32Environment, self).__init__()
+        self._installed_path = os.path.join(PROG_DIR, 'installed.txt')
+        self._path = None
+
+    def setup(self):
+        if self.dry_run:
+            return
+        tempdir = self.get_realpath(TEMP_DIR)
+        progdir = self.get_realpath(PROG_DIR)
+        distdir = self.get_distdir()
+        for dir in (tempdir, progdir, distdir):
+            if not os.path.exists(dir):
+                os.makedirs(dir)
+
+    def get_distdir(self):
+        return r'C:\Dist'
+
+    def add_to_path(self, directory):
+        if self.verbose:
+            print 'adding "%s" to PATH' % directory
+        if self._path is None:
+            self._path = self.run(('cmd.exe', '/c', 'echo', '%PATH%'), redirection='always').strip()
+        self._path = directory + ';' + self._path
+        batch = r'%s\setpath.bat' % TEMP_DIR
+        with open(batch, 'w') as fp:
+            fp.write('@ECHO off\r\n')
+            fp.write('setx PATH "%s"\r\n' % self._path)
+        try:
+            self.run((batch,))
+        finally:
+            os.unlink(batch)
+
+
+class Helper(object):
+
+    DEPENDENCIES = (
+        # Install 7zip first, since we'll be using it for extracting/installing some of the other dependencies.
+        ('7zip'             , 'http://www.7-zip.org/a/7z1514.exe'                                                                                 , 'f2e5efd7b47d1fb5b68d355191cfed1a66b82c79', None, ('/S', r'/D=%s\7-Zip' % PROG_DIR), r'%s\7-Zip' % PROG_DIR),
+        # Note: we force the installation directory, otherwise the installer gets confused when run under AppVeyor, and installs in the wrong directory...
+        ('wxPython'         , 'http://downloads.sourceforge.net/wxpython/wxPython3.0-win32-3.0.2.0-py27.exe'                                      , '864d44e418a0859cabff71614a495bea57738c5d', None, ('/SP-', '/VERYSILENT', '/DIR=%s' % SITE_DIR), None),
+        # Note: '--always-unzip' is needed, as pyHook cannot work from a single egg file.
+        ('pyhook'           , 'http://downloads.sourceforge.net/project/pyhook/pyhook/1.5.1/pyHook-1.5.1.win32-py2.7.exe'                         , '9afb7a5b2858a69c6b0f6d2cb1b2eb2a3f4183d2', 'easy_install', ('--always-unzip',), None),
+        ('pywin32'          , 'http://downloads.sourceforge.net/project/pywin32/pywin32/Build 219/pywin32-219.win32-py2.7.exe'                    , '8bc39008383c646bed01942584117113ddaefe6b', 'easy_install', (), None),
+        ('appdirs'          , 'pip:appdirs'                                                                                                       , None                                      , None, (), None),
+        ('mock'             , 'pip:mock'                                                                                                          , None                                      , None, (), None),
+        ('pyserial'         , 'pip:pyserial'                                                                                                      , None                                      , None, (), None),
+        ('pywinauto'        , 'pip:pywinauto'                                                                                                     , None                                      , None, (), None),
+        ('pywinusb'         , 'pip:pywinusb'                                                                                                      , None                                      , None, (), None),
+        ('PyInstaller'      , 'pip:PyInstaller==3.1.1'                                                                                            , None                                      , None, (), None),
+        ('PyTest'           , 'pip:pytest'                                                                                                        , None                                      , None, (), None),
+        # We need to downgrade setuptools...
+        ('setuptools'       , 'pip:setuptools==19.2'                                                                                              , None                                      , None, (), None),
+    )
+
+    def __init__(self):
+        self.dry_run = False
+        self.verbose = False
+        self.unattended = True
+        self._parser = argparse.ArgumentParser(description='Windows Environment Helper')
+        self._parser.add_argument('-v', '--verbose', dest='_verbose',
+                                  action='store_true', help='enable verbose traces')
+        self._parser.add_argument('-n', '--dry-run', dest='_dry_run',
+                                  action='store_true', help='don\'t actuall run any command, but show what would be done')
+        self._subparsers = self._parser.add_subparsers(dest='_command', metavar='COMMAND')
+
+        for name in dir(self):
+            if not name.startswith('cmd_'):
+                continue
+            cmd = getattr(self, name)
+            argspec = inspect.getargspec(cmd)
+            name = name[4:]
+            doc = cmd.__doc__.strip().split('\n')
+            help = doc[0]
+            parser = self._subparsers.add_parser(name, help=help, add_help=False)
+            args_help = {}
+            for line in doc[1:]:
+                line = line.strip()
+                if not line:
+                    continue
+                name, doc = line.split(': ', 2)
+                args_help[name] = doc
+            short_opts = set()
+            assert 'self' == argspec.args[0]
+            for n, a in enumerate(argspec.args[1:]):
+                if argspec.defaults is None or n >= len(argspec.defaults):
+                    default = None
+                else:
+                    default = argspec.defaults[n]
+                if default is None:
+                    name_or_flags = (a,)
+                    action = None
+                else:
+                    metavar = None
+                    name = '--' + a
+                    short_name = '-' + a[0]
+                    if short_name not in short_opts:
+                        short_opts.add(short_name)
+                        name_or_flags = (short_name, name)
+                    else:
+                        name_or_flags = name,
+                    if isinstance(default, bool):
+                        action = 'store_' + str(not default).lower()
+                    else:
+                        action = 'store'
+                parser.add_argument(*name_or_flags,
+                                    action=action,
+                                    default=default,
+                                    help=args_help.get(a))
+            if argspec.varargs is not None:
+                parser.add_argument(argspec.varargs,
+                                    nargs=argparse.REMAINDER,
+                                    help=args_help.get(argspec.varargs))
+
+
+        self._env = Environment()
+        self._install_handlers = {
+            'easy_install': self._easy_install,
+            'pip'         : self._pip_install,
+            '.exe'        : self._install_exe,
+            '.msi'        : self._install_msi,
+            '.rar'        : self._install_archive,
+            '.zip'        : self._install_archive,
+        }
+
+    def _rmtree(self, path):
+        if not os.path.exists(path):
+            return
+        if self.verbose:
+            print 'rm -rf', path
+        if self.dry_run:
+            return
+        shutil.rmtree(path)
+
+    def _makedirs(self, path):
+        if os.path.exists(path):
+            return
+        if self.verbose:
+            print 'mkdir -p', path
+        if self.dry_run:
+            return
+        os.makedirs(path)
+
+    def _rename(self, old, new):
+        if self.verbose:
+            print 'mv', old, new
+        if self.dry_run:
+            return
+        os.rename(old, new)
+
+    def _copyfile(self, src, dst):
+        if self.verbose:
+            print 'cp', src, dst
+        if self.dry_run:
+            return
+        shutil.copyfile(src, dst)
+
+    def _copytree(self, src, dst):
+        if self.verbose:
+            print 'cp -r', src, dst
+        if self.dry_run:
+            return
+        shutil.copytree(src, dst)
+
+    def _extract(self, archive, destination, *args):
+        if self.verbose:
+            print 'extracting %s to %s' % (archive, destination)
+        cmd = ['7z.exe', 'x', archive, '-y', '-o%s' % destination]
+        cmd.extend(args)
+        realdir = self._env.get_realpath(destination)
+        self._rmtree(realdir)
+        self._env.run(cmd)
+        if self.dry_run:
+            return
+        contents = os.listdir(realdir)
+        if 1 == len(contents):
+            tmpdir = '%s.tmp' % realdir
+            os.rename(realdir, tmpdir)
+            os.rename(os.path.join(tmpdir, contents[0]), realdir)
+            os.rmdir(tmpdir)
+
+    def _install_exe(self, filename, *options):
+        cmd = [filename]
+        cmd.extend(options)
+        self._env.run(cmd)
+
+    def _install_msi(self, filename, *options):
+        cmd = ['msiexec.exe', '/i', filename]
+        if self.unattended:
+            cmd.append('/q')
+        cmd.extend(options)
+        self._env.run(cmd)
+
+    def _install_archive(self, filename, install_basename, add_to_path=True):
+        program_dir = r'%s\%s' % (PROG_DIR, install_basename)
+        self._extract(filename, program_dir)
+        if add_to_path:
+            self._env.add_to_path(program_dir)
+
+    def _easy_install(self, filename, *options):
+        if not self.unattended and filename.endswith('.exe'):
+            cmd = [filename]
+        else:
+            cmd = ['easy_install.exe']
+            if not self.verbose:
+                cmd.append('--quiet')
+            cmd.extend(options)
+            cmd.extend(('--', filename))
+        self._env.run(cmd)
+
+    def _pip_install(self, *specs):
+        cmd = ['pip.exe',
+               '--timeout=5',
+               '--retries=2',
+               '--disable-pip-version-check']
+        if not self.verbose:
+            cmd.append('--quiet')
+        cmd.extend(('install', '--upgrade', '--'))
+        cmd.extend(specs)
+        self._env.run(cmd)
+
+    def _download(self, url, checksum, dst):
+        retries = 0
+        while retries < 2:
+            if not os.path.exists(dst):
+                retries += 1
+                try:
+                    wget.download(url, out=dst)
+                    print
+                except Exception as e:
+                    print
+                    print 'error', e
+                    continue
+            h = hashlib.sha1()
+            with open(dst, 'rb') as fp:
+                while True:
+                    d = fp.read(4 * 1024 * 1024)
+                    if not d:
+                        break
+                    h.update(d)
+            if h.hexdigest() == checksum:
+                break
+            print 'sha1 does not match: %s instead of %s' % (h.hexdigest(), checksum)
+            os.unlink(dst)
+        assert os.path.exists(dst), 'could not successfully retrieve %s' % url
+
+    def install(self, name, src, checksum, handler_format=None, handler_args=(), path_dir=None):
+        installed = self._env.get_installed()
+        if src == installed.get(name):
+            return
+        info('installing %s', name)
+        if src.startswith('pip:'):
+            handler_format = 'pip'
+            dst = src[4:]
+        else:
+            distdir = self._env.get_distdir()
+            dst = os.path.join(distdir, os.path.basename(src))
+            if not self.dry_run:
+                self._download(src, checksum, dst)
+            if handler_format is None:
+                root, handler_format = os.path.splitext(dst)
+        handler = self._install_handlers.get(handler_format)
+        assert handler, 'no handler for installing format %s' % handler_format
+        handler(dst, *handler_args)
+        if path_dir is not None:
+            self._env.add_to_path(path_dir)
+        self._env.mark_installed(name, src)
+
+    def cmd_help(self, *commands):
+        '''print detailed help'''
+        if not commands:
+            commands = self._subparsers.choices.keys()
+            self._parser.print_help()
+        for name in commands:
+            print
+            parser = self._subparsers.choices.get(name)
+            if parser is None:
+                raise ValueError('unknown command name: %s' % name)
+            print '%s COMMAND' % name.upper()
+            print
+            parser.print_help()
+
+    def cmd_setup(self, interactive=False):
+        '''setup environment
+
+        interactive: don't run unattended
+        '''
+        self.unattended = not interactive
+        self._env.setup()
+        for name, src, checksum, handler_format, handler_args, path_dir in self.DEPENDENCIES:
+            self.install(name, src, checksum, handler_format=handler_format, handler_args=handler_args, path_dir=path_dir)
+
+    def cmd_run(self, executable, *args):
+        '''run command in environment
+
+        executable: name of the executable to run
+        args: additional arguments to pass to the executable
+        '''
+        self._env.run((executable,) + tuple(args), redirection='never')
+
+    def cmd_dist(self):
+        '''create windows distribution
+        '''
+        self._rmtree('build')
+        self._rmtree('dist')
+        info('creating distribution')
+        self._env.run(('pyinstaller.exe',
+                       '--log-level=WARN',
+                       '--specpath=build',
+                       '--additional-hooks-dir=%s' % WIN_DIR,
+                       '--name=%s' % APPNAME,
+                       '--icon=%s' % ICON,
+                       '--noconfirm',
+                       '--windowed',
+                       '--onefile',
+                       'launch.py'))
+        self._rename('dist/%s.exe' % APPNAME, 'dist/%s-%s.exe' % (APPNAME, VERSION))
+
+    def main(self, args):
+        opts = self._parser.parse_args(args)
+        self.dry_run = self._env.dry_run = opts._dry_run
+        self.verbose = self._env.verbose = opts._verbose
+        args = {
+            name: value
+            for name, value
+            in opts._get_kwargs()
+            if not name.startswith('_')
+        }
+        cmd = getattr(self, 'cmd_%s' % opts._command)
+        argspec = inspect.getargspec(cmd)
+        args = []
+        assert 'self' == argspec.args[0]
+        for a in argspec.args[1:]:
+            args.append(getattr(opts, a))
+        if argspec.varargs is not None:
+            args.extend(getattr(opts, argspec.varargs))
+        try:
+            cmd(*args)
+        except CommandExecutionException as e:
+            if e.stdout:
+                print >>sys.stdout, e.stdout
+            if e.stderr:
+                print >>sys.stderr, e.stderr
+            error('execution failed, returned %u: %s',
+                  e.exitcode, ' '.join(e.args))
+            return e.exitcode
+        except Exception as e:
+            error('exception: %s', str(e))
+            traceback.print_exc()
+            return -1
+        return 0
+
+
+class WineHelper(Helper):
+
+    DEPENDENCIES = (
+        ('Python', 'https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi', 'b14ebf1198fe4bbb940bcce90d910b8eddd60209', None, (), None),
+    ) + Helper.DEPENDENCIES
+
+    def __init__(self):
+        super(WineHelper, self).__init__()
+        self._env = WineEnvironment(os.path.join(WIN_DIR, '.wine'))
+
+    def cmd_run(self, executable, *args):
+        '''run command in environment
+
+        executable: executable to run (the executable will be automatically run with Wine when it ends with ".exe")
+        args: additional arguments to pass to the executable
+        '''
+        super(WineHelper, self).cmd_run(executable, *args)
+
+
+class Win32Helper(Helper):
+
+    def __init__(self):
+        super(Win32Helper, self).__init__()
+        self._env = Win32Environment()
+
+
+if '__main__' == __name__:
+    if sys.platform.startswith('linux'):
+        h = WineHelper()
+    elif sys.platform.startswith('win32'):
+        h = Win32Helper()
+    sys.exit(h.main(sys.argv[1:]))
+

--- a/windows/hook-plover.py
+++ b/windows/hook-plover.py
@@ -1,0 +1,6 @@
+
+datas = []
+hiddenimports = []
+
+datas.append(('plover/assets/*', '.'))
+


### PR DESCRIPTION
The Appveyor build consist of the following steps:
-  install all the required packages
-  run the testsuite
- package a version with PyInstaller.

The version number will be derived from `git describe --tag`, e.g. `v2.5.8-301-g6284391` -> `Plover-2.5.8+302.g315e5ee.exe`.

Most of the work is done by the `windows/helper.py` script, which can also be used on Linux to setup a Wine prefix to test and package the Windows version (see `--help` for usage).