### PR TITLE
Rework AppVeyor and Travis CI deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,3 @@ deploy:
     - "dist/*.whl"
   on:
     tags: true
-    repo: openstenoproject/plover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 
-skip_tags: true
+skip_tags: false
 
 pull_requests:
 
@@ -9,7 +9,7 @@ pull_requests:
 deploy:
 
 - provider: GitHub
-  release: weekly-v$(appveyor_build_version)
+  release: $(APPVEYOR_REPO_TAG_NAME)
   description: Weekly Pre-release
   prerelease: true
   draft: true
@@ -17,7 +17,7 @@ deploy:
     secure: m8kBg3jFX2k516nlmWkvxNCrBwlQZMaa6hNn7A+rktl781BRTyKssCXQqKAwPJLs
   artifact: executable
   on:
-    branch: weekly
+    appveyor_repo_tag: true
 
 environment:
 
@@ -59,9 +59,6 @@ build:
 before_build:
   # Update version number from VCS.
   - "python setup.py patch_version"
-  # And the build number accordingly.
-  - ps: "Update-AppveyorBuild -Version \"$(python setup.py --version)\""
-  - "ECHO appveyor_build_version: %appveyor_build_version%"
 
 build_script:
   - "ECHO PATH=%PATH%"


### PR DESCRIPTION
The constraints:
* Travis CI deploy on tag
* when creating a draft release with AppVeyor, the tag creation is deferred to publication, so Travis CI (deployment) builds won't start until the release is published
* it's better to create a draft release, so we get a chance to edit release notes, and test the build artifacts before the actual release

So this pull request change the process of creating a new weekly to:
* run: `./setup.py tag_weekly`, this will tag the current `HEAD` based on the last stable release, e.g. `weekly-v2.5.8+443.gf47e969`
* push the tag to GitHub (the branch does not matter)
* AppVeyor and Travis CI will both start buildings, and their artifacts will be deployed to a draft release
* edit the draft release notes, test the build artifacts
* publish!

Note:
* the AppVeyor build version is no longer patched according to the version number, as this could result in multiple builds trying to use the same build number (different branches, or tag vs commit builds)
* I removed the repository constraints for Travis CI deployment, as it's one less conflicting entry when setting up a custom repository
* when we do actually release the next stable version, we'll be able to use a similar process: manually patch the version, commit, tag, push...
