### PR TITLE
Add stroke buffer configuration, default to 100

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -80,6 +80,9 @@ def update_engine(engine, config, reset_machine=False):
     space_placement = config.get_space_placement()
     engine.set_space_placement(space_placement)
 
+    undo_levels = config.get_undo_levels()
+    engine.set_undo_levels(undo_levels)
+
     start_capitalized = config.get_start_capitalized()
     start_attached = config.get_start_attached()
     engine.set_starting_stroke_state(attach=start_attached,
@@ -134,9 +137,6 @@ class StenoEngine(object):
         self.formatter = formatting.Formatter()
         self.translator.add_listener(log.translation)
         self.translator.add_listener(self.formatter.format)
-        # This seems like a reasonable number. If this becomes a problem it can
-        # be parameterized.
-        self.translator.set_min_undo_length(10)
 
         self.full_output = SimpleNamespace()
         self.command_only_output = SimpleNamespace()
@@ -254,7 +254,11 @@ class StenoEngine(object):
     def set_starting_stroke_state(self, capitalize=False, attach=False):
         self.formatter.start_attached = attach
         self.formatter.start_capitalized = capitalize
-        
+
+    def set_undo_levels(self, levels):
+        """Set the maximum number of changes that can be undone."""
+        self.translator.set_min_undo_length(levels)
+
     def enable_translation_logging(self, b):
         """Turn translation logging on or off."""
         log.enable_translation_logging(b)

--- a/plover/config.py
+++ b/plover/config.py
@@ -64,6 +64,8 @@ DEFAULT_SUGGESTIONS_DISPLAY_Y = -1
 OUTPUT_CONFIG_SECTION = 'Output Configuration'
 OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION = 'space_placement'
 DEFAULT_OUTPUT_CONFIG_SPACE_PLACEMENT = 'Before Output'
+OUTPUT_CONFIG_UNDO_LEVELS = 'undo_levels'
+DEFAULT_OUTPUT_CONFIG_UNDO_LEVELS = 100
 OUTPUT_CONFIG_START_CAPITALIZED = 'capitalize_first_stroke'
 DEFAULT_OUTPUT_CONFIG_START_CAPITALIZED = False
 OUTPUT_CONFIG_START_ATTACHED = 'attach_first_stroke'
@@ -306,6 +308,13 @@ class Config(object):
 
     def set_space_placement(self, s):
         self._set(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION, s)
+
+    def get_undo_levels(self):
+        return self._get_int(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_UNDO_LEVELS,
+                             DEFAULT_OUTPUT_CONFIG_UNDO_LEVELS)
+
+    def set_undo_levels(self, levels):
+        self._set(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_UNDO_LEVELS, levels)
 
     def get_start_capitalized(self):
         return self._get_bool(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_START_CAPITALIZED,

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -45,6 +45,7 @@ SPACE_PLACEMENTS_LABEL = "Space Placement:"
 SPACE_PLACEMENT_BEFORE = "Before Output"
 SPACE_PLACEMENT_AFTER = "After Output"
 SPACE_PLACEMENTS = [SPACE_PLACEMENT_BEFORE, SPACE_PLACEMENT_AFTER]
+UNDO_LEVELS_LABEL = "Stroke Undo Limit:"
 FIRST_STROKE_LABEL = "First Stroke:"
 START_CAPITALIZED_LABEL = "Start Capitalized"
 START_ATTACHED_LABEL = "Suppress Space"
@@ -625,36 +626,63 @@ class OutputConfig(wx.Panel):
         """
         wx.Panel.__init__(self, parent)
         self.config = config
-        sizer = wx.BoxSizer(wx.VERTICAL)
+        gap = COMPONENT_SPACE * 3
+        sizer = wx.GridBagSizer(gap, gap)
 
-        box = wx.BoxSizer(wx.HORIZONTAL)
-        box.Add(wx.StaticText(self, label=SPACE_PLACEMENTS_LABEL),
-                border=COMPONENT_SPACE,
-                flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.RIGHT)
+        # Space Placement Dropdown
+        sizer.Add(wx.StaticText(self, label=SPACE_PLACEMENTS_LABEL),
+                  pos=(0, 0),
+                  flag=wx.ALIGN_CENTER_VERTICAL)
         self.space_placement_choice = wx.Choice(self, choices=SPACE_PLACEMENTS)
         self.space_placement_choice.SetStringSelection(
             self.config.get_space_placement())
-        box.Add(self.space_placement_choice, proportion=1, flag=wx.EXPAND)
-        sizer.Add(box, border=UI_BORDER, flag=wx.ALL | wx.EXPAND)
+        sizer.Add(self.space_placement_choice,
+                  flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL,
+                  pos=(0, 1))
 
-        first_stroke_label = wx.StaticText(self, label=FIRST_STROKE_LABEL)
-        self.start_attached = wx.CheckBox(self, label=START_ATTACHED_LABEL)
+        # Undo Levels Spin Control
+        sizer.Add(wx.StaticText(self, label=UNDO_LEVELS_LABEL),
+                  pos=(1, 0),
+                  flag=wx.ALIGN_CENTER_VERTICAL)
+        buffer_selector = wx.SpinCtrl(self)
+        buffer_selector.SetRange(conf.MINIMUM_OUTPUT_CONFIG_UNDO_LEVELS,
+                                 100000)
+        buffer_selector.SetValue(config.get_undo_levels())
+        sizer.Add(buffer_selector,
+                  pos=(1, 1),
+                  flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+
+        self.start_attached = wx.CheckBox(self,
+                                          label=START_ATTACHED_LABEL)
         self.start_attached.SetValue(self.config.get_start_attached())
         self.start_capitalized = wx.CheckBox(
-            self, label=START_CAPITALIZED_LABEL)
+            self, label=START_CAPITALIZED_LABEL
+        )
         self.start_capitalized.SetValue(self.config.get_start_capitalized())
 
-        sizer.AddF(first_stroke_label,
-                   wx.SizerFlags().Border(wx.ALL, UI_BORDER))
-        checkbox_flags = wx.SizerFlags().Border(wx.LEFT, COMPONENT_SPACE * 6)
-        sizer.AddF(self.start_capitalized, checkbox_flags)
-        sizer.AddF(self.start_attached, checkbox_flags)
+        sizer.Add(wx.StaticText(self, label=FIRST_STROKE_LABEL),
+                  pos=(2, 0))
 
-        self.SetSizer(sizer)
+        starting_options = wx.BoxSizer(wx.VERTICAL)
+        starting_options.Add(self.start_attached)
+        starting_options.Add(self.start_capitalized)
+        sizer.Add(starting_options,
+                  pos=(2, 1),
+                  span=(1, 2),
+                  flag=wx.ALIGN_CENTER_VERTICAL)
+
+        self.buffer_selector = buffer_selector
+
+        border = wx.BoxSizer(wx.HORIZONTAL)
+        border.AddF(sizer, wx.SizerFlags().Border(wx.ALL, UI_BORDER))
+
+        self.SetSizer(border)
 
     def save(self):
         """Write all parameters to the config."""
         self.config.set_space_placement(
-            self.space_placement_choice.GetStringSelection())
+            self.space_placement_choice.GetStringSelection()
+        )
         self.config.set_start_attached(self.start_attached.GetValue())
         self.config.set_start_capitalized(self.start_capitalized.GetValue())
+        self.config.set_undo_levels(self.buffer_selector.GetValue())

--- a/plover/gui/suggestions.py
+++ b/plover/gui/suggestions.py
@@ -16,7 +16,6 @@ ON_TOP_TEXT = "Always on top"
 UI_BORDER = 4
 LAST_WORD_TEXT = 'Last Word: %s'
 DEFAULT_LAST_WORD = 'N/A'
-HISTORY_SIZE = 10
 MAX_DISPLAY_LINES = 20
 STROKE_INDENT = 2
 
@@ -161,7 +160,8 @@ class SuggestionsDisplayDialog(wx.Dialog):
     def show_suggestions(self, suggestion_list):
 
         # Limit history.
-        if len(self.history) == HISTORY_SIZE:
+        undo_levels = self.config.get_undo_levels()
+        while len(self.history) >= undo_levels:
             _, text_length = self.history.pop(0)
             last_position = self.listbox.GetLastPosition()
             self.listbox.Remove(last_position - text_length, last_position)


### PR DESCRIPTION
Add buffer configuration, default 100. UI arbitrarily maxes out at 100,000, minimum is set to 1.

Fix #300 

<img width="598" alt="screen shot 2016-02-29 at 4 41 32 pm" src="https://cloud.githubusercontent.com/assets/5840970/13409997/76fa1910-df03-11e5-9465-bd441a116ca3.png">