### PR TITLE
Shorten unicode on Add Translation dialog

### DIFF
--- a/plover/gui/add_translation.py
+++ b/plover/gui/add_translation.py
@@ -145,6 +145,7 @@ class AddTranslationDialog(wx.Dialog):
                 label = '%s maps to %s' % (strokes, translation)
             else:
                 label = '%s is not in the dictionary' % strokes
+            label = util.shorten_unicode(label)
         else:
             label = ''
         self.stroke_mapping_text.SetLabel(label)
@@ -162,6 +163,7 @@ class AddTranslationDialog(wx.Dialog):
                 label = '%s is mapped from %s' % (translation, strokes)
             else:
                 label = '%s is not in the dictionary' % translation
+            label = util.shorten_unicode(label)
         else:
             label = ''
         self.translation_mapping_text.SetLabel(label)


### PR DESCRIPTION
Prevent another Unicode-caused crash with the shorten Unicode function on Mac:

<img width="666" alt="screen shot 2016-02-16 at 6 22 02 pm" src="https://cloud.githubusercontent.com/assets/5840970/13094676/40e00764-d4da-11e5-8a4c-81e66d06d57c.png">

Only tested on Mac.