### PR TITLE
Override Cancel labels, fix #373

### DIFF
--- a/plover/gui/add_translation.py
+++ b/plover/gui/add_translation.py
@@ -27,7 +27,7 @@ class AddTranslationDialog(wx.Dialog):
         self.strokes_text = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
         self.translation_text = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
         button = wx.Button(self, id=wx.ID_OK, label='Add to dictionary')
-        cancel = wx.Button(self, id=wx.ID_CANCEL)
+        cancel = wx.Button(self, id=wx.ID_CANCEL, label='Cancel')
         self.stroke_mapping_text = wx.StaticText(self)
         self.translation_mapping_text = wx.StaticText(self)
         

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -120,7 +120,7 @@ class ConfigurationDialog(wx.Dialog):
         button_sizer.AddButton(save_button)
 
         # Configuring and adding the cancel button
-        cancel_button = wx.Button(self, wx.ID_CANCEL)
+        cancel_button = wx.Button(self, wx.ID_CANCEL, label='Cancel')
         button_sizer.AddButton(cancel_button)
         button_sizer.Realize()
 

--- a/plover/gui/keyboard_config.py
+++ b/plover/gui/keyboard_config.py
@@ -136,7 +136,7 @@ class KeyboardConfigDialog(wx.Dialog):
 
         ok_button = wx.Button(self, id=wx.ID_OK)
         ok_button.SetDefault()
-        cancel_button = wx.Button(self, id=wx.ID_CANCEL)
+        cancel_button = wx.Button(self, id=wx.ID_CANCEL, label='Cancel')
 
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         button_sizer.Add(ok_button, border=UI_BORDER, flag=wx.ALL)

--- a/plover/gui/lookup.py
+++ b/plover/gui/lookup.py
@@ -24,7 +24,7 @@ class LookupDialog(wx.Dialog):
 
         # components
         self.translation_text = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
-        cancel = wx.Button(self, id=wx.ID_CANCEL)
+        cancel = wx.Button(self, id=wx.ID_CANCEL, label='Cancel')
         self.listbox = wx.ListBox(self, size=wx.Size(210, 200))
         
         # layout


### PR DESCRIPTION
- Default label for Cancel labels is '&Cancel', meaning any time
  the user tries to copy on OSX (Cmd-C), the active window would
  "cancel".
- See wx bug: http://trac.wxwidgets.org/ticket/15678