### PR TITLE
More robust init

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -62,16 +62,16 @@ def update_engine(engine, old, new, reset_machine=False):
         old = NoneConfig()
 
     machine_type = new.get_machine_type()
-    machine_mappings = new.get_system_keymap(machine_type)
-    machine_options = new.get_machine_specific_options(machine_type)
+    try:
+        machine_mappings = new.get_system_keymap(machine_type)
+        machine_options = new.get_machine_specific_options(machine_type)
+    except NoSuchMachineException as e:
+        raise InvalidConfigurationError(unicode(e))
     if (reset_machine or
             old.get_machine_type() != machine_type or
             old.get_system_keymap(machine_type) != machine_mappings or
             old.get_machine_specific_options(machine_type) != machine_options):
-        try:
-            machine_class = machine_registry.get(machine_type)
-        except NoSuchMachineException as e:
-            raise InvalidConfigurationError(unicode(e))
+        machine_class = machine_registry.get(machine_type)
         machine = machine_class(machine_options)
         if machine_mappings is None:
             log.warning('no mappings defined for %s, the machine won\'t be usable', machine_type)

--- a/plover/app.py
+++ b/plover/app.py
@@ -40,8 +40,8 @@ class SimpleNamespace(object):
 
 def init_engine(engine, config):
     """Initialize a StenoEngine from a config object."""
-    update_engine(engine, config)
     engine.set_is_running(config.get_auto_start())
+    update_engine(engine, config)
 
 def reset_machine(engine, config):
     """Set the machine on the engine based on config."""

--- a/plover/app.py
+++ b/plover/app.py
@@ -40,75 +40,50 @@ class SimpleNamespace(object):
 
 def init_engine(engine, config):
     """Initialize a StenoEngine from a config object."""
-    update_engine(engine, None, config)
+    update_engine(engine, config)
     engine.set_is_running(config.get_auto_start())
 
 def reset_machine(engine, config):
     """Set the machine on the engine based on config."""
-    update_engine(engine, config, config, reset_machine=True)
+    update_engine(engine, config, reset_machine=True)
 
-def update_engine(engine, old, new, reset_machine=False):
+def update_engine(engine, config, reset_machine=False):
     """Modify a StenoEngine using a before and after config object.
     
     Using the before and after allows this function to not make unnecessary 
     changes.
     """
-    if old is None:
-        # Fake config that will return None for each
-        # option, hence triggering an update.
-        class NoneConfig(object):
-            def __getattr__(self, name):
-                return lambda *args: None
-        old = NoneConfig()
+    if reset_machine:
+        engine.set_machine(None)
 
-    machine_type = new.get_machine_type()
+    machine_type = config.get_machine_type()
     try:
-        machine_mappings = new.get_system_keymap(machine_type)
-        machine_options = new.get_machine_specific_options(machine_type)
+        machine_class = machine_registry.get(machine_type)
     except NoSuchMachineException as e:
         raise InvalidConfigurationError(unicode(e))
-    if (reset_machine or
-            old.get_machine_type() != machine_type or
-            old.get_system_keymap(machine_type) != machine_mappings or
-            old.get_machine_specific_options(machine_type) != machine_options):
-        machine_class = machine_registry.get(machine_type)
-        machine = machine_class(machine_options)
-        if machine_mappings is None:
-            log.warning('no mappings defined for %s, the machine won\'t be usable', machine_type)
-        else:
-            machine.set_mappings(machine_mappings)
-        engine.set_machine(machine)
+    machine_options = config.get_machine_specific_options(machine_type)
+    machine_mappings = config.get_system_keymap(machine_type)
+    engine.set_machine(machine_class, machine_options, machine_mappings)
 
-    dictionary_file_names = new.get_dictionary_file_names()
-    if old.get_dictionary_file_names() != dictionary_file_names:
-        try:
-            dicts = dict_manager.load(dictionary_file_names)
-        except DictionaryLoaderException as e:
-            raise InvalidConfigurationError(unicode(e))
-        engine.get_dictionary().set_dicts(dicts)
+    dictionary_file_names = config.get_dictionary_file_names()
+    engine.set_dictionaries(dictionary_file_names)
 
-    log_file_name = new.get_log_file_name()
-    if old.get_log_file_name() != log_file_name:
-        engine.set_log_file_name(new)
+    log_file_name = config.get_log_file_name()
+    engine.set_log_file_name(config)
 
-    enable_stroke_logging = new.get_enable_stroke_logging()
-    if old.get_enable_stroke_logging() != enable_stroke_logging:
-        engine.enable_stroke_logging(enable_stroke_logging)
+    enable_stroke_logging = config.get_enable_stroke_logging()
+    engine.enable_stroke_logging(enable_stroke_logging)
 
-    enable_translation_logging = new.get_enable_translation_logging()
-    if old.get_enable_translation_logging() != enable_translation_logging:
-        engine.enable_translation_logging(enable_translation_logging)
+    enable_translation_logging = config.get_enable_translation_logging()
+    engine.enable_translation_logging(enable_translation_logging)
 
-    space_placement = new.get_space_placement()
-    if old.get_space_placement() != space_placement:
-        engine.set_space_placement(space_placement)
+    space_placement = config.get_space_placement()
+    engine.set_space_placement(space_placement)
 
-    start_capitalized = new.get_start_capitalized()
-    start_attached = new.get_start_attached()
-    if (old.get_start_capitalized() != start_capitalized or
-            old.get_start_attached() != start_attached):
-        engine.set_starting_stroke_state(attach=start_attached,
-                                         capitalize=start_capitalized)
+    start_capitalized = config.get_start_capitalized()
+    start_attached = config.get_start_attached()
+    engine.set_starting_stroke_state(attach=start_attached,
+                                     capitalize=start_capitalized)
 
 def same_thread_hook(fn, *args):
     fn(*args)
@@ -150,6 +125,9 @@ class StenoEngine(object):
         self.stroke_listeners = []
         self.is_running = False
         self.machine = None
+        self.machine_class = None
+        self.machine_options = None
+        self.machine_mappings = None
         self.thread_hook = thread_hook
 
         self.translator = translation.Translator()
@@ -165,25 +143,45 @@ class StenoEngine(object):
         self.running_state = self.translator.get_state()
         self.set_is_running(False)
 
-    def set_machine(self, machine):
+    def set_machine(self, machine_class,
+                    machine_options=None,
+                    machine_mappings=None):
+        if (self.machine_class and machine_class and
+            self.machine_options and machine_options and
+            self.machine_mappings and machine_mappings):
+            return
+        self.machine_class = None
+        self.machine_options = None
+        self.machine_mappings = None
         if self.machine is not None:
             self.machine.remove_state_callback(self._machine_state_callback)
             self.machine.remove_stroke_callback(
                 self._translator_machine_callback)
             self.machine.remove_stroke_callback(log.stroke)
             self.machine.stop_capture()
-        self.machine = machine
-        if self.machine is not None:
+        self.machine = None
+        if machine_class is not None:
+            self.machine = machine_class(machine_options)
+            if machine_mappings is not None:
+                self.machine.set_mappings(machine_mappings)
             self.machine.add_state_callback(self._machine_state_callback)
             self.machine.add_stroke_callback(log.stroke)
             self.machine.add_stroke_callback(self._translator_machine_callback)
             self.machine.start_capture()
-            self.set_is_running(self.is_running)
+            self.machine_class = machine_class
+            self.machine_options = machine_options
+            self.machine_mappings = machine_mappings
+            is_running = self.is_running
         else:
-            self.set_is_running(False)
+            is_running = False
+        self.set_is_running(self.is_running)
 
-    def set_dictionary(self, d):
-        self.translator.set_dictionary(d)
+    def set_dictionaries(self, file_names):
+        dictionary = self.translator.get_dictionary()
+        if tuple(file_names) == tuple(d.get_path() for d in dictionary.dicts):
+            return
+        dicts = dict_manager.load(file_names)
+        dictionary.set_dicts(dicts)
 
     def get_dictionary(self):
         return self.translator.get_dictionary()

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -19,7 +19,6 @@ import plover.gui.dictionary_editor
 from plover import log
 from plover.app import update_engine
 from plover.machine.registry import machine_registry
-from plover.exception import InvalidConfigurationError
 from plover.dictionary.loading_manager import manager as dict_manager
 from plover.gui.paper_tape import StrokeDisplayDialog
 from plover.gui.suggestions import SuggestionsDisplayDialog
@@ -170,7 +169,7 @@ class ConfigurationDialog(wx.Dialog):
 
         try:
             update_engine(self.engine, old_config, self.config)
-        except InvalidConfigurationError:
+        except Exception:
             log.error('updating engine configuration failed', exc_info=True)
             return
 
@@ -259,7 +258,11 @@ class MachineConfig(wx.Panel):
     def _update(self, event=None):
         # Refreshes the UI to reflect current data.
         machine_name = self.choice.GetStringSelection()
-        options = self.config.get_machine_specific_options(machine_name)
+        try:
+            options = self.config.get_machine_specific_options(machine_name)
+        except Exception:
+            log.error('could not get machine specific options', exc_info=True)
+            options = {}
         self.advanced_options = options
         self.config_button.Enable(bool(options))
 

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -159,7 +159,6 @@ class ConfigurationDialog(wx.Dialog):
         event.Skip()
 
     def _save(self, event):
-        old_config = self.config.clone()
 
         self.machine_config.save()
         self.dictionary_config.save()
@@ -168,7 +167,7 @@ class ConfigurationDialog(wx.Dialog):
         self.output_config.save()
 
         try:
-            update_engine(self.engine, old_config, self.config)
+            update_engine(self.engine, self.config)
         except Exception:
             log.error('updating engine configuration failed', exc_info=True)
             return

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -170,13 +170,8 @@ class ConfigurationDialog(wx.Dialog):
 
         try:
             update_engine(self.engine, old_config, self.config)
-        except InvalidConfigurationError as e:
-            alert_dialog = wx.MessageDialog(self,
-                                            unicode(e),
-                                            "Configuration error",
-                                            wx.OK | wx.ICON_INFORMATION)
-            alert_dialog.ShowModal()
-            alert_dialog.Destroy()
+        except InvalidConfigurationError:
+            log.error('updating engine configuration failed', exc_info=True)
             return
 
         with open(self.config.target_file, 'wb') as f:

--- a/plover/gui/log_dbus.py
+++ b/plover/gui/log_dbus.py
@@ -7,14 +7,13 @@ import logging
 pynotify.init(__software_name__.capitalize())
 
 
-
 class DbusNotificationHandler(logging.Handler):
     """ Handler using DBus notifications to show messages. """
 
     def __init__(self):
         super(DbusNotificationHandler, self).__init__()
         self.setLevel(log.WARNING)
-        self.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
 
     def emit(self, record):
         level = record.levelno

--- a/plover/gui/log_osx.py
+++ b/plover/gui/log_osx.py
@@ -13,7 +13,7 @@ class OSXNotificationHandler(logging.Handler):
     def __init__(self):
         super(OSXNotificationHandler, self).__init__()
         self.setLevel(log.WARNING)
-        self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
+        self.setFormatter(log.NoExceptionTracebackFormatter('%(message)s'))
 
     def emit(self, record):
         # Notification Center has no levels or timeouts.
@@ -21,7 +21,7 @@ class OSXNotificationHandler(logging.Handler):
 
         notification.setTitle_(__software_name__.capitalize())
         notification.setSubtitle_(record.levelname.title())
-        notification.setInformativeText_(record.message)
+        notification.setInformativeText_(self.format(record))
 
         ns = NSUserNotificationCenter.defaultUserNotificationCenter()
         ns.setDelegate_(always_present_delegator)

--- a/plover/gui/log_osx.py
+++ b/plover/gui/log_osx.py
@@ -13,7 +13,7 @@ class OSXNotificationHandler(logging.Handler):
     def __init__(self):
         super(OSXNotificationHandler, self).__init__()
         self.setLevel(log.WARNING)
-        self.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
 
     def emit(self, record):
         # Notification Center has no levels or timeouts.

--- a/plover/gui/log_wx.py
+++ b/plover/gui/log_wx.py
@@ -23,7 +23,7 @@ class WxNotificationHandler(logging.Handler):
     def __init__(self):
         super(WxNotificationHandler, self).__init__()
         self.setLevel(log.WARNING)
-        self.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
 
     def emit(self, record):
         level = record.levelno

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -25,6 +25,7 @@ from plover.machine.registry import machine_registry
 from plover.exception import InvalidConfigurationError
 from plover.gui.paper_tape import StrokeDisplayDialog
 from plover.gui.suggestions import SuggestionsDisplayDialog
+from plover import log
 
 from plover import __name__ as __software_name__
 from plover import __version__
@@ -208,8 +209,8 @@ class MainFrame(wx.Frame):
         try:
             with open(config.target_file, 'rb') as f:
                 self.config.load(f)
-        except InvalidConfigurationError as e:
-            self._show_alert(unicode(e))
+        except InvalidConfigurationError:
+            log.error('loading configuration failed, reseting to default', exc_info=True)
             self.config.clear()
 
         rect = wx.Rect(config.get_main_frame_x(), config.get_main_frame_y(), *self.GetSize())
@@ -226,7 +227,7 @@ class MainFrame(wx.Frame):
                 app.init_engine(self.steno_engine, self.config)
                 break
             except InvalidConfigurationError as e:
-                self._show_alert(unicode(e))
+                log.error('engine initialization failed', exc_info=True)
                 dlg = ConfigurationDialog(self.steno_engine,
                                           self.config,
                                           parent=self)
@@ -234,7 +235,7 @@ class MainFrame(wx.Frame):
                 if ret == wx.ID_CANCEL:
                     self._quit()
                     return
-                    
+
         self.steno_engine.add_stroke_listener(
             StrokeDisplayDialog.stroke_handler)
         if self.config.get_show_stroke_display():
@@ -351,14 +352,6 @@ class MainFrame(wx.Frame):
         info.Developers = __credits__
         info.License = __license__
         wx.AboutBox(info)
-
-    def _show_alert(self, message):
-        alert_dialog = wx.MessageDialog(self,
-                                        message,
-                                        self.ALERT_DIALOG_TITLE,
-                                        wx.OK | wx.ICON_INFORMATION)
-        alert_dialog.ShowModal()
-        alert_dialog.Destroy()
 
     def on_move(self, event):
         pos = self.GetScreenPositionTuple()

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -221,20 +221,6 @@ class MainFrame(wx.Frame):
         self.steno_engine.set_output(
             Output(self.consume_command, self.steno_engine))
 
-        while True:
-            try:
-                app.init_engine(self.steno_engine, self.config)
-                break
-            except Exception:
-                log.error('engine initialization failed', exc_info=True)
-                dlg = ConfigurationDialog(self.steno_engine,
-                                          self.config,
-                                          parent=self)
-                ret = dlg.ShowModal()
-                if ret == wx.ID_CANCEL:
-                    self._quit()
-                    return
-
         self.steno_engine.add_stroke_listener(
             StrokeDisplayDialog.stroke_handler)
         if self.config.get_show_stroke_display():
@@ -244,6 +230,12 @@ class MainFrame(wx.Frame):
             SuggestionsDisplayDialog.stroke_handler)
         if self.config.get_show_suggestions_display():
             SuggestionsDisplayDialog.display(self, self.config, self.steno_engine)
+
+        try:
+            app.init_engine(self.steno_engine, self.config)
+        except Exception:
+            log.error('engine initialization failed', exc_info=True)
+            self._show_config_dialog()
 
     def consume_command(self, command):
         # The first commands can be used whether plover has output enabled or not.

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -58,9 +58,6 @@ class PloverGUI(wx.App):
         return True
 
 
-def gui_thread_hook(fn, *args):
-    wx.CallAfter(fn, *args)
-
 class MainFrame(wx.Frame):
     """The top-level GUI element of the Plover application."""
 

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -22,7 +22,6 @@ import plover.gui.lookup
 from plover.oslayer.keyboardcontrol import KeyboardEmulation
 from plover.machine.base import STATE_ERROR, STATE_INITIALIZING, STATE_RUNNING
 from plover.machine.registry import machine_registry
-from plover.exception import InvalidConfigurationError
 from plover.gui.paper_tape import StrokeDisplayDialog
 from plover.gui.suggestions import SuggestionsDisplayDialog
 from plover import log
@@ -209,7 +208,7 @@ class MainFrame(wx.Frame):
         try:
             with open(config.target_file, 'rb') as f:
                 self.config.load(f)
-        except InvalidConfigurationError:
+        except Exception:
             log.error('loading configuration failed, reseting to default', exc_info=True)
             self.config.clear()
 
@@ -226,7 +225,7 @@ class MainFrame(wx.Frame):
             try:
                 app.init_engine(self.steno_engine, self.config)
                 break
-            except InvalidConfigurationError as e:
+            except Exception:
                 log.error('engine initialization failed', exc_info=True)
                 dlg = ConfigurationDialog(self.steno_engine,
                                           self.config,

--- a/plover/log.py
+++ b/plover/log.py
@@ -6,9 +6,13 @@
 import os
 import sys
 import logging
+import traceback
+
 from logging.handlers import RotatingFileHandler
 from logging import DEBUG, INFO, WARNING, ERROR
+
 from plover.oslayer.config import CONFIG_DIR
+
 
 LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
 LOG_FILENAME = os.path.join(CONFIG_DIR, 'plover.log')
@@ -16,6 +20,26 @@ LOG_MAX_BYTES = 10000000
 LOG_COUNT = 9
 
 STROKE_LOG_FORMAT = '%(asctime)s %(message)s'
+
+
+class NoExceptionTracebackFormatter(logging.Formatter):
+    """Custom formatter for formatting exceptions without traceback."""
+
+    def format(self, record):
+        # Calls to formatException are cached.
+        # (see http://bugs.python.org/issue1295)
+        orig_exc_text = record.exc_text
+        record.exc_text = None
+        try:
+            return super(NoExceptionTracebackFormatter, self).format(record)
+        finally:
+            record.exc_text = orig_exc_text
+
+    def formatException(self, exc_info):
+        etype, evalue, tb = exc_info
+        lines = traceback.format_exception_only(etype, evalue)
+        return u''.join(lines)
+
 
 class FileHandler(RotatingFileHandler):
 

--- a/plover/log.py
+++ b/plover/log.py
@@ -15,7 +15,7 @@ from plover.oslayer.config import CONFIG_DIR
 
 
 LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
-LOG_FILENAME = os.path.join(CONFIG_DIR, 'plover.log')
+LOG_FILENAME = os.path.realpath(os.path.join(CONFIG_DIR, 'plover.log'))
 LOG_MAX_BYTES = 10000000
 LOG_COUNT = 9
 
@@ -66,6 +66,7 @@ class Logger(object):
         self._logger = logging.getLogger('plover')
         self._logger.addHandler(self._print_handler)
         self._logger.setLevel(INFO)
+        self._stroke_filename = None
         self._stroke_logger = logging.getLogger('plover-strokes')
         self._stroke_logger.setLevel(INFO)
         self._stroke_handler = None
@@ -78,17 +79,20 @@ class Logger(object):
         self._logger.addHandler(self._file_handler)
 
     def set_stroke_filename(self, filename=None):
+        if filename is not None:
+            filename = os.path.realpath(filename)
+        if self._stroke_filename == filename:
+            return
         self.info('set_stroke_filename(%s)', filename)
         if self._stroke_handler is not None:
             self._stroke_logger.removeHandler(self._stroke_handler)
             self._stroke_handler = None
-        if filename is None:
-            return
-        assert filename != LOG_FILENAME
-        filename = os.path.abspath(filename)
-        self._stroke_handler = FileHandler(filename=filename,
-                                           format=STROKE_LOG_FORMAT)
-        self._stroke_logger.addHandler(self._stroke_handler)
+        if filename is not None:
+            assert filename != LOG_FILENAME
+            self._stroke_handler = FileHandler(filename=filename,
+                                               format=STROKE_LOG_FORMAT)
+            self._stroke_logger.addHandler(self._stroke_handler)
+        self._stroke_filename = filename
 
     def enable_stroke_logging(self, b):
         self.info('enable_stroke_logging(%s)', b)

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -27,9 +27,7 @@ class Stenotype(StenotypeBase):
         self._bindings = {}
         self._down_keys = set()
         self._released_keys = set()
-        self._keyboard_capture = KeyboardCapture()
-        self._keyboard_capture.key_down = self._key_down
-        self._keyboard_capture.key_up = self._key_up
+        self._keyboard_capture = None
         self._last_stroke_key_down_count = 0
         self._update_bindings()
 
@@ -52,12 +50,24 @@ class Stenotype(StenotypeBase):
 
     def start_capture(self):
         """Begin listening for output from the stenotype machine."""
-        self._keyboard_capture.start()
+        self._released_keys.clear()
+        self._last_stroke_key_down_count = 0
+        self._initializing()
+        try:
+            self._keyboard_capture = KeyboardCapture()
+            self._keyboard_capture.key_down = self._key_down
+            self._keyboard_capture.key_up = self._key_up
+            self._keyboard_capture.start()
+        except:
+            self._error()
+            raise
         self._ready()
 
     def stop_capture(self):
         """Stop listening for output from the stenotype machine."""
-        self._keyboard_capture.cancel()
+        if self._keyboard_capture is not None:
+            self._keyboard_capture.cancel()
+            self._keyboard_capture = None
         self._stopped()
 
     def set_suppression(self, enabled):


### PR DESCRIPTION
Fix #273.

* use blanket except clauses so Plover does not crash if something goes wrong during the init.
* use the logger for reporting exceptions.
* use a custom formatter for GUI log handlers: don't show traceback on exception, since the messages are usually limited in length, and the information is not really useful to most users (the full traceback is still logged to the console and the logfile).
