### PR TITLE
Fix #391 - Remove artifacts from Windows config dialog

### DIFF
--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -133,6 +133,7 @@ class ConfigurationDialog(wx.Dialog):
         sizer.Add(button_sizer, flag=wx.ALL | wx.ALIGN_RIGHT, border=UI_BORDER)
 
         self.SetSizerAndFit(sizer)
+        self.Layout()
         self.SetRect(AdjustRectToScreen(self.GetRect()))
 
         # Binding the save button to the self._save callback


### PR DESCRIPTION
### About

Call "Layout()" to prevent artifacts. Seems like an innocent regression while refactoring.

### Issues

Fixes #391

### Tested Platforms

Windows 10 and OS X El Capitan tested, @benoit-pierre if you could verify that this didn't regress your Linux, then please merge
