### PR TITLE
Rename "NKRO Keyboard" and "Sidewinder" to "Keyboard"

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -19,7 +19,7 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, 'plover.cfg')
 # General configuration sections, options and defaults.
 MACHINE_CONFIG_SECTION = 'Machine Configuration'
 MACHINE_TYPE_OPTION = 'machine_type'
-DEFAULT_MACHINE_TYPE = 'NKRO Keyboard'
+DEFAULT_MACHINE_TYPE = 'Keyboard'
 MACHINE_AUTO_START_OPTION = 'auto_start'
 DEFAULT_MACHINE_AUTO_START = False
 

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -1,11 +1,7 @@
 # Copyright (c) 2010 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
-# TODO: look into programmatically pasting into other applications
-
-"For use with a Microsoft Sidewinder X4 keyboard used as stenotype machine."
-
-# TODO: Change name to NKRO Keyboard.
+"For use with a computer keyboard (preferably NKRO) as a steno machine."
 
 from plover.machine.base import StenotypeBase
 from plover.machine.keymap import Keymap
@@ -13,7 +9,7 @@ from plover.oslayer.keyboardcontrol import KeyboardCapture
 
 
 class Stenotype(StenotypeBase):
-    """Standard stenotype interface for a Microsoft Sidewinder X4 keyboard.
+    """Standard stenotype interface for a computer keyboard.
 
     This class implements the three methods necessary for a standard
     stenotype interface: start_capture, stop_capture, and
@@ -22,7 +18,7 @@ class Stenotype(StenotypeBase):
     """
 
     def __init__(self, params):
-        """Monitor a Microsoft Sidewinder X4 keyboard via X events."""
+        """Monitor the keyboard's events."""
         StenotypeBase.__init__(self)
         self.arpeggiate = params['arpeggiate']
         self.keymap = params['keymap'].to_dict()

--- a/plover/machine/registry.py
+++ b/plover/machine/registry.py
@@ -5,7 +5,7 @@
 
 from plover.machine.geminipr import Stenotype as geminipr
 from plover.machine.txbolt import Stenotype as txbolt
-from plover.machine.sidewinder import Stenotype as sidewinder
+from plover.machine.keyboard import Stenotype as keyboard
 from plover.machine.stentura import Stenotype as stentura
 from plover.machine.passport import Stenotype as passport
 from plover import log
@@ -51,7 +51,7 @@ class Registry(object):
             return name
 
 machine_registry = Registry()
-machine_registry.register('NKRO Keyboard', sidewinder)
+machine_registry.register('Keyboard', keyboard)
 machine_registry.register('Gemini PR', geminipr)
 machine_registry.register('TX Bolt', txbolt)
 machine_registry.register('Stentura', stentura)
@@ -59,4 +59,7 @@ machine_registry.register('Passport', passport)
 if treal:
     machine_registry.register('Treal', treal)
 
-machine_registry.add_alias('Microsoft Sidewinder X4', 'NKRO Keyboard')
+# Legacy configuration
+machine_registry.add_alias('Microsoft Sidewinder X4', 'Keyboard')
+machine_registry.add_alias('NKRO Keyboard', 'Keyboard')
+

--- a/plover/machine/test_registry.py
+++ b/plover/machine/test_registry.py
@@ -32,9 +32,13 @@ class RegistryClassTestCase(unittest.TestCase):
         self.assertEqual(['a', 'b'], sorted(registry.get_all_names()))
 
 class MachineRegistryTestCase(unittest.TestCase):
-    def test_sidewinder(self):
-        self.assertEqual(machine_registry.get("NKRO Keyboard"), 
+    def test_keyboard_as_sidewinder(self):
+        self.assertEqual(machine_registry.get("Keyboard"),
                          machine_registry.get('Microsoft Sidewinder X4'))
+
+    def test_keyboard_as_nkro(self):
+        self.assertEqual(machine_registry.get("Keyboard"),
+                         machine_registry.get('NKRO Keyboard'))
 
     def test_unknown_machine(self):
         with self.assertRaises(NoSuchMachineException):


### PR DESCRIPTION
In the code, we still refer to the Sidewinder even though it is no longer relevant for most users. As such, it's a little confusing when you are looking for the "keyboard" machine and you need to learn that it's called the Sidewinder internally. Also, it's a little misleading to say "NKRO Keyboard: connected", because users who don't have an NKRO keyboard will open Plover and see this message, and may be confused.

These issues affected me when I very first started using Plover (no NKRO keyboard, looking to find the plover/machine/keyboard).

@stenoknight, can I get your comment on this? Particularly, the change from "NKRO Keyboard: connected" to "Keyboard: connected"? 
<img width="403" alt="screen shot 2016-02-14 at 11 42 54 pm" src="https://cloud.githubusercontent.com/assets/5840970/13040008/b83042fa-d374-11e5-92c9-ff9aa43e34a8.png">
<img width="343" alt="screen shot 2016-02-14 at 11 42 44 pm" src="https://cloud.githubusercontent.com/assets/5840970/13040009/b85e66ee-d374-11e5-8675-a1b2c8257a42.png">

