### PR TITLE
Fix a Mac crash relating to long Unicode after switching to 64-bit

### DIFF
--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -29,6 +29,7 @@ from Quartz import (
     kCGKeyboardEventKeycode,
     kCGSessionEventTap,
 )
+import Foundation
 import threading
 import collections
 import sys
@@ -291,11 +292,9 @@ def characters(s):
         character = encoded[start:end].decode('utf-32-be')
         yield character
 
-native_utf16 = 'utf-16-le' if sys.byteorder == 'little' else 'utf-16-be'
-
 def set_string(event, s):
-    buf = s.encode(native_utf16)
-    CGEventKeyboardSetUnicodeString(event, len(buf) / 2, buf)
+    buf = Foundation.NSString.stringWithString_(s)
+    CGEventKeyboardSetUnicodeString(event, len(buf), buf)
 
 class KeyboardEmulation(object):
 

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -248,7 +248,7 @@ class KeyboardCapture(threading.Thread):
                 handler = self.key_up if event_type == kCGEventKeyUp else self.key_down
                 handler(key)
                 if key in self._suppressed_keys:
-                    # Supress event.
+                    # Suppress event.
                     event = None
             return event
 
@@ -285,8 +285,7 @@ class KeyboardCapture(threading.Thread):
 # let's us iterate over full characters in the string.
 def characters(s):
     encoded = s.encode('utf-32-be')
-    characters = []
-    for i in xrange(len(encoded)/4):
+    for i in xrange(len(encoded) / 4):
         start = i * 4
         end = start + 4
         character = encoded[start:end].decode('utf-32-be')


### PR DESCRIPTION
We switched over to the PyObjc version of set Unicode string when going to 64-bit, and this broke a work around that [Hesky had figured out](http://stackoverflow.com/questions/18027342/how-can-i-call-cgeventkeyboardsetunicodestring-from-python) a while back. With the current dependencies, we don't need the work around.

In master right now, emojis crash output, this change fixes that.

Tested on Mac.