### PR TITLE
Switch to x64 builds on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ nosetests.xml
 #Translations
 *.mo
 
+# PyCharm
+.idea
+
 #Mr Developer
 .mr.developer.cfg
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -4,7 +4,7 @@
 
 ### Python
 
-You need Python 2.7, with 32-bit support. `brew install python --universal --framework`
+You need Python 2.7. We build with brewed Python, as Apple's Python will cause you a few unexpected issues. `brew install python --framework`
 
 ### XCode Tools
 
@@ -14,53 +14,21 @@ You need XCode commandline tools. Check by running `gcc` in the terminal. You wi
 
 Get wxPython 3+. `brew install wxpython`
 
-### cython-hidapi
-
-Installing hidapi through pip only creates a 64-bit binary on my system, so when it is stripped to 32-bit for Plover, you cannot use the module. The workaround for this is to install `hidapi` from another source. I've forked `cython-hidapi` for this purpose. Please [build and install the fork](https://github.com/morinted/cython-hidapi).
-
 ### Pip
 
 Pip dependencies can be grabbed with:
 
-`pip install appdirs pyserial simplejson py2app Cython mock pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz`
+`pip install appdirs pyserial simplejson py2app Cython mock hidapi pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz`
 
 ### Running
 
 To run in development, you need access to Assistive Devices. We can circumvent this by running as sudo. To run Plover in development, use:
 
-`sudo arch -32 python launch.py`
+`sudo python launch.py`
 
 ### Building
 
-In the `/osx` folder, you can run `make app` to build `/dist/Plover.app`. To package into a `dmg` instead, use `make dmg`. There is also `make clean` in order to clear out the build and dist folders. I tend to use `make clean app` in development for testing builds.
+In the `/osx` folder, you can run `make app` to build `/dist/Plover.app`. To package into a `dmg` instead, use `make dmg`. There is also `make clean` in order to clear out the build and dist folders.
 
 After each build, you need to approve Plover as an Assistive Device. Do `System Preferences / Security & Privacy / Privacy / Accessiblity / + Plover.app`, and then you can launch the `.app` (`open ../dist/Plover.app`).
 
-## Usage with VirtualEnv
-
-If you would like to use virtualenv, you will need to follow additional instructions.
-
-Create an environment using virtualenv (1.11.6) from virtualenv.org. Once in the virtualenv (i.e. activate the environment) you’ll want to update pip and setuptools.
-
-### Hacking wxPython into your virtualenv
-
-You need to hack your virtualenv to have wxPython. This is only necessary if you’re using virtualenv but it’s still highly recommended. If you want to understand what you’re about to do you can read more at the following link: http://wiki.wxpython.org/wxPythonVirtualenvOnMac
-
-Run these commands while in the top directory of your plover virtualenv:
-
-```
-ln -s /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wxredirect.pth lib/python2.7/site-packages
-mv bin/python bin/bad_python
-ln -s /Library/Frameworks/Python.framework/Versions/2.7/bin/python bin/python
-echo 'PYTHONHOME=$VIRTUAL_ENV; export PYTHONHOME' >> bin/activate
-```
-
-### Fix a bug in py2app or modulegraph
-
-There is a bug right now between py2app and modulegraph:
-
-https://bitbucket.org/ronaldoussoren/modulegraph/issue/22/scan_code-in-modulegraphpy-contains-a
-
-Until it’s fixed, we need to fix it ourselves. A quick fix that you can run from the root of the virtualenv:
-
-`sed -i .bak -e 's/\.scan_code/._scan_code/' -e 's/\.load_module/._load_module/' lib/python2.7/site-packages/py2app/recipes/virtualenv.py`

--- a/osx/makefile
+++ b/osx/makefile
@@ -18,7 +18,7 @@ dmg: $(DMG)
 
 $(APP):
 	cd $(topdir) && $(PYTHON) setup.py py2app
-	ditto --arch i386 $(APP) $(APP:%.app=%Stripped.app)
+	ditto --arch x86_64 $(APP) $(APP:%.app=%Stripped.app)
 	rm -rf $(APP)
 	mv $(APP:%.app=%Stripped.app) $(APP)
 

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -7,6 +7,7 @@ from Quartz import (
     CGEventCreateKeyboardEvent,
     CGEventGetFlags,
     CGEventGetIntegerValueField,
+    CGEventKeyboardSetUnicodeString,
     CGEventMaskBit,
     CGEventPost,
     CGEventSetFlags,
@@ -294,13 +295,11 @@ def characters(s):
         character = encoded[start:end].decode('utf-32-be')
         yield character
 
-CGEventKeyboardSetUnicodeString = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ApplicationServices')).CGEventKeyboardSetUnicodeString
-CGEventKeyboardSetUnicodeString.restype = None
 native_utf16 = 'utf-16-le' if sys.byteorder == 'little' else 'utf-16-be'
 
 def set_string(event, s):
     buf = s.encode(native_utf16)
-    CGEventKeyboardSetUnicodeString(objc.pyobjc_id(event), len(buf) / 2, buf)
+    CGEventKeyboardSetUnicodeString(event, len(buf) / 2, buf)
 
 class KeyboardEmulation(object):
 


### PR DESCRIPTION
We were using 32-bit builds due to an old version of wxPython.
Additionally, PyObjc had an update that allowed us to use
"CGEventKeyboardSetUnicodeString" without a conversion through
PyObjc.

The application could still technically be built with 32-bit
support in "universal" fashion, but that value is super marginal,
because it's more complex to get setup and this would only affect
users on 32-bit OSX machines, which are very few. If they insist
on 32-bit, they can use the older builds.

The other reason to stick with a stripped application is the
filesize. A universal OSX application weighs in at about 90MB,
the 64/32-bit-only versions are a lighter 50MB (less in a .dmg).

@jeremy-w Can you please try this out and see if it resolves your
issues with Plover crashing after running it as `sudo`? If this works,
it will greatly simplify setting up Travis CI, which I'm very excited about.

I also removed the venv instructions, I get the sense they have no
value at this point, especially if we implement your bootstrap (or,
perhaps just the requirements.txt as it may no longer be necessary).