### PR TITLE
Fix retro delete space to work with meta actions and numbers

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -838,6 +838,10 @@ def _apply_carry_capitalize(meta, last_action, spaces_after=False):
     action = last_action.copy_state()
     action.attach = attach_next
 
+    # Spaces after: delete last space if we're attaching.
+    replace_last = last_action.text.endswith(SPACE) and attach_last
+    action.replace = SPACE if replace_last else NO_SPACE
+
     if meta_content:
         action.word = meta_content
 
@@ -846,10 +850,6 @@ def _apply_carry_capitalize(meta, last_action, spaces_after=False):
         # Only suffix a space if spaces are after or there's an attach_next flag.
         suffix = NO_SPACE if attach_next or not spaces_after else SPACE
         action.text = prefix + meta_content + suffix
-
-        # Spaces after: delete last space if we're attaching.
-        replace_last = last_action.text.endswith(SPACE) and attach_last
-        action.replace = SPACE if replace_last else NO_SPACE
 
     return action
 

--- a/plover/test_formatting.py
+++ b/plover/test_formatting.py
@@ -539,6 +539,11 @@ class FormatterTestCase(unittest.TestCase):
           action(text='EQUIPPED ', word='EQUIPPED', replace='equipped ', upper_carry=True),
          ]),
 
+        (('{.}{^~|^}zshrc', action(), True),
+         [action(text='. ', capitalize=True),
+          action(attach=True, capitalize=True, replace=' '),
+          action(text='Zshrc ', word='Zshrc')]),
+
         (('notanumber {*($c)}', action(), True),
          [action(text='notanumber ', word='notanumber'),
           action(text='', word='notanumber', replace=''),

--- a/plover/test_translation.py
+++ b/plover/test_translation.py
@@ -636,6 +636,21 @@ class TranslateStrokeTestCase(unittest.TestCase):
         self.assertTranslations(do)
         self.assertOutput(undo, do, None)
 
+    def test_retrospective_delete_space_with_number(self):
+        self.define('T/E/S/T', 'a longer key')
+        self.define('U', 'user')
+        self.define('SP*', '{*!}')
+        self.translate(stroke('U'))
+        self.translate(stroke('1-'))
+        self.translate(stroke('SP*'))
+        undo = self.lt('U 1-')
+        do = self.lt('SP*')
+        do[0].english = 'user{^~|^}{&1}'
+        do[0].is_retrospective_command = True
+        do[0].replaced = undo
+        self.assertTranslations(do)
+        self.assertOutput(undo, do, None)
+
     def test_retrospective_delete_space_with_period(self):
         self.define('T/E/S/T', 'a longer key')
         self.define('P-P', '{.}')

--- a/plover/test_translation.py
+++ b/plover/test_translation.py
@@ -630,7 +630,23 @@ class TranslateStrokeTestCase(unittest.TestCase):
         self.translate(stroke('SP*'))
         undo = self.lt('K B')
         do = self.lt('SP*')
-        do[0].english = 'kickback'
+        do[0].english = 'kick{^~|^}back'
+        do[0].is_retrospective_command = True
+        do[0].replaced = undo
+        self.assertTranslations(do)
+        self.assertOutput(undo, do, None)
+
+    def test_retrospective_delete_space_with_period(self):
+        self.define('T/E/S/T', 'a longer key')
+        self.define('P-P', '{.}')
+        self.define('SH*', 'zshrc')
+        self.define('SP*', '{*!}')
+        self.translate(stroke('P-P'))
+        self.translate(stroke('SH*'))
+        self.translate(stroke('SP*'))
+        undo = self.lt('P-P SH*')
+        do = self.lt('SP*')
+        do[0].english = '{.}{^~|^}zshrc'
         do[0].is_retrospective_command = True
         do[0].replaced = undo
         self.assertTranslations(do)

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -301,6 +301,8 @@ class Translator(object):
             for t in replaced:
                 if t.english is not None:
                     english.append(t.english)
+                elif len(t.rtfcre) is 1 and t.rtfcre[0].isdigit():
+                    english.append('{&%s}' % t.rtfcre[0])
             if len(english) > 1:
                 t = Translation([stroke], '{^~|^}'.join(english))
                 t.replaced = replaced

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -267,7 +267,6 @@ class Translator(object):
             self._state.translations.extend(do)
 
     def _find_translation(self, translations, stroke, mapping):
-
         t = self._find_translation_helper(translations, stroke)
         if t:
             return t
@@ -303,7 +302,7 @@ class Translator(object):
                 if t.english is not None:
                     english.append(t.english)
             if len(english) > 1:
-                t = Translation([stroke], ''.join(english))
+                t = Translation([stroke], '{^~|^}'.join(english))
                 t.replaced = replaced
                 t.is_retrospective_command = True
                 return t


### PR DESCRIPTION
### About

Retro-del-space would only join the previous two translations, which didn't work for cases like "{.}" because the output would be "{.}word" which equates to ". Word". Instead, now we join with `{^~|^}` which will remove the space and maintain capitalization (".Word" in this example).

Also handle numbers. Previously we only used the translation's english value, but if the stroke is a number it has no english value.

### Issues

Fixes #402, #405

### Release Notes

Fix retroactive delete space with punctuation, numbers, and other meta commands.