### PR TITLE
Add Linux support to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,65 @@
-language: python
+language: generic
+
 matrix:
   include:
+    - os: linux
+      dist: trusty
+      sudo: required
     - os: osx
-      language: generic
+
 before_install:
- - >
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]];
-  then
-    brew update &&
-    brew install python --framework &&
-    brew link --overwrite python &&
-    brew install wxpython &&
-    (cd osx && ./bootstrap.sh); fi
+  - |
+    case "$TRAVIS_OS_NAME" in
+    osx)
+      brew update &&
+      brew install python --framework &&
+      brew link --overwrite python &&
+      brew install wxpython &&
+      true
+      ;;
+    linux)
+      sudo apt-add-repository -y ppa:adamwolf/kicad-trusty-backports &&
+      sudo apt-get update -qq &&
+      sudo apt-get install -y cython libudev-dev libusb-1.0-0-dev python-dev python-wxgtk3.0 python-xlib &&
+      true
+      ;;
+    esac &&
+    python -c 'import setup; setup.write_requirements()' &&
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt &&
+    # We need to downgrade setuptools for py2app to work correctly...
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2' &&
+    pip --disable-pip-version-check list &&
+    true
 
 install: true
+
 script:
+  - depth=50; while ! git describe --tag '--match=v[0-9]*'; do depth=$(($depth+10)); git fetch --depth $depth; done
   - python setup.py patch_version
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then (cd osx && make); fi
+  - python setup.py test
+  - |
+    case "$TRAVIS_OS_NAME" in
+    osx)
+      make -C osx &&
+      true
+      ;;
+    linux)
+      python setup.py bdist_egg &&
+      python setup.py bdist_wheel &&
+      true
+      ;;
+    esac
+
 deploy:
   provider: releases
   skip_cleanup: true
   api_key:
     secure: p1QHOgNToBnHht/Y05+Nr2QdWgwxYeGJwWvhkcPUNKh7YC59v2AKkRx5YeRF0sYgXK6VOPcxDmdnZ9+5ztVpgjMrMsIGhckYoLOVkHVRhXEKqmz2A8Ol0pTmrvvmqalufa2+6l414/C2GciK95yoQJIfZGZT4xA6QO5dWx52azAtRZVbyG6oenrOPuCeSfXrE9UslHSBKe4afoBiHNEEDewObys45yjXvU1KXRR9TRdO0wOSi0i+cZKj4Azpm7MeFU1ftkjALYoLYinIe5swhpYTsrJRv/qyQR1ZCougFD+PbECx4OJB4Ssn5xdfqj4IKKi3Ja1q6FUF3I+6jI8+p62e5YHjSWahsUOVbaIkDQcC7jNDuT85BXIH2pZT1mjFIhec9q4ramP30BR/1IgX1WYwGLk9y0XYfoTOsPmohFoX3i9U5CgZrjmuNsRbelxFZadVKqwRpJffw3Iaeu6D6kwtN4hGHpYskTEpxWY0M9uFoVwTTFBk9qCr13nkTeXRz3ERRfan2NWPfj8n2O2gG/NOd0SCG5eofHY1EDj7ciULVLl3KFyxBlTDAzy8xoK8laz+WCJ5dxlM2RV0G3OCdCPfLl+vqzcNk9eTtBBshb7qInfgk+hg7eviOeeCOTVcRjxCQHGAvMB4mVxwKHa+DNRmTInFw0Z/rCdEH5DaWog=
-  file: "dist/Plover.dmg"
+  file_glob: true
+  file:
+    - "dist/*.dmg"
+    - "dist/*.egg"
+    - "dist/*.whl"
   on:
     tags: true
     repo: openstenoproject/plover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ deploy:
   prerelease: true
   auth_token:
     secure: m8kBg3jFX2k516nlmWkvxNCrBwlQZMaa6hNn7A+rktl781BRTyKssCXQqKAwPJLs
-  artifact: executable, egg
+  artifact: executable
   on:
     branch: weekly
 
@@ -69,7 +69,6 @@ build_script:
 
 after_build:
   - "python windows\\helper.py dist"
-  - "python setup.py bdist_egg"
 
 test_script:
   - "py.test-2.7 -v -ra plover"
@@ -79,5 +78,3 @@ artifacts:
   - path: dist\*.exe
     name: executable
 
-  - path: dist\*.egg
-    name: egg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,9 @@ build:
   verbosity: minimal
 
 before_build:
+  # Update version number from VCS.
   - "python setup.py patch_version"
+  # And the build number accordingly.
   - ps: "Update-AppveyorBuild -Version \"$(python setup.py --version)\""
   - "ECHO appveyor_build_version: %appveyor_build_version%"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,10 +48,12 @@ install:
   - "python --version"
 
   # Install wget module.
-  - "pip install --disable-pip-version-check --timeout 5 --retries 2 wget"
+  - "pip --disable-pip-version-check --timeout 5 --retries 2 install wget"
 
   # Setup the rest of the environment.
   - "python windows\\helper.py setup"
+
+  - "pip --disable-pip-version-check list"
 
   # Update PATH.
   - "SET PATH=C:\\Prog\\7-Zip;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ after_build:
   - "python windows\\helper.py dist"
 
 test_script:
-  - "py.test-2.7 -v -ra plover"
+  - "python setup.py test"
 
 artifacts:
 

--- a/launch.py
+++ b/launch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 
 from plover.main import main
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,11 @@ if sys.platform.startswith('darwin'):
     # Py2app will not look at entry_points.
     kwargs['app'] = 'launch.py',
 
+setup_requires.extend(('pytest-runner', 'pytest'))
+options['aliases'] = {
+    'test': 'pytest --addopts -ra --addopts plover',
+}
+
 setuptools.setup(
     name=__software_name__.capitalize(),
     version=__version__,
@@ -91,6 +96,9 @@ setuptools.setup(
         'patch_version': PatchVersion,
     },
     setup_requires=setup_requires,
+    tests_require=[
+        'mock',
+    ],
     install_requires=[
         'setuptools',
         'pyserial>=2.7',

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -281,14 +281,7 @@ class Helper(object):
         # Note: '--always-unzip' is needed, as pyHook cannot work from a single egg file.
         ('pyhook'           , 'http://downloads.sourceforge.net/project/pyhook/pyhook/1.5.1/pyHook-1.5.1.win32-py2.7.exe'                         , '9afb7a5b2858a69c6b0f6d2cb1b2eb2a3f4183d2', 'easy_install', ('--always-unzip',), None),
         ('pywin32'          , 'http://downloads.sourceforge.net/project/pywin32/pywin32/Build 219/pywin32-219.win32-py2.7.exe'                    , '8bc39008383c646bed01942584117113ddaefe6b', 'easy_install', (), None),
-        ('appdirs'          , 'pip:appdirs'                                                                                                       , None                                      , None, (), None),
-        ('mock'             , 'pip:mock'                                                                                                          , None                                      , None, (), None),
-        ('pyserial'         , 'pip:pyserial'                                                                                                      , None                                      , None, (), None),
         ('pywinusb'         , 'pip:pywinusb'                                                                                                      , None                                      , None, (), None),
-        ('PyInstaller'      , 'pip:PyInstaller==3.1.1'                                                                                            , None                                      , None, (), None),
-        ('PyTest'           , 'pip:pytest'                                                                                                        , None                                      , None, (), None),
-        # We need to downgrade setuptools...
-        ('setuptools'       , 'pip:setuptools==19.2'                                                                                              , None                                      , None, (), None),
     )
 
     def __init__(self):
@@ -445,15 +438,15 @@ class Helper(object):
             cmd.extend(('--', filename))
         self._env.run(cmd)
 
-    def _pip_install(self, *specs):
+    def _pip_install(self, *args):
         cmd = ['pip.exe',
                '--timeout=5',
                '--retries=2',
                '--disable-pip-version-check']
         if not self.verbose:
             cmd.append('--quiet')
-        cmd.extend(('install', '--upgrade', '--'))
-        cmd.extend(specs)
+        cmd.extend(('install', '--upgrade'))
+        cmd.extend(args)
         self._env.run(cmd)
 
     def _download(self, url, checksum, dst):
@@ -526,6 +519,9 @@ class Helper(object):
         self._env.setup()
         for name, src, checksum, handler_format, handler_args, path_dir in self.DEPENDENCIES:
             self.install(name, src, checksum, handler_format=handler_format, handler_args=handler_args, path_dir=path_dir)
+        info('install requirements')
+        self._env.run(('python.exe', '-c', 'import setup; setup.write_requirements()'))
+        self._pip_install('-r', 'requirements.txt')
 
     def cmd_run(self, executable, *args):
         '''run command in environment


### PR DESCRIPTION
* add Linux to the build matrix
* run test suite for both OSX and Linux builds
* add egg and wheel deployments to the Linux build
* reduce overlap in dependencies handling when possible by using `setup.py develop` to install those that are supported by pip