### PR TITLE
Update contributors in about dialog

### DIFF
--- a/plover/__init__.py
+++ b/plover/__init__.py
@@ -7,11 +7,16 @@ __version__ = '2.5.8'
 __copyright__ = '(C) Open Steno Project'
 __url__ = 'http://www.openstenoproject.org/'
 __download_url__ = 'http://www.openstenoproject.org/plover'
-__credits__ = ['Stenographer: Mirabai Knight',
-               'Coder: Joshua Harlan Lifton',
-               'Contributors: Hesky Fisher']
+__credits__ = ['Founded by stenographer Mirabai Knight.\n\nDevelopers:'
+               '\nJoshua Lifton',
+               'Hesky Fisher',
+               'Ted Morin',
+               'Benoit Pierre',
+               '\nand many more on GitHub: \n<https://github.com/openstenoproject/plover>'
+               ]
 __license__ = 'GNU General Public License, version 2'
 __description__ = 'Open Source Stenography Software',
-__long_description__ = """Plover is a free open source program intended to
-bring realtime stenographic technology not just to stenographers, but also to
+__long_description__ = """\
+Plover is a free open source program intended to bring realtime
+stenographic technology not just to stenographers, but also to
 hackers, hobbyists, accessibility mavens, and all-around speed demons."""


### PR DESCRIPTION
### About

Update contributors dialog with a link to GitHub to reflect the many developers that we are lucky to have. Also reword to better highlight @stenoknight as the founder of the project.

- Include a non-clickable link to the GitHub repo
- Reformat to ensure that the about window doesn't resize when expanding and collapsing sections.

<img width="564" alt="screen shot 2016-02-21 at 1 11 25 am" src="https://cloud.githubusercontent.com/assets/5840970/13201294/3369fc0a-d838-11e5-806b-ac50fec7f8b6.png">

### Issues

Fixes #372

### Tested Platforms

Only tested OS X, I believe this window type is supposed to be cross platform (GTK-style about dialog)