### PR TITLE
Lower meta: carry space to maintain was_space state

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -648,6 +648,10 @@ def _atom_to_action_spaces_after(atom, last_action):
             action.lower = False
         elif meta == META_LOWER:
             action = last_action.copy_state()
+            if was_space:
+                # Persist space state
+                action.replace = SPACE
+                action.text = SPACE
             action.lower = True
             action.capitalize = False
         elif meta == META_UPPER:

--- a/plover/test_formatting.py
+++ b/plover/test_formatting.py
@@ -277,6 +277,22 @@ class FormatterTestCase(unittest.TestCase):
           action(combo='ALT_L(Grave)', capitalize=True),
           action(text=' ', attach=True)
          ]),
+
+        (('{-|}{>}{&a}{>}{&b}', action(), False),
+         [action(capitalize=True),
+          action(lower=True),
+          action(text=' a', word='a', glue=True),
+          action(lower=True, word='a', text='', glue=True),
+          action(text='b', word='ab', glue=True),
+         ]),
+
+        (('{-|}{>}{&a}{>}{&b}', action(), True),
+         [action(capitalize=True),
+          action(lower=True),
+          action(text='a ', word='a', glue=True),
+          action(lower=True, word='a', text=' ', replace=' ', glue=True),
+          action(text='b ', replace=' ', word='ab', glue=True),
+         ]),
          
          (('{-|} equip {^s}', action(), False),
           [action(capitalize=True),
@@ -814,7 +830,7 @@ class FormatterTestCase(unittest.TestCase):
          action(capitalize=True, word='test')),
 
         (('{>}', action(word='test', text='test ')),
-         action(lower=True, word='test')),
+         action(lower=True, word='test', replace=' ', text=' ')),
 
         (('{<}', action(word='test', text='test ')),
          action(upper=True, word='test')),


### PR DESCRIPTION
### About

Lower meta doesn't have text content, so "was_space" wasn't triggering for the next action. Workaround is to replace space and set lower's text to space, in order to carry over the "was_space" state.

Fixes #407 

### Release Notes

Fix fingerspelling when output is set to place spaces after.

