### PR TITLE
setup: add missing 'system' module to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,7 @@ if __name__ == '__main__':
         packages=[
             'plover', 'plover.machine', 'plover.gui',
             'plover.oslayer', 'plover.dictionary',
+            'plover.system',
         ],
         package_data={
             'plover': ['assets/*'],


### PR DESCRIPTION
Unfortunately, our egg and wheel files for the first weekly don't work because of this missing module...