### PR TITLE
Fix xkeyboardcontrol send_key_combination

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1263,12 +1263,13 @@ class KeyboardEmulation(object):
             else:
                 current_command.append(c)
         # Record final command key.
-        keystring = ''.join(current_command)
-        keysym = XK.string_to_keysym(keystring)
-        mapping = self._get_mapping(keysym)
-        if mapping is not None:
-            keycode_events.append((mapping.keycode, X.KeyPress))
-            keycode_events.append((mapping.keycode, X.KeyRelease))
+        if current_command:
+            keystring = ''.join(current_command)
+            keysym = XK.string_to_keysym(keystring)
+            mapping = self._get_mapping(keysym)
+            if mapping is not None:
+                keycode_events.append((mapping.keycode, X.KeyPress))
+                keycode_events.append((mapping.keycode, X.KeyRelease))
         # Release all keys.
         for keycode in key_down_stack:
             keycode_events.append((keycode, X.KeyRelease))

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1152,7 +1152,10 @@ class KeyboardEmulation(object):
                     modifiers |= X.Mod5Mask
                 mapping = self.Mapping(keycode, modifiers, keysym, custom_mapping)
                 if keysym != X.NoSymbol:
-                    self.keymap[keysym] = mapping
+                    # Some keysym are mapped multiple times, prefer lower modifiers combos.
+                    previous_mapping = self.keymap.get(keysym)
+                    if previous_mapping is None or mapping.modifiers < previous_mapping.modifiers:
+                        self.keymap[keysym] = mapping
                 if custom_mapping is not None:
                     self.custom_mappings_queue.append(mapping)
             keycode += 1


### PR DESCRIPTION
Fix #387:  in this instance`Super_L` is also mapped to a higher keycode with a modifier, and this end-up as the default mapping in our keymap. The problem is `send_key_combinations` expect mappings with no modifiers, and ignore them.

The solution is to prefer lower modifiers combos when building the mapping table.