### PR TITLE
config: allow first stroke to be capitalized and attached

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -52,6 +52,8 @@ def init_engine(engine, config):
     engine.enable_stroke_logging(config.get_enable_stroke_logging())
     engine.enable_translation_logging(config.get_enable_translation_logging())
     engine.set_space_placement(config.get_space_placement())
+    engine.set_starting_stroke_state(capitalize=config.get_start_capitalized(),
+                                     attach=config.get_start_attached())
     
     engine.set_is_running(config.get_auto_start())
 
@@ -104,6 +106,13 @@ def update_engine(engine, old, new):
     space_placement = new.get_space_placement()
     if old.get_space_placement() != space_placement:
         engine.set_space_placement(space_placement)
+
+    start_capitalized = new.get_start_capitalized()
+    start_attached = new.get_start_attached()
+    if (old.get_start_capitalized() != start_capitalized or
+            old.get_start_attached() != start_attached):
+        engine.set_starting_stroke_state(attach=start_attached,
+                                         capitalize=start_capitalized)
 
 def same_thread_hook(fn, *args):
     fn(*args)
@@ -247,6 +256,10 @@ class StenoEngine(object):
     def set_space_placement(self, s):
         """Set whether spaces will be inserted before the output or after the output."""
         self.formatter.set_space_placement(s)
+
+    def set_starting_stroke_state(self, capitalize=False, attach=False):
+        self.formatter.start_attached = attach
+        self.formatter.start_capitalized = capitalize
         
     def enable_translation_logging(self, b):
         """Turn translation logging on or off."""

--- a/plover/config.py
+++ b/plover/config.py
@@ -63,6 +63,10 @@ DEFAULT_SUGGESTIONS_DISPLAY_Y = -1
 OUTPUT_CONFIG_SECTION = 'Output Configuration'
 OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION = 'space_placement'
 DEFAULT_OUTPUT_CONFIG_SPACE_PLACEMENT = 'Before Output'
+OUTPUT_CONFIG_START_CAPITALIZED = 'capitalize_first_stroke'
+DEFAULT_OUTPUT_CONFIG_START_CAPITALIZED = False
+OUTPUT_CONFIG_START_ATTACHED = 'attach_first_stroke'
+DEFAULT_OUTPUT_CONFIG_START_ATTACHED = False
 
 CONFIG_FRAME_SECTION = 'Config Frame'
 CONFIG_FRAME_X_OPTION = 'x'
@@ -276,6 +280,20 @@ class Config(object):
 
     def set_space_placement(self, s):
         self._set(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION, s)
+
+    def get_start_capitalized(self):
+        return self._get_bool(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_START_CAPITALIZED,
+                              DEFAULT_OUTPUT_CONFIG_START_CAPITALIZED)
+
+    def set_start_capitalized(self, b):
+        self._set(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_START_CAPITALIZED, b)
+
+    def get_start_attached(self):
+        return self._get_bool(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_START_ATTACHED,
+                              DEFAULT_OUTPUT_CONFIG_START_ATTACHED)
+
+    def set_start_attached(self, b):
+        self._set(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_START_ATTACHED, b)
 
     def set_stroke_display_on_top(self, b):
         self._set(STROKE_DISPLAY_SECTION, STROKE_DISPLAY_ON_TOP_OPTION, b)

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -39,6 +39,8 @@ class Formatter(object):
     output_type = namedtuple(
         'output', ['send_backspaces', 'send_string', 'send_key_combination',
                    'send_engine_command'])
+    start_capitalized = False
+    start_attached = False
 
     def __init__(self):
         self.set_output(None)
@@ -94,7 +96,7 @@ class Formatter(object):
 
         """
         for t in do:
-            last_action = _get_last_action(prev.formatting if prev else None)
+            last_action = self._get_last_action(prev.formatting if prev else None)
             if t.english:
                 t.formatting = _translation_to_actions(t.english, last_action,
                                                        self.spaces_after)
@@ -117,6 +119,12 @@ class Formatter(object):
             callback(old, new)
 
         OutputHelper(self._output).render(old[i:], new[i:])
+
+    def _get_last_action(self, actions):
+        """Return last action in actions if possible or return a default action."""
+        if actions:
+            return actions[-1]
+        return _Action(attach=self.start_attached, capitalize=self.start_capitalized)
 
 
 class OutputHelper(object):
@@ -181,11 +189,6 @@ class OutputHelper(object):
                 self.commit()
                 self.output.send_engine_command(a.command)
         self.commit()
-
-
-def _get_last_action(actions):
-    """Return last action in actions if possible or return a blank action."""
-    return actions[-1] if actions else _Action()
 
 
 class _Action(object):

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -46,6 +46,10 @@ SPACE_PLACEMENTS_LABEL = "Space Placement:"
 SPACE_PLACEMENT_BEFORE = "Before Output"
 SPACE_PLACEMENT_AFTER = "After Output"
 SPACE_PLACEMENTS = [SPACE_PLACEMENT_BEFORE, SPACE_PLACEMENT_AFTER]
+FIRST_STROKE_LABEL = "First Stroke:"
+START_CAPITALIZED_LABEL = "Start Capitalized"
+START_ATTACHED_LABEL = "Suppress Space"
+
 UI_BORDER = 4
 COMPONENT_SPACE = 3
 UP_IMAGE_FILE = os.path.join(conf.ASSETS_DIR, 'up.png')
@@ -520,13 +524,26 @@ class OutputConfig(wx.Panel):
         box.Add(wx.StaticText(self, label=SPACE_PLACEMENTS_LABEL),
                 border=COMPONENT_SPACE,
                 flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.RIGHT)
-        self.choice = wx.Choice(self, choices=SPACE_PLACEMENTS)
-        self.choice.SetStringSelection(self.config.get_space_placement())
-        box.Add(self.choice, proportion=1, flag=wx.EXPAND)
-        sizer.Add(box, border=UI_BORDER, flag=wx.ALL | wx.EXPAND)        
+        self.space_placement_choice = wx.Choice(self, choices=SPACE_PLACEMENTS)
+        self.space_placement_choice.SetStringSelection(self.config.get_space_placement())
+        box.Add(self.space_placement_choice, proportion=1, flag=wx.EXPAND)
+        sizer.Add(box, border=UI_BORDER, flag=wx.ALL | wx.EXPAND)
+
+        first_stroke_label = wx.StaticText(self, label=FIRST_STROKE_LABEL)
+        self.start_attached = wx.CheckBox(self, label=START_ATTACHED_LABEL)
+        self.start_attached.SetValue(self.config.get_start_attached())
+        self.start_capitalized = wx.CheckBox(self, label=START_CAPITALIZED_LABEL)
+        self.start_capitalized.SetValue(self.config.get_start_capitalized())
+
+        sizer.AddF(first_stroke_label, wx.SizerFlags().Border(wx.ALL, UI_BORDER))
+        checkbox_flags = wx.SizerFlags().Border(wx.LEFT, COMPONENT_SPACE * 6)
+        sizer.AddF(self.start_capitalized, checkbox_flags)
+        sizer.AddF(self.start_attached, checkbox_flags)
 
         self.SetSizer(sizer)
 
     def save(self):
         """Write all parameters to the config."""
-        self.config.set_space_placement(self.choice.GetStringSelection())
+        self.config.set_space_placement(self.space_placement_choice.GetStringSelection())
+        self.config.set_start_attached(self.start_attached.GetValue())
+        self.config.set_start_capitalized(self.start_capitalized.GetValue())


### PR DESCRIPTION
### About

Add output configuration options so that the first stroke after Plover is enabled can be capitalized or attached (no space). The default behavior is the same as Plover 2.5.8, and this shows up as checkboxes in the output section of the configuration.

<img width="598" alt="Configuration screenshot" src="https://cloud.githubusercontent.com/assets/5840970/13301785/a6a9809e-db14-11e5-999d-97d91cb7a235.png">

### Reason

This never really bothered me until @stanographer asked for it. It seems like a sensible feature, because some users (like me) always want no space and capitals, some users might want capitals *with* a space (writing text, for example), and some users may not want this change at all.

### Release Notes

Configure whether Plover's first stroke after being turned on is capitalized and has a space.

### Tested Platforms

Only tried on OS X, but also included test cases to verify the functionality.