### PR TITLE
log: don't set the print handler level

### DIFF
--- a/plover/log.py
+++ b/plover/log.py
@@ -38,7 +38,6 @@ class Logger(object):
 
     def __init__(self):
         self._print_handler = PrintHandler()
-        self._print_handler.setLevel(WARNING)
         self._file_handler = None
         self._logger = logging.getLogger('plover')
         self._logger.addHandler(self._print_handler)

--- a/plover/log.py
+++ b/plover/log.py
@@ -51,7 +51,6 @@ class Logger(object):
     def setup_logfile(self):
         assert self._file_handler is None
         self._file_handler = FileHandler()
-        self._file_handler.setLevel(INFO)
         self._logger.addHandler(self._file_handler)
 
     def set_stroke_filename(self, filename=None):


### PR DESCRIPTION
Otherwise, it acts as a second (possibly more restrictive) filter, after
the logger level. Leaving it unset make it possible to change the level
at the logger level.