### PR TITLE
Fix currency retroformatting exception

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -511,26 +511,8 @@ def _atom_to_action_spaces_before(atom, last_action):
                 action.replace = last_action.text
                 action.text = _upper(last_action.text)
         elif meta.startswith(META_RETRO_FORMAT):
-            if (meta.startswith(META_RETRO_FORMAT) and meta.endswith(')')):
-                dict_format = meta[len(META_RETRO_FORMAT):-len(')')]
-                action = last_action.copy_state()
-                action.replace = last_action.word
-                try:
-                    float(last_action.word)
-                except ValueError:
-                    pass
-                else:
-                    format = dict_format.replace('c', '{:,.2f}')
-                    cast_input = float(last_action.word)
-                try:
-                    int(last_action.word)
-                except ValueError:
-                    pass
-                else:
-                    format = dict_format.replace('c', '{:,}')
-                    cast_input = int(last_action.word)
-                action.text = format.format(cast_input)
-                action.word = action.text
+            if meta.startswith(META_RETRO_FORMAT) and meta.endswith(')'):
+                action = _apply_currency(meta, last_action)
         elif meta.startswith(META_COMMAND):
             action = last_action.copy_state()
             action.command = meta[len(META_COMMAND):]
@@ -695,26 +677,8 @@ def _atom_to_action_spaces_after(atom, last_action):
                 action.replace = last_action.text
                 action.text = _upper(last_action.text)
         elif meta.startswith(META_RETRO_FORMAT):
-            if (meta.startswith(META_RETRO_FORMAT) and meta.endswith(')')):
-                dict_format = meta[len(META_RETRO_FORMAT):-len(')')]
-                action = last_action.copy_state()
-                action.replace = last_action.word + SPACE
-                try:
-                    float(last_action.word)
-                except ValueError:
-                    pass
-                else:
-                    format = dict_format.replace('c', '{:,.2f}')
-                    cast_input = float(last_action.word)
-                try:
-                    int(last_action.word)
-                except ValueError:
-                    pass
-                else:
-                    format = dict_format.replace('c', '{:,}')
-                    cast_input = int(last_action.word)
-                action.text = format.format(cast_input) + SPACE
-                action.word = format.format(cast_input)
+            if meta.startswith(META_RETRO_FORMAT) and meta.endswith(')'):
+                action = _apply_currency(meta, last_action, spaces_after=True)
         elif meta.startswith(META_COMMAND):
             action = last_action.copy_state()
             action.command = meta[len(META_COMMAND):]
@@ -824,6 +788,32 @@ def _apply_mode(text, case, space_char, begin, last_attach,
                 text = _lower(text)
 
     return text
+
+
+def _apply_currency(meta, last_action, spaces_after=False):
+    dict_format = meta[len(META_RETRO_FORMAT):-len(')')]
+    action = last_action.copy_state()
+    cast_input = None
+    try:
+        cast_input = float(last_action.word)
+    except ValueError:
+        pass
+    else:
+        currency_format = dict_format.replace('c', '{:,.2f}')
+    try:
+        cast_input = int(last_action.word)
+    except ValueError:
+        pass
+    else:
+        currency_format = dict_format.replace('c', '{:,}')
+    if cast_input is not None:
+        action.replace = last_action.word
+        action.word = currency_format.format(cast_input)
+        action.text = action.word
+        if spaces_after:
+            action.replace += SPACE
+            action.text += SPACE
+    return action
 
 
 def _change_mode(command, action):

--- a/plover/test_formatting.py
+++ b/plover/test_formatting.py
@@ -304,6 +304,21 @@ class FormatterTestCase(unittest.TestCase):
           action(text='EQUIPPED', word='EQUIPPED', replace='equipped', upper_carry=True),
          ]),
 
+        (('notanumber {*($c)}', action(), False),
+         [action(text=' notanumber', word='notanumber'),
+          action(text='', word='notanumber', replace=''),
+         ]),
+
+        (('0 {*($c)}', action(), False),
+         [action(text=' 0', word='0'),
+          action(text='$0', word='$0', replace='0'),
+         ]),
+
+        (('0.00 {*($c)}', action(), False),
+         [action(text=' 0.00', word='0.00'),
+          action(text='$0.00', word='$0.00', replace='0.00'),
+         ]),
+
         (('1234 {*($c)}', action(), False),
          [action(text=' 1234', word='1234'),
           action(text='$1,234', word='$1,234', replace='1234'),
@@ -443,6 +458,21 @@ class FormatterTestCase(unittest.TestCase):
          [action(text='equip ', word='equip'),
           action(text='ped ', word='equipped', replace=' '),
           action(text='EQUIPPED ', word='EQUIPPED', replace='equipped ', upper_carry=True),
+         ]),
+
+        (('notanumber {*($c)}', action(), True),
+         [action(text='notanumber ', word='notanumber'),
+          action(text='', word='notanumber', replace=''),
+         ]),
+
+        (('0 {*($c)}', action(), True),
+         [action(text='0 ', word='0'),
+          action(text='$0 ', word='$0', replace='0 '),
+         ]),
+
+        (('0.00 {*($c)}', action(), True),
+         [action(text='0.00 ', word='0.00'),
+          action(text='$0.00 ', word='$0.00', replace='0.00 '),
          ]),
 
         (('1234 {*($c)}', action(), True),


### PR DESCRIPTION
When trying to currency format after an output that wasn't a number, there
was an exception and Plover's output would cease completely.

To work around this is just to define the case where the user's previous
word is not a number, at which point the command should do nothing.
Explicitly added tests for the 0 cases as well, because they are edge.