### PR TITLE
osx/bootstrap.sh: Check presence, not architecture

### DIFF
--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -6,8 +6,8 @@
 
 # Exit Statuses
 EX_FAILURE_NO_CCTOOLS=1
-EX_FAILURE_NO_64BIT_PYTHON=2
-EX_FAILURE_NO_64BIT_WXPYTHON=3
+EX_FAILURE_NO_PYTHON=2
+EX_FAILURE_NO_WXPYTHON=3
 
 PYTHON=${PYTHON:=$(which python)}
 PIP=${PIP:=$(which pip)}
@@ -28,9 +28,9 @@ has_cli_tools() {
 }
 
 
-has_x86_64_python() {
-    echo "$0: checking $REAL_PYTHON for 64-bit slice"
-    if otool -vf "$REAL_PYTHON" | grep x86_64 >/dev/null; then
+has_python() {
+    echo "$0: checking for functioning python"
+    if $PYTHON -c 'import sys; sys.exit(0)'; then
         "true"
     else
         "false"
@@ -38,9 +38,9 @@ has_x86_64_python() {
 }
 
 
-has_x86_64_wx() {
-    echo "$0: checking for working x86_64 wxPython"
-    if arch -64 $REAL_PYTHON -c 'import wx' 2>&1 >/dev/null; then
+has_wxPython() {
+    echo "$0: checking for functioning wxPython"
+    if $PYTHON -c 'import wx' 2>&1 >/dev/null; then
         "true"
     else
         "false"
@@ -60,34 +60,33 @@ EOT
     fi
 
 
-    if ! has_x86_64_python; then
+    if ! has_python; then
         cat 1>&2 <<EOT
-$0: 64-bit Python is required, but
+$0: Python is required, but
 $PYTHON
-doesn't have an x86_64 slice. Please run:
+appears not to be executable. Please run:
 
-    brew uninstall python
     brew install python --framework
 
 or use a different Python by setting the PYTHON env var.
 EOT
-        exit $EX_FAILURE_NO_64BIT_PYTHON
+        exit $EX_FAILURE_NO_PYTHON
     else
-        echo "$0: 64-bit slice found"
+        echo "$0: python works"
     fi
 
 
-    if ! has_x86_64_wx; then
+    if ! has_wxPython; then
         cat 1>&2 <<EOT
-$0: 64-bit wxPython is required, but |import wx| when running
-64-bit $PYTHON failed. Please run:
+$0: wxPython is required, but |import wx| when running
+$PYTHON
+failed. Please run:
 
-    brew uninstall wxpython
     brew install wxpython
 EOT
         exit $EX_FAILURE_NO_64BIT_WXPYTHON
     else
-        echo "$0: successfully imported wx into 64-bit Python"
+        echo "$0: successfully imported wx"
     fi
 
 


### PR DESCRIPTION
Trying to check architecture made it needlessly brittle.
Of course it's going to be 64-bit, if it works at all.