### PR TITLE
translation: fix undo strokes on empty state

### DIFF
--- a/plover/test_translation.py
+++ b/plover/test_translation.py
@@ -535,7 +535,7 @@ class TranslateStrokeTestCase(unittest.TestCase):
 
     def test_empty_undo(self):
         self.translate(stroke('*'))
-        self.assertEquals(self.s.translations[0].english, _back_string())
+        self.assertTranslations([])
         self.assertOutput([], [Translation([Stroke('*')], _back_string())], None)
 
     def test_undo_translation(self):
@@ -558,7 +558,7 @@ class TranslateStrokeTestCase(unittest.TestCase):
     def test_undo_tail(self):
         self.s.tail = self.t('T/A/I/L')
         self.translate(stroke('*'))
-        self.assertEquals(self.s.translations[0].english, _back_string())
+        self.assertTranslations([])
         self.assertOutput([], [Translation([Stroke('*')], _back_string())], self.t('T/A/I/L'))
         
     def test_suffix_folding(self):

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -209,6 +209,7 @@ class Translator(object):
 
         undo = []
         do = []
+        add_to_history = True
 
         # TODO: Test the behavior of undoing until a translation is undoable.
         if stroke.is_correction:
@@ -223,8 +224,9 @@ class Translator(object):
                 do.extend(t.replaced)
             if empty:
                 # There is no more buffer to delete from -- remove undo and add a
-                # stroke that removes last word on the user's OS
-                undo = []
+                # stroke that removes last word on the user's OS, but don't add it
+                # to the state history.
+                add_to_history = False
                 do = [Translation([stroke], _back_string())]
         else:
             # Figure out how much of the translation buffer can be involved in this
@@ -261,7 +263,8 @@ class Translator(object):
                 undo.extend(t.replaced)
         del self._state.translations[len(self._state.translations) - len(undo):]
         self._output(undo, do, self._state.last())
-        self._state.translations.extend(do)
+        if add_to_history:
+            self._state.translations.extend(do)
 
     def _find_translation(self, translations, stroke, mapping):
 


### PR DESCRIPTION
Don't add those strokes to the state history (since undo strokes are not supposed to be undo-able).