### PR TITLE
Add preliminary system support

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -10,6 +10,7 @@ from cStringIO import StringIO
 from plover.exception import InvalidConfigurationError
 from plover.machine.registry import machine_registry
 from plover.oslayer.config import ASSETS_DIR, CONFIG_DIR
+from plover import system
 
 SPINNER_FILE = os.path.join(ASSETS_DIR, 'spinner.gif')
 
@@ -115,6 +116,10 @@ KEYBOARD_CONFIG_FRAME_X_OPTION = 'x'
 DEFAULT_KEYBOARD_CONFIG_FRAME_X = -1
 KEYBOARD_CONFIG_FRAME_Y_OPTION = 'y'
 DEFAULT_KEYBOARD_CONFIG_FRAME_Y = -1
+
+DEFAULT_SYSTEM = 'English Stenotype'
+SYSTEM_CONFIG_SECTION = 'System: %s'
+SYSTEM_KEYMAP_OPTION = 'keymap[%s]'
 
 # Dictionary constants.
 JSON_EXTENSION = '.json'
@@ -506,6 +511,16 @@ class Config(object):
         return self._get_int(KEYBOARD_CONFIG_FRAME_SECTION, 
                              KEYBOARD_CONFIG_FRAME_Y_OPTION,
                              DEFAULT_KEYBOARD_CONFIG_FRAME_Y)
+
+    def set_system_keymap(self, machine_type, mappings):
+        section = SYSTEM_CONFIG_SECTION % DEFAULT_SYSTEM
+        option = SYSTEM_KEYMAP_OPTION % machine_type
+        self._set(section, option, mappings)
+
+    def get_system_keymap(self, machine_type):
+        section = SYSTEM_CONFIG_SECTION % DEFAULT_SYSTEM
+        option = SYSTEM_KEYMAP_OPTION % machine_type
+        return self._get(section, option, system.KEYMAPS.get(machine_type))
 
     def _set(self, section, option, value):
         if not self._config.has_section(section):

--- a/plover/gui/keyboard_config.py
+++ b/plover/gui/keyboard_config.py
@@ -24,7 +24,7 @@ class EditKeysDialog(wx.Dialog):
     def __init__(self, parent, action, keys):
         super(EditKeysDialog, self).__init__(parent)
         self.sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer_flags = wx.SizerFlags().Border(wx.ALL, UI_BORDER).Align(wx.ALIGN_CENTER_HORIZONTAL)
+        sizer_flags = wx.SizerFlags().Border(wx.ALL, UI_BORDER).Center()
         instructions = wx.StaticText(self, label='Press on the key you want to add/remove.')
         self.sizer.AddF(instructions, sizer_flags)
         self.message = wx.StaticText(self)
@@ -86,11 +86,11 @@ class EditKeymapWidget(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
                              id=wx.ID_ANY,
                              pos=wx.DefaultPosition,
                              size=(300, 200),
-                             style=wx.LC_REPORT)
+                             style=wx.LC_REPORT|wx.LC_HRULES|wx.LC_VRULES)
         listmix.ListCtrlAutoWidthMixin.__init__(self)
         self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.edit_item)
-        self.InsertColumn(0, 'Steno Keys / Actions')
-        self.InsertColumn(1, 'Keys')
+        self.InsertColumn(0, 'Steno Keys / Actions', width=wx.LIST_AUTOSIZE_USEHEADER)
+        self.InsertColumn(1, 'Keys', width=wx.LIST_AUTOSIZE_USEHEADER)
 
     def edit_item(self, event):
         # Disallow editing of first column.
@@ -137,13 +137,13 @@ class KeyboardConfigDialog(wx.Dialog):
         wx.Dialog.__init__(self, parent, title=DIALOG_TITLE, pos=pos)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer_flags = wx.SizerFlags().Border(wx.ALL, UI_BORDER).Align(wx.ALIGN_CENTER_HORIZONTAL)
 
         instructions = wx.StaticText(self, label=ARPEGGIATE_INSTRUCTIONS)
-        sizer.Add(instructions, border=UI_BORDER, flag=wx.ALL)
+        sizer.AddF(instructions, sizer_flags.Align(wx.LEFT))
         self.arpeggiate_option = wx.CheckBox(self, label=ARPEGGIATE_LABEL)
         self.arpeggiate_option.SetValue(options.arpeggiate)
-        sizer.Add(self.arpeggiate_option, border=UI_BORDER, 
-                  flag=wx.LEFT | wx.RIGHT | wx.BOTTOM)
+        sizer.AddF(self.arpeggiate_option, sizer_flags)
 
         # editable list for keymap bindings
         self.keymap = Keymap(KeyboardMachine.KEYS_LAYOUT.split(), KeyboardMachine.ACTIONS)
@@ -152,7 +152,7 @@ class KeyboardConfigDialog(wx.Dialog):
             self.keymap.set_mappings(mappings)
         self.keymap_widget = EditKeymapWidget(self)
         self.keymap_widget.set_mappings(self.keymap.get_mappings())
-        sizer.Add(self.keymap_widget, flag=wx.EXPAND)
+        sizer.AddF(self.keymap_widget, sizer_flags.Expand())
 
         ok_button = wx.Button(self, id=wx.ID_OK)
         ok_button.SetDefault()
@@ -160,15 +160,14 @@ class KeyboardConfigDialog(wx.Dialog):
         reset_button = wx.Button(self, id=wx.ID_RESET, label='Reset to default')
 
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        button_sizer.Add(ok_button, border=UI_BORDER, flag=wx.ALL)
-        button_sizer.Add(cancel_button, border=UI_BORDER, flag=wx.ALL)
-        button_sizer.Add(reset_button, border=UI_BORDER, flag=wx.ALL)
-        sizer.Add(button_sizer, flag=wx.ALL | wx.ALIGN_RIGHT, border=UI_BORDER)
-                  
-        self.SetSizer(sizer)
-        sizer.Fit(self)
+        button_sizer.AddF(ok_button, sizer_flags)
+        button_sizer.AddF(cancel_button, sizer_flags)
+        button_sizer.AddF(reset_button, sizer_flags)
+        sizer.AddF(button_sizer, sizer_flags)
+
+        self.SetSizerAndFit(sizer)
         self.SetRect(AdjustRectToScreen(self.GetRect()))
-        
+
         self.Bind(wx.EVT_MOVE, self.on_move)
         ok_button.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_OK))
         cancel_button.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_CANCEL))

--- a/plover/gui/keyboard_config.py
+++ b/plover/gui/keyboard_config.py
@@ -18,14 +18,17 @@ class EditKeysDialog(wx.Dialog):
     def __init__(self, parent, action, keys):
         super(EditKeysDialog, self).__init__(parent)
         self.sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer_flags = wx.SizerFlags().Border(wx.ALL, UI_BORDER).Align(wx.ALIGN_CENTER_HORIZONTAL)
         instructions = wx.StaticText(self, label='Press on the key you want to add/remove.')
-        self.sizer.Add(instructions, border=UI_BORDER, flag=wx.ALL|wx.ALIGN_CENTER_HORIZONTAL)
+        self.sizer.AddF(instructions, sizer_flags)
         self.message = wx.StaticText(self)
-        self.sizer.Add(self.message, border=UI_BORDER, flag=wx.ALL|wx.ALIGN_CENTER_HORIZONTAL)
+        self.sizer.AddF(self.message, sizer_flags)
         buttons = self.CreateButtonSizer(wx.OK|wx.CANCEL)
-        self.sizer.Add(buttons, border=UI_BORDER, flag=wx.ALL|wx.ALIGN_CENTER_HORIZONTAL)
-        self.SetSizer(self.sizer)
-        self.sizer.Fit(self)
+        clear_button = wx.Button(self, id=wx.ID_CLEAR)
+        clear_button.Bind(wx.EVT_BUTTON, self.on_clear)
+        buttons.InsertF(0, clear_button, sizer_flags.Left())
+        self.sizer.AddF(buttons, sizer_flags.Expand())
+        self.SetSizerAndFit(self.sizer)
         self.action = action
         self.keys = set(keys)
         self.original_keys = self.keys.copy()
@@ -58,6 +61,10 @@ class EditKeysDialog(wx.Dialog):
         self.message.SetLabelText(message)
         self.sizer.Fit(self)
         self.sizer.Layout()
+
+    def on_clear(self, event):
+        self.keys.clear()
+        self.update_message()
 
     def on_capture_key(self, key):
         if key in self.keys:

--- a/plover/gui/paper_tape.py
+++ b/plover/gui/paper_tape.py
@@ -6,15 +6,12 @@
 import wx
 from wx.lib.utils import AdjustRectToScreen
 from collections import deque
-from plover.steno import STENO_KEY_ORDER, STENO_KEY_NUMBERS
+from plover import system
 from plover.gui.util import find_fixed_width_font
 
 TITLE = 'Plover: Stroke Display'
 ON_TOP_TEXT = "Always on top"
 UI_BORDER = 4
-ALL_KEYS = ''.join(x[0].strip('-') for x in 
-                   sorted(STENO_KEY_ORDER.items(), key=lambda x: x[1]))
-REVERSE_NUMBERS = {v: k for k, v in STENO_KEY_NUMBERS.items()}
 MAX_STROKE_LINES = 30
 STYLE_TEXT = 'Style:'
 STYLE_PAPER = 'Paper'
@@ -55,11 +52,16 @@ class StrokeDisplayDialog(wx.Dialog):
 
         fixed_font = find_fixed_width_font()
 
+        self.all_keys = ''.join(x[0].strip('-') for x in 
+                                sorted(system.KEY_ORDER.items(),
+                                       key=lambda x: x[1]))
+        self.reverse_numbers = {v: k for k, v in system.NUMBERS.items()}
+
         # Calculate required width and height.
         dc = wx.ScreenDC()
         dc.SetFont(fixed_font)
         # Extra spaces for Max OS X...
-        text_width, text_height = dc.GetTextExtent(ALL_KEYS + 2 * ' ')
+        text_width, text_height = dc.GetTextExtent(self.all_keys + 2 * ' ')
         scroll_width = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
         scroll_height = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
 
@@ -128,7 +130,7 @@ class StrokeDisplayDialog(wx.Dialog):
         self.listbox.Clear()
         self.line_lengths = []
         if STYLE_PAPER == format:
-            self.header.SetLabel(ALL_KEYS)
+            self.header.SetLabel(self.all_keys)
         else:
             self.header.SetLabel('')
         for stroke in self.strokes:
@@ -136,15 +138,15 @@ class StrokeDisplayDialog(wx.Dialog):
         self.config.set_stroke_display_style(format)
 
     def paper_format(self, stroke):
-        text = [' '] * len(ALL_KEYS)
+        text = [' '] * len(self.all_keys)
         keys = stroke.steno_keys[:]
-        if any(key in REVERSE_NUMBERS for key in keys):
+        if any(key in self.reverse_numbers for key in keys):
             keys.append('#')
         for key in keys:
-            if key in REVERSE_NUMBERS:
-                key = REVERSE_NUMBERS[key]
-            index = STENO_KEY_ORDER[key]
-            text[index] = ALL_KEYS[index]
+            if key in self.reverse_numbers:
+                key = self.reverse_numbers[key]
+            index = system.KEY_ORDER[key]
+            text[index] = self.all_keys[index]
         text = ''.join(text)
         return text        
 
@@ -210,7 +212,7 @@ class TestApp(wx.App):
         #self.SetTopWindow(dlg)
         import random
         from plover.steno import Stroke
-        keys = STENO_KEY_ORDER.keys()
+        keys = system.KEY_ORDER.keys()
         for i in range(100):
             num = random.randint(1, len(keys))
             StrokeDisplayDialog.stroke_handler(Stroke(random.sample(keys, num)))

--- a/plover/gui/suggestions.py
+++ b/plover/gui/suggestions.py
@@ -8,7 +8,7 @@ import re
 from collections import namedtuple
 from wx.lib.utils import AdjustRectToScreen
 from plover.gui.util import find_fixed_width_font, shorten_unicode
-from plover.steno import STENO_KEY_ORDER
+from plover import system
 
 PAT = re.compile(r'[-\'"\w]+|[^\w\s]')
 TITLE = 'Plover: Suggestions Display'
@@ -19,7 +19,6 @@ DEFAULT_LAST_WORD = 'N/A'
 HISTORY_SIZE = 10
 MAX_DISPLAY_LINES = 20
 STROKE_INDENT = 2
-DISPLAY_WIDTH = len(STENO_KEY_ORDER) + 2 * STROKE_INDENT + 1 # extra +1 for /
 
 class SuggestionsDisplayDialog(wx.Dialog):
 
@@ -54,11 +53,12 @@ class SuggestionsDisplayDialog(wx.Dialog):
         fixed_font = find_fixed_width_font()
 
         # Calculate required width and height.
+        display_width = len(system.KEY_ORDER) + 2 * STROKE_INDENT + 1 # extra +1 for /
         dc = wx.ScreenDC()
         dc.SetFont(fixed_font)
-        fixed_text_size = dc.GetTextExtent(' ' * DISPLAY_WIDTH)
+        fixed_text_size = dc.GetTextExtent(' ' * display_width)
         dc.SetFont(standard_font)
-        standard_text_size = dc.GetTextExtent(' ' * DISPLAY_WIDTH)
+        standard_text_size = dc.GetTextExtent(' ' * display_width)
 
         text_width, text_height = [max(d1, d2) for d1, d2 in
                                    zip(fixed_text_size, standard_text_size)]

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -11,7 +11,7 @@ import threading
 
 from plover import log
 from plover.machine.keymap import Keymap
-from plover.steno import STENO_KEY_ORDER
+from plover import system
 
 
 STATE_STOPPED = 'closed'
@@ -27,19 +27,20 @@ class StenotypeBase(object):
     KEYS_LAYOUT = ()
     # And possible actions to map to.
     ACTIONS = (
-        tuple(sorted(STENO_KEY_ORDER.keys(),
-                     key=lambda k: STENO_KEY_ORDER[k]))
+        tuple(sorted(system.KEY_ORDER.keys(),
+                     key=lambda k: system.KEY_ORDER[k]))
         + ('no-op',)
     )
-    # And default mapping of actions (e.g. steno key) to those keys.
-    DEFAULT_MAPPINGS = {}
 
     def __init__(self):
         self.keymap = Keymap(self.KEYS_LAYOUT.split(), self.ACTIONS)
-        self.keymap.set_mappings(self.DEFAULT_MAPPINGS)
         self.stroke_subscribers = []
         self.state_subscribers = []
         self.state = STATE_STOPPED
+
+    def set_mappings(self, mappings):
+        """Setup machine keymap: mappings of action to keys."""
+        self.keymap.set_mappings(mappings)
 
     def start_capture(self):
         """Begin listening for output from the stenotype machine."""

--- a/plover/machine/geminipr.py
+++ b/plover/machine/geminipr.py
@@ -41,33 +41,6 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
         res2
     '''
 
-    DEFAULT_MAPPINGS = {
-        '#'         : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', '#B', '#C'),
-        'S-'        : ('S1-', 'S2-'),
-        'T-'        : 'T-',
-        'K-'        : 'K-',
-        'P-'        : 'P-',
-        'W-'        : 'W-',
-        'H-'        : 'H-',
-        'R-'        : 'R-',
-        'A-'        : 'A-',
-        'O-'        : 'O-',
-        '*'         : ('*1', '*2', '*3', '*4'),
-        '-E'        : '-E',
-        '-U'        : '-U',
-        '-F'        : '-F',
-        '-R'        : '-R',
-        '-P'        : '-P',
-        '-B'        : '-B',
-        '-L'        : '-L',
-        '-G'        : '-G',
-        '-T'        : '-T',
-        '-S'        : '-S',
-        '-D'        : '-D',
-        '-Z'        : '-Z',
-        'no-op'     : ('Fn', 'pwr', 'res1', 'res2'),
-    }
-
     def run(self):
         """Overrides base class run method. Do not call directly."""
         self._ready()

--- a/plover/machine/geminipr.py
+++ b/plover/machine/geminipr.py
@@ -12,12 +12,12 @@ import plover.machine.base
 # such, there are really only seven bits of steno data in each packet
 # byte. This is why the STENO_KEY_CHART below is visually presented as
 # six rows of seven elements instead of six rows of eight elements.
-STENO_KEY_CHART = ("Fn", "#", "#", "#", "#", "#", "#",
-                   "S-", "S-", "T-", "K-", "P-", "W-", "H-",
-                   "R-", "A-", "O-", "*", "*", "res", "res",
-                   "pwr", "*", "*", "-E", "-U", "-F", "-R",
+STENO_KEY_CHART = ("Fn", "#1", "#2", "#3", "#4", "#5", "#6",
+                   "S1-", "S2-", "T-", "K-", "P-", "W-", "H-",
+                   "R-", "A-", "O-", "*1", "*2", "res1", "res2",
+                   "pwr", "*3", "*4", "-E", "-U", "-F", "-R",
                    "-P", "-B", "-L", "-G", "-T", "-S", "-D",
-                   "#", "#", "#", "#", "#", "#", "-Z")
+                   "#7", "#8", "#9", "#A", "#B", "#C", "-Z")
 
 BYTES_PER_STROKE = 6
 
@@ -30,6 +30,43 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
     add_callback.
 
     """
+
+    KEYS_LAYOUT = '''
+        #1 #2  #3 #4 #5 #6 #7 #8 #9 #A #B #C
+        Fn S1- T- P- H- *1 *3 -F -P -L -T -D
+           S2- K- W- R- *2 *4 -R -B -G -S -Z
+                  A- O-       -E -U
+        pwr
+        res1
+        res2
+    '''
+
+    DEFAULT_MAPPINGS = {
+        '#'         : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', '#B', '#C'),
+        'S-'        : ('S1-', 'S2-'),
+        'T-'        : 'T-',
+        'K-'        : 'K-',
+        'P-'        : 'P-',
+        'W-'        : 'W-',
+        'H-'        : 'H-',
+        'R-'        : 'R-',
+        'A-'        : 'A-',
+        'O-'        : 'O-',
+        '*'         : ('*1', '*2', '*3', '*4'),
+        '-E'        : '-E',
+        '-U'        : '-U',
+        '-F'        : '-F',
+        '-R'        : '-R',
+        '-P'        : '-P',
+        '-B'        : '-B',
+        '-L'        : '-L',
+        '-G'        : '-G',
+        '-T'        : '-T',
+        '-S'        : '-S',
+        '-D'        : '-D',
+        '-Z'        : '-Z',
+        'no-op'     : ('Fn', 'pwr', 'res1', 'res2'),
+    }
 
     def run(self):
         """Overrides base class run method. Do not call directly."""
@@ -59,6 +96,8 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
                     if (b & (0x80 >> j)):
                         steno_keys.append(STENO_KEY_CHART[i * 7 + j - 1])
 
-            # Notify all subscribers.
-            self._notify(steno_keys)
+            steno_keys = self.keymap.keys_to_actions(steno_keys)
+            if steno_keys:
+                # Notify all subscribers.
+                self._notify(steno_keys)
 

--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -21,33 +21,6 @@ class Stenotype(SerialStenotypeBase):
         ! ^ +
     '''
 
-    DEFAULT_MAPPINGS = {
-        '#'    : '#',
-        'S-'   : ('S', 'C'),
-        'T-'   : 'T',
-        'K-'   : 'K',
-        'P-'   : 'P',
-        'W-'   : 'W',
-        'H-'   : 'H',
-        'R-'   : 'R',
-        'A-'   : 'A',
-        'O-'   : 'O',
-        '*'    : ('~', '*'),
-        '-E'   : 'E',
-        '-U'   : 'U',
-        '-F'   : 'F',
-        '-R'   : 'Q',
-        '-P'   : 'N',
-        '-B'   : 'B',
-        '-L'   : 'L',
-        '-G'   : 'G',
-        '-T'   : 'Y',
-        '-S'   : 'X',
-        '-D'   : 'D',
-        '-Z'   : 'Z',
-        'no-op': ('!', '^', '+'),
-    }
-
     def __init__(self, params):
         super(Stenotype, self).__init__(params)
         self.packet = []

--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -3,49 +3,53 @@
 
 "Thread-based monitoring of a stenotype machine using the passport protocol."
 
-from plover.machine.base import SerialStenotypeBase
 from itertools import izip_longest
+
+from plover.machine.base import SerialStenotypeBase
 
 # Passport protocol is documented here:
 # http://www.eclipsecat.com/?q=system/files/Passport%20protocol_0.pdf
 
-STENO_KEY_CHART = {
-    '!': None,
-    '#': '#',
-    '^': None,
-    '+': None,
-    'S': 'S-',
-    'C': 'S-',
-    'T': 'T-',
-    'K': 'K-',
-    'P': 'P-',
-    'W': 'W-',
-    'H': 'H-',
-    'R': 'R-',
-    '~': '*',
-    '*': '*',
-    'A': 'A-',
-    'O': 'O-',
-    'E': '-E',
-    'U': '-U',
-    'F': '-F',
-    'Q': '-R',
-    'N': '-P',
-    'B': '-B',
-    'L': '-L',
-    'G': '-G',
-    'Y': '-T',
-    'X': '-S',
-    'D': '-D',
-    'Z': '-Z',
-}
-
-
 class Stenotype(SerialStenotypeBase):
     """Passport interface."""
 
+    KEYS_LAYOUT = '''
+        # # # # # # # # # #
+        S T P H ~ F N L Y D
+        C K W R * Q B G X Z
+            A O   E U
+        ! ^ +
+    '''
+
+    DEFAULT_MAPPINGS = {
+        '#'    : '#',
+        'S-'   : ('S', 'C'),
+        'T-'   : 'T',
+        'K-'   : 'K',
+        'P-'   : 'P',
+        'W-'   : 'W',
+        'H-'   : 'H',
+        'R-'   : 'R',
+        'A-'   : 'A',
+        'O-'   : 'O',
+        '*'    : ('~', '*'),
+        '-E'   : 'E',
+        '-U'   : 'U',
+        '-F'   : 'F',
+        '-R'   : 'Q',
+        '-P'   : 'N',
+        '-B'   : 'B',
+        '-L'   : 'L',
+        '-G'   : 'G',
+        '-T'   : 'Y',
+        '-S'   : 'X',
+        '-D'   : 'D',
+        '-Z'   : 'Z',
+        'no-op': ('!', '^', '+'),
+    }
+
     def __init__(self, params):
-        SerialStenotypeBase.__init__(self, params)
+        super(Stenotype, self).__init__(params)
         self.packet = []
 
     def _read(self, b):
@@ -57,15 +61,14 @@ class Stenotype(SerialStenotypeBase):
 
     def _handle_packet(self, packet):
         encoded = packet.split('/')[1]
-        keys = []
+        steno_keys = []
         for key, shadow in grouper(encoded, 2, 0):
             shadow = int(shadow, base=16)
             if shadow >= 8:
-                key = STENO_KEY_CHART[key]
-                if key:
-                    keys.append(key)
-        if keys:
-            self._notify(keys)
+                steno_keys.append(key)
+        steno_keys = self.keymap.keys_to_actions(steno_keys)
+        if steno_keys:
+            self._notify(steno_keys)
 
     def run(self):
         """Overrides base class run method. Do not call directly."""
@@ -82,8 +85,8 @@ class Stenotype(SerialStenotypeBase):
             for b in raw:
                 self._read(b)
 
-    @staticmethod
-    def get_option_info():
+    @classmethod
+    def get_option_info(cls):
         """Get the default options for this machine."""
         bool_converter = lambda s: s == 'True'
         sb = lambda s: int(float(s)) if float(s).is_integer() else float(s)

--- a/plover/machine/stentura.py
+++ b/plover/machine/stentura.py
@@ -648,33 +648,6 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
         ^
     '''
 
-    DEFAULT_MAPPINGS = {
-        '#'    : '#',
-        'S-'   : 'S-',
-        'T-'   : 'T-',
-        'K-'   : 'K-',
-        'P-'   : 'P-',
-        'W-'   : 'W-',
-        'H-'   : 'H-',
-        'R-'   : 'R-',
-        'A-'   : 'A-',
-        'O-'   : 'O-',
-        '*'    : '*',
-        '-E'   : '-E',
-        '-U'   : '-U',
-        '-F'   : '-F',
-        '-R'   : '-R',
-        '-P'   : '-P',
-        '-B'   : '-B',
-        '-L'   : '-L',
-        '-G'   : '-G',
-        '-T'   : '-T',
-        '-S'   : '-S',
-        '-D'   : '-D',
-        '-Z'   : '-Z',
-        'no-op': '^',
-    }
-
     def _on_stroke(self, keys):
         steno_keys = self.keymap.keys_to_actions(keys)
         if steno_keys:

--- a/plover/machine/stentura.py
+++ b/plover/machine/stentura.py
@@ -640,13 +640,50 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
     add_callback.
     """
 
-    def __init__(self, params):
-        plover.machine.base.SerialStenotypeBase.__init__(self, params)
+    KEYS_LAYOUT = '''
+        #  #  #  #  #  #  #  #  #  #
+        S- T- P- H- * -F -P -L -T -D
+        S- K- W- R- * -R -B -G -S -Z
+              A- O-   -E -U
+        ^
+    '''
+
+    DEFAULT_MAPPINGS = {
+        '#'    : '#',
+        'S-'   : 'S-',
+        'T-'   : 'T-',
+        'K-'   : 'K-',
+        'P-'   : 'P-',
+        'W-'   : 'W-',
+        'H-'   : 'H-',
+        'R-'   : 'R-',
+        'A-'   : 'A-',
+        'O-'   : 'O-',
+        '*'    : '*',
+        '-E'   : '-E',
+        '-U'   : '-U',
+        '-F'   : '-F',
+        '-R'   : '-R',
+        '-P'   : '-P',
+        '-B'   : '-B',
+        '-L'   : '-L',
+        '-G'   : '-G',
+        '-T'   : '-T',
+        '-S'   : '-S',
+        '-D'   : '-D',
+        '-Z'   : '-Z',
+        'no-op': '^',
+    }
+
+    def _on_stroke(self, keys):
+        steno_keys = self.keymap.keys_to_actions(keys)
+        if steno_keys:
+            self._notify(steno_keys)
 
     def run(self):
         """Overrides base class run method. Do not call directly."""
         try:
-            _loop(self.serial_port, self.finished, self._notify, self._ready)
+            _loop(self.serial_port, self.finished, self._on_stroke, self._ready)
         except _StopException:
             pass
         except Exception as e:

--- a/plover/machine/test_passport.py
+++ b/plover/machine/test_passport.py
@@ -43,7 +43,7 @@ def cmp_keys(a, b):
     return all(starmap(eq, zip(a, b)))
 
 class TestCase(unittest.TestCase):
-    def test_pasport(self):
+    def test_passport(self):
         
         def p(s):
             return '<123/%s/something>' % s

--- a/plover/machine/test_passport.py
+++ b/plover/machine/test_passport.py
@@ -5,10 +5,14 @@
 
 from operator import eq
 from itertools import starmap
-import unittest
-from mock import patch
-from plover.machine.passport import Stenotype
 import time
+import unittest
+
+from mock import patch
+
+from plover.machine.passport import Stenotype
+from plover import system
+
 
 class MockSerial(object):
     
@@ -68,6 +72,7 @@ class TestCase(unittest.TestCase):
                 actual = []
                 m = Stenotype(params)
                 m.add_stroke_callback(lambda s: actual.append(s))
+                m.set_mappings(system.KEYMAPS['Passport'])
                 m.start_capture()
                 while mock.index < len(mock.inputs):
                     time.sleep(0.00001)

--- a/plover/machine/treal.py
+++ b/plover/machine/treal.py
@@ -61,33 +61,6 @@ class Stenotype(StenotypeBase):
                    A- O- X3 -E -U
     '''
 
-    DEFAULT_MAPPINGS = {
-        '#'    : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', '#B'),
-        'S-'   : ('S1-', 'S2-'),
-        'T-'   : 'T-',
-        'K-'   : 'K-',
-        'P-'   : 'P-',
-        'W-'   : 'W-',
-        'H-'   : 'H-',
-        'R-'   : 'R-',
-        'A-'   : 'A-',
-        'O-'   : 'O-',
-        '*'    : ('*1', '*2'),
-        '-E'   : '-E',
-        '-U'   : '-U',
-        '-F'   : '-F',
-        '-R'   : '-R',
-        '-P'   : '-P',
-        '-B'   : '-B',
-        '-L'   : '-L',
-        '-G'   : '-G',
-        '-T'   : '-T',
-        '-S'   : '-S',
-        '-D'   : '-D',
-        '-Z'   : '-Z',
-        'no-op': ('X1-', 'X2-', 'X3'),
-    }
-
     def __init__(self, params):
         super(Stenotype, self).__init__()
         self._machine = None

--- a/plover/machine/treal.py
+++ b/plover/machine/treal.py
@@ -15,11 +15,11 @@ else:
     from plover.machine.base import ThreadedStenotypeBase as StenotypeBase
     import hid
 
-STENO_KEY_CHART = (('K-', 'W-', 'R-', '*', '-R', '-B', '-G', '-S'),
-                   ('*', '-F', '-P', '-L', '-T', '-D', '', 'S-'),
-                   ('#', '#', '#', '', 'S-', 'T-', 'P-', 'H-'),
-                   ('#', '#', '#', '#', '#', '#', '#', '#'),
-                   ('', '', '-Z', 'A-', 'O-', '', '-E', '-U'))
+STENO_KEY_CHART = (('K-', 'W-', 'R-', '*2', '-R', '-B', '-G', '-S'),
+                   ('*1', '-F', '-P', '-L', '-T', '-D', 'X2-', 'S2-'),
+                   ('#9', '#A', '#B', 'X1-', 'S1-', 'T-', 'P-', 'H-'),
+                   ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8'),
+                   ('', '', '-Z', 'A-', 'O-', 'X3', '-E', '-U'))
 
 def packet_to_stroke(p):
    keys = []
@@ -54,9 +54,48 @@ class DataHandler(object):
 
 class Stenotype(StenotypeBase):
 
+    KEYS_LAYOUT = '''
+        #1  #2  #3 #4 #5 #6 #7 #8 #9 #A #B
+        X1- S1- T- P- H- *1 -F -P -L -T -D
+        X2- S2- K- W- R- *2 -R -B -G -S -Z
+                   A- O- X3 -E -U
+    '''
+
+    DEFAULT_MAPPINGS = {
+        '#'    : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', '#B'),
+        'S-'   : ('S1-', 'S2-'),
+        'T-'   : 'T-',
+        'K-'   : 'K-',
+        'P-'   : 'P-',
+        'W-'   : 'W-',
+        'H-'   : 'H-',
+        'R-'   : 'R-',
+        'A-'   : 'A-',
+        'O-'   : 'O-',
+        '*'    : ('*1', '*2'),
+        '-E'   : '-E',
+        '-U'   : '-U',
+        '-F'   : '-F',
+        '-R'   : '-R',
+        '-P'   : '-P',
+        '-B'   : '-B',
+        '-L'   : '-L',
+        '-G'   : '-G',
+        '-T'   : '-T',
+        '-S'   : '-S',
+        '-D'   : '-D',
+        '-Z'   : '-Z',
+        'no-op': ('X1-', 'X2-', 'X3'),
+    }
+
     def __init__(self, params):
         super(Stenotype, self).__init__()
         self._machine = None
+
+    def _on_stroke(self, keys):
+        steno_keys = self.keymap.keys_to_actions(keys)
+        if steno_keys:
+            self._notify(steno_keys)
 
     if sys.platform.startswith('win32'):
 
@@ -70,7 +109,7 @@ class Stenotype(StenotypeBase):
                 return
             self._machine = devices[0]
             self._machine.open()
-            handler = DataHandler(self._notify)
+            handler = DataHandler(self._on_stroke)
 
             def callback(p):
                 if len(p) != 6: return
@@ -98,7 +137,7 @@ class Stenotype(StenotypeBase):
             super(Stenotype, self).start_capture()
 
         def run(self):
-            handler = DataHandler(self._notify)
+            handler = DataHandler(self._on_stroke)
             self._ready()
             while not self.finished.isSet():
                 packet = self._machine.read(5)

--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -46,32 +46,6 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
               A- O-   -E -U
     '''
 
-    DEFAULT_MAPPINGS = {
-        '#'    : '#',
-        'S-'   : 'S-',
-        'T-'   : 'T-',
-        'K-'   : 'K-',
-        'P-'   : 'P-',
-        'W-'   : 'W-',
-        'H-'   : 'H-',
-        'R-'   : 'R-',
-        'A-'   : 'A-',
-        'O-'   : 'O-',
-        '*'    : '*',
-        '-E'   : '-E',
-        '-U'   : '-U',
-        '-F'   : '-F',
-        '-R'   : '-R',
-        '-P'   : '-P',
-        '-B'   : '-B',
-        '-L'   : '-L',
-        '-G'   : '-G',
-        '-T'   : '-T',
-        '-S'   : '-S',
-        '-D'   : '-D',
-        '-Z'   : '-Z',
-    }
-
     def __init__(self, params):
         super(Stenotype, self).__init__(params)
         self._reset_stroke_state()

--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -39,8 +39,41 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
 
     """
 
+    KEYS_LAYOUT = '''
+        #  #  #  #  #  #  #  #  #  #
+        S- T- P- H- * -F -P -L -T -D
+        S- K- W- R- * -R -B -G -S -Z
+              A- O-   -E -U
+    '''
+
+    DEFAULT_MAPPINGS = {
+        '#'    : '#',
+        'S-'   : 'S-',
+        'T-'   : 'T-',
+        'K-'   : 'K-',
+        'P-'   : 'P-',
+        'W-'   : 'W-',
+        'H-'   : 'H-',
+        'R-'   : 'R-',
+        'A-'   : 'A-',
+        'O-'   : 'O-',
+        '*'    : '*',
+        '-E'   : '-E',
+        '-U'   : '-U',
+        '-F'   : '-F',
+        '-R'   : '-R',
+        '-P'   : '-P',
+        '-B'   : '-B',
+        '-L'   : '-L',
+        '-G'   : '-G',
+        '-T'   : '-T',
+        '-S'   : '-S',
+        '-D'   : '-D',
+        '-Z'   : '-Z',
+    }
+
     def __init__(self, params):
-        plover.machine.base.SerialStenotypeBase.__init__(self, params)
+        super(Stenotype, self).__init__(params)
         self._reset_stroke_state()
 
     def _reset_stroke_state(self):
@@ -48,7 +81,9 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
         self._last_key_set = 0
 
     def _finish_stroke(self):
-        self._notify(self._pressed_keys)
+        steno_keys = self.keymap.keys_to_actions(self._pressed_keys)
+        if steno_keys:
+            self._notify(self._pressed_keys)
         self._reset_stroke_state()
 
     def run(self):

--- a/plover/oslayer/keyboardcontrol.py
+++ b/plover/oslayer/keyboardcontrol.py
@@ -35,29 +35,16 @@ class KeyboardCapture(keyboardcontrol.KeyboardCapture):
     """Listen to keyboard events."""
 
     """Supported keys."""
-    SUPPORTED_KEYS = [chr(n) for n in range(ord('a'), ord('z') + 1)]
-    for n in range(12):
-        SUPPORTED_KEYS.append('F%u' % (n + 1))
-        for c in '`1234567890-=[];\',./\\':
-            SUPPORTED_KEYS.append(c)
-            SUPPORTED_KEYS.extend(
-                '''
-                BackSpace
-                Delete
-                Down
-                End
-                Escape
-                Home
-                Insert
-                Left
-                Page_Down
-                Page_Up
-                Return
-                Right
-                Tab
-                Up
-                space
-                '''.split())
+    SUPPORTED_KEYS_LAYOUT = '''
+    Escape  F1 F2 F3 F4  F5 F6 F7 F8  F9 F10 F11 F12
+
+      `  1  2  3  4  5  6  7  8  9  0  -  =  \\ BackSpace  Insert Home Page_Up
+     Tab  q  w  e  r  t  y  u  i  o  p  [  ]               Delete End  Page_Down
+           a  s  d  f  g  h  j  k  l  ;  '      Return
+            z  x  c  v  b  n  m  ,  .  /                          Up
+                     space                                   Left Down Right
+    '''
+    SUPPORTED_KEYS = tuple(SUPPORTED_KEYS_LAYOUT.split())
 
 
 class KeyboardEmulation(keyboardcontrol.KeyboardEmulation):

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -13,8 +13,10 @@ Stroke -- A data model class that encapsulates a sequence of steno keys.
 
 import re
 
+from plover import system
+
+
 STROKE_DELIMITER = '/'
-IMPLICIT_HYPHENS = set('AOEU*50')
 
 
 def normalize_steno(strokes_string):
@@ -22,56 +24,21 @@ def normalize_steno(strokes_string):
     strokes = strokes_string.split(STROKE_DELIMITER)
     normalized_strokes = []
     for stroke in strokes:
-        if '#' in stroke:
-            stroke = stroke.replace('#', '')
+        if system.NUMBER_KEY in stroke:
+            stroke = stroke.replace(system.NUMBER_KEY, '')
             if not re.search('[0-9]', stroke):
-                stroke = '#' + stroke
+                stroke = system.NUMBER_KEY + stroke
         # Insert dash when dealing with 'explicit' numbers
         if re.search('[1-4][6-9]', stroke):
             start = re.search('[6-9]', stroke).start()
             stroke = stroke[:start] + '-' + stroke[start:]
-        has_implicit_dash = bool(set(stroke) & IMPLICIT_HYPHENS)
+        has_implicit_dash = bool(set(stroke) & system.IMPLICIT_HYPHENS)
         if has_implicit_dash:
             stroke = stroke.replace('-', '')
         if stroke.endswith('-'):
             stroke = stroke[:-1]
         normalized_strokes.append(stroke)
     return tuple(normalized_strokes)
-
-STENO_KEY_NUMBERS = {'S-': '1-',
-                     'T-': '2-',
-                     'P-': '3-',
-                     'H-': '4-',
-                     'A-': '5-',
-                     'O-': '0-',
-                     '-F': '-6',
-                     '-P': '-7',
-                     '-L': '-8',
-                     '-T': '-9'}
-
-STENO_KEY_ORDER = {"#": 0,
-                   "S-": 1,
-                   "T-": 2,
-                   "K-": 3,
-                   "P-": 4,
-                   "W-": 5,
-                   "H-": 6,
-                   "R-": 7,
-                   "A-": 8,
-                   "O-": 9,
-                   "*": 10,
-                   "-E": 11,
-                   "-U": 12,
-                   "-F": 13,
-                   "-R": 14,
-                   "-P": 15,
-                   "-B": 16,
-                   "-L": 17,
-                   "-G": 18,
-                   "-T": 19,
-                   "-S": 20,
-                   "-D": 21,
-                   "-Z": 22}
 
 
 class Stroke(object):
@@ -87,8 +54,6 @@ class Stroke(object):
 
     """
 
-    IMPLICIT_HYPHEN = set(('A-', 'O-', '5-', '0-', '-E', '-U', '*'))
-
     def __init__(self, steno_keys) :
         """Create a steno stroke by formatting steno keys.
 
@@ -103,30 +68,30 @@ class Stroke(object):
         steno_keys = list(steno_keys_set)
 
         # Order the steno keys so comparisons can be made.
-        steno_keys.sort(key=lambda x: STENO_KEY_ORDER.get(x, -1))
+        steno_keys.sort(key=lambda x: system.KEY_ORDER.get(x, -1))
          
         # Convert strokes involving the number bar to numbers.
-        if '#' in steno_keys:
+        if system.NUMBER_KEY in steno_keys:
             numeral = False
             for i, e in enumerate(steno_keys):
-                if e in STENO_KEY_NUMBERS:
-                    steno_keys[i] = STENO_KEY_NUMBERS[e]
+                if e in system.NUMBERS:
+                    steno_keys[i] = system.NUMBERS[e]
                     numeral = True
             if numeral:
-                steno_keys.remove('#')
+                steno_keys.remove(system.NUMBER_KEY)
         
-        if steno_keys_set & self.IMPLICIT_HYPHEN:
+        if steno_keys_set & system.IMPLICIT_HYPHEN_KEYS:
             self.rtfcre = ''.join(key.strip('-') for key in steno_keys)
         else:
             pre = ''.join(k.strip('-') for k in steno_keys if k[-1] == '-' or 
-                          k == '#')
+                          k == system.NUMBER_KEY)
             post = ''.join(k.strip('-') for k in steno_keys if k[0] == '-')
             self.rtfcre = '-'.join([pre, post]) if post else pre
 
         self.steno_keys = steno_keys
 
         # Determine if this stroke is a correction stroke.
-        self.is_correction = (self.rtfcre == '*')
+        self.is_correction = (self.rtfcre == system.UNDO_STROKE_STENO)
 
     def __str__(self):
         if self.is_correction:

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -1,0 +1,49 @@
+
+from plover.oslayer.config import CONFIG_DIR, ASSETS_DIR
+
+import os
+import re
+
+
+def _load_wordlist(filename):
+    if filename is None:
+        return {}
+    path = None
+    for dir in (CONFIG_DIR, ASSETS_DIR):
+        path = os.path.realpath(os.path.join(dir, filename))
+        if os.path.exists(path):
+            break
+    words = {}
+    with open(path) as f:
+        pairs = [word.strip().rsplit(' ', 1) for word in f]
+        pairs.sort(reverse=True, key=lambda x: int(x[1]))
+        words = {p[0].lower(): int(p[1]) for p in pairs}
+    return words
+
+_EXPORTS = {
+    'KEY_ORDER'                : lambda mod: dict((l, n) for n, l in enumerate(mod.KEYS)),
+    'NUMBER_KEY'               : lambda mod: mod.NUMBER_KEY,
+    'NUMBERS'                  : lambda mod: dict(mod.NUMBERS),
+    'SUFFIX_KEYS'              : lambda mod: set(mod.SUFFIX_KEYS),
+    'UNDO_STROKE_STENO'        : lambda mod: mod.UNDO_STROKE_STENO,
+    'IMPLICIT_HYPHEN_KEYS'     : lambda mod: set(mod.IMPLICIT_HYPHEN_KEYS),
+    'IMPLICIT_HYPHENS'         : lambda mod: set(l.replace('-', '')
+                                                 for l in mod.IMPLICIT_HYPHEN_KEYS),
+    'ORTHOGRAPHY_WORDS'        : lambda mod: _load_wordlist(mod.ORTHOGRAPHY_WORDLIST),
+    'ORTHOGRAPHY_RULES'        : lambda mod: [(re.compile(pattern, re.I), replacement)
+                                              for pattern, replacement in mod.ORTHOGRAPHY_RULES],
+    'ORTHOGRAPHY_RULES_ALIASES': lambda mod: dict(mod.ORTHOGRAPHY_RULES_ALIASES),
+    'KEYMAPS'                  : lambda mod: mod.KEYMAPS,
+}
+
+def setup():
+    from plover.system import english_stenotype as mod
+    globs = globals()
+    for symbol, init in _EXPORTS.items():
+        globs[symbol] = init(mod)
+    globs['NAME'] = 'English Stenotype'
+
+
+# Setup default system.
+setup()
+

--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -1,0 +1,239 @@
+
+KEYS = (
+    '#',
+    'S-', 'T-', 'K-', 'P-', 'W-', 'H-', 'R-',
+    'A-', 'O-',
+    '*',
+    '-E', '-U',
+    '-F', '-R', '-P', '-B', '-L', '-G', '-T', '-S', '-D', '-Z',
+)
+
+IMPLICIT_HYPHEN_KEYS = ('A-', 'O-', '5-', '0-', '-E', '-U', '*')
+
+SUFFIX_KEYS = ('-S', '-G', '-Z', '-D')
+
+NUMBER_KEY = '#'
+
+NUMBERS = {
+    'S-': '1-',
+    'T-': '2-',
+    'P-': '3-',
+    'H-': '4-',
+    'A-': '5-',
+    'O-': '0-',
+    '-F': '-6',
+    '-P': '-7',
+    '-L': '-8',
+    '-T': '-9',
+}
+
+UNDO_STROKE_STENO = '*'
+
+ORTHOGRAPHY_RULES = [
+    # == +ly ==
+    # artistic + ly = artistically
+    (r'^(.*[aeiou]c) \^ ly$', r'\1ally'),
+        
+    # == +ry ==      
+    # statute + ry = statutory
+    (r'^(.*t)e \^ ry$', r'\1ory'),
+        
+    # == t +cy ==      
+    # frequent + cy = frequency (tcy/tecy removal)
+    (r'^(.*[naeiou])te? \^ cy$', r'\1cy'),
+
+    # == +s ==
+    # establish + s = establishes (sibilant pluralization)
+    (r'^(.*(?:s|sh|x|z|zh)) \^ s$', r'\1es'),
+    # speech + s = speeches (soft ch pluralization)
+    (r'^(.*(?:oa|ea|i|ee|oo|au|ou|l|n|(?<![gin]a)r|t)ch) \^ s$', r'\1es'),
+    # cherry + s = cherries (consonant + y pluralization)
+    (r'^(.+[bcdfghjklmnpqrstvwxz])y \^ s$', r'\1ies'),
+
+    # == y ==
+    # die+ing = dying
+    (r'^(.+)ie \^ ing$', r'\1ying'),
+    # metallurgy + ist = metallurgist
+    (r'^(.+[cdfghlmnpr])y \^ ist$', r'\1ist'),
+    # beauty + ful = beautiful (y -> i)
+    (r'^(.+[bcdfghjklmnpqrstvwxz])y \^ ([a-hj-xz].*)$', r'\1i\2'),
+
+    # == e ==
+    # write + en = written
+    (r'^(.+)te \^ en$', r'\1tten'),
+    # free + ed = freed 
+    (r'^(.+e)e \^ (e.+)$', r'\1\2'),
+    # narrate + ing = narrating (silent e)
+    (r'^(.+[bcdfghjklmnpqrstuvwxz])e \^ ([aeiouy].*)$', r'\1\2'),
+
+    # == misc ==
+    # defer + ed = deferred (consonant doubling)   XXX monitor(stress not on last syllable)
+    (r'^(.*(?:[bcdfghjklmnprstvwxyz]|qu)[aeiou])([bcdfgklmnprtvz]) \^ ([aeiouy].*)$', r'\1\2\2\3'),
+]
+
+ORTHOGRAPHY_RULES_ALIASES = {
+    'able': 'ible',
+}
+
+ORTHOGRAPHY_WORDLIST = 'american_english_words.txt'
+
+KEYMAPS = {
+    'Gemini PR': {
+        '#'         : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', '#B', '#C'),
+        'S-'        : ('S1-', 'S2-'),
+        'T-'        : 'T-',
+        'K-'        : 'K-',
+        'P-'        : 'P-',
+        'W-'        : 'W-',
+        'H-'        : 'H-',
+        'R-'        : 'R-',
+        'A-'        : 'A-',
+        'O-'        : 'O-',
+        '*'         : ('*1', '*2', '*3', '*4'),
+        '-E'        : '-E',
+        '-U'        : '-U',
+        '-F'        : '-F',
+        '-R'        : '-R',
+        '-P'        : '-P',
+        '-B'        : '-B',
+        '-L'        : '-L',
+        '-G'        : '-G',
+        '-T'        : '-T',
+        '-S'        : '-S',
+        '-D'        : '-D',
+        '-Z'        : '-Z',
+        'no-op'     : ('Fn', 'pwr', 'res1', 'res2'),
+    },
+    'Keyboard': {
+        '#'         : ('1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '='),
+        'S-'        : ('a', 'q'),
+        'T-'        : 'w',
+        'K-'        : 's',
+        'P-'        : 'e',
+        'W-'        : 'd',
+        'H-'        : 'r',
+        'R-'        : 'f',
+        'A-'        : 'c',
+        'O-'        : 'v',
+        '*'         : ('t', 'g', 'y', 'h'),
+        '-E'        : 'n',
+        '-U'        : 'm',
+        '-F'        : 'u',
+        '-R'        : 'j',
+        '-P'        : 'i',
+        '-B'        : 'k',
+        '-L'        : 'o',
+        '-G'        : 'l',
+        '-T'        : 'p',
+        '-S'        : ';',
+        '-D'        : '[',
+        '-Z'        : '\'',
+        'arpeggiate': 'space',
+        # Suppress adjacent keys to prevent miss-strokes.
+        'no-op'     : ('z', 'x', 'b', ',', '.', '/', ']', '\\'),
+    },
+    'Passport': {
+        '#'    : '#',
+        'S-'   : ('S', 'C'),
+        'T-'   : 'T',
+        'K-'   : 'K',
+        'P-'   : 'P',
+        'W-'   : 'W',
+        'H-'   : 'H',
+        'R-'   : 'R',
+        'A-'   : 'A',
+        'O-'   : 'O',
+        '*'    : ('~', '*'),
+        '-E'   : 'E',
+        '-U'   : 'U',
+        '-F'   : 'F',
+        '-R'   : 'Q',
+        '-P'   : 'N',
+        '-B'   : 'B',
+        '-L'   : 'L',
+        '-G'   : 'G',
+        '-T'   : 'Y',
+        '-S'   : 'X',
+        '-D'   : 'D',
+        '-Z'   : 'Z',
+        'no-op': ('!', '^', '+'),
+    },
+    'Stentura': {
+        '#'    : '#',
+        'S-'   : 'S-',
+        'T-'   : 'T-',
+        'K-'   : 'K-',
+        'P-'   : 'P-',
+        'W-'   : 'W-',
+        'H-'   : 'H-',
+        'R-'   : 'R-',
+        'A-'   : 'A-',
+        'O-'   : 'O-',
+        '*'    : '*',
+        '-E'   : '-E',
+        '-U'   : '-U',
+        '-F'   : '-F',
+        '-R'   : '-R',
+        '-P'   : '-P',
+        '-B'   : '-B',
+        '-L'   : '-L',
+        '-G'   : '-G',
+        '-T'   : '-T',
+        '-S'   : '-S',
+        '-D'   : '-D',
+        '-Z'   : '-Z',
+        'no-op': '^',
+    },
+    'TX Bolt': {
+        '#'    : '#',
+        'S-'   : 'S-',
+        'T-'   : 'T-',
+        'K-'   : 'K-',
+        'P-'   : 'P-',
+        'W-'   : 'W-',
+        'H-'   : 'H-',
+        'R-'   : 'R-',
+        'A-'   : 'A-',
+        'O-'   : 'O-',
+        '*'    : '*',
+        '-E'   : '-E',
+        '-U'   : '-U',
+        '-F'   : '-F',
+        '-R'   : '-R',
+        '-P'   : '-P',
+        '-B'   : '-B',
+        '-L'   : '-L',
+        '-G'   : '-G',
+        '-T'   : '-T',
+        '-S'   : '-S',
+        '-D'   : '-D',
+        '-Z'   : '-Z',
+    },
+    'Treal': {
+        '#'    : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', '#B'),
+        'S-'   : ('S1-', 'S2-'),
+        'T-'   : 'T-',
+        'K-'   : 'K-',
+        'P-'   : 'P-',
+        'W-'   : 'W-',
+        'H-'   : 'H-',
+        'R-'   : 'R-',
+        'A-'   : 'A-',
+        'O-'   : 'O-',
+        '*'    : ('*1', '*2'),
+        '-E'   : '-E',
+        '-U'   : '-U',
+        '-F'   : '-F',
+        '-R'   : '-R',
+        '-P'   : '-P',
+        '-B'   : '-B',
+        '-L'   : '-L',
+        '-G'   : '-G',
+        '-T'   : '-T',
+        '-S'   : '-S',
+        '-D'   : '-D',
+        '-Z'   : '-Z',
+        'no-op': ('X1-', 'X2-', 'X3'),
+    },
+}
+


### PR DESCRIPTION
Move all system/theory related parameters to a dedicated module:
* steno keys, number keys, suffix keys
* undo stroke
* orthography word list and rules
* default keymaps for supported machines

Note:
* the keyboard keymap configuration option was moved out of the `[Keyboard]` section to a new `[System: English Stenotype]` section
* although not supported in the GUI, it was simpler and cleaner to use a generic approach, so it possible to change a machine (other than the keyboard) keymap through the configuration, e.g.:
```python
[System: English Stenotype]
keymap[treal] = [["#", ["#1", "#2", "#3", "#4", "#5", "#6", "#7", "#8", "#9", "#A", "#B", "X3"]], ["S-", ["S1-", "S2-"]], ["T-", ["T-"]], ["K-", ["K-"]], ["P-", ["P-"]], ["W-", ["W-"]], ["H-", ["H-"]], ["R-", ["R-"]], ["A-", ["A-"]], ["O-", ["O-"]], ["*", ["*1", "*2"]], ["-E", ["-E"]], ["-U", ["-U"]], ["-F", ["-F"]], ["-R", ["-R"]], ["-P", ["-P"]], ["-B", ["-B"]], ["-L", ["-L"]], ["-G", ["-G"]], ["-T", ["-T"]], ["-S", ["-S"]], ["-D", ["-D"]], ["-Z", ["-Z"]], ["no-op", ["X1-", "X2-"]]]
```