### PR TITLE
Replace triple-dot with ellipsis in user strings

### DIFF
--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Copyright (c) 2010-2011 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
@@ -40,7 +41,7 @@ LOG_FILE_LABEL = "Log File:"
 LOG_STROKES_LABEL = "Log Strokes"
 LOG_TRANSLATIONS_LABEL = "Log Translations"
 LOG_FILE_DIALOG_TITLE = "Select a Log File"
-CONFIG_BUTTON_NAME = "Configure..."
+CONFIG_BUTTON_NAME = u"Configure…"
 SPACE_PLACEMENTS_LABEL = "Space Placement:"
 SPACE_PLACEMENT_BEFORE = "Before Output"
 SPACE_PLACEMENT_AFTER = "After Output"

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Copyright (c) 2010-2011 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
@@ -75,9 +76,9 @@ class MainFrame(wx.Frame):
     RUNNING_MESSAGE = "running"
     STOPPED_MESSAGE = "stopped"
     ERROR_MESSAGE = "error"
-    CONFIGURE_BUTTON_LABEL = "Configure..."
-    ABOUT_BUTTON_LABEL = "About..."
-    RECONNECT_BUTTON_LABEL = "Reconnect..."
+    CONFIGURE_BUTTON_LABEL = u"Configure…"
+    ABOUT_BUTTON_LABEL = u"About…"
+    RECONNECT_BUTTON_LABEL = u"Reconnect…"
     COMMAND_SUSPEND = 'SUSPEND'
     COMMAND_ADD_TRANSLATION = 'ADD_TRANSLATION'
     COMMAND_LOOKUP = 'LOOKUP'

--- a/plover/gui/serial_config.py
+++ b/plover/gui/serial_config.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Copyright (c) 2010 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
@@ -20,7 +21,7 @@ RTS_CTS_STR = 'RTS/CTS'
 XON_XOFF_STR = 'Xon/Xoff'
 OK_STR = 'OK'
 SCAN_STR = "Scan"
-LOADING_STR = "Scanning ports..."
+LOADING_STR = u"Scanning ports…"
 CANCEL_STR = 'Cancel'
 CONNECTION_STR = 'Connection'
 PORT_STR = 'Port'


### PR DESCRIPTION
Fixes visual appearance of too-wide triple-dot.

Required setting a coding through a
[magic comment](https://www.python.org/dev/peps/pep-0263/)
in order to avoid ugly raw Unicode escapes.