### PR TITLE
osxkeyboardcontrol: explicity remove unwanted mask flags

### DIFF
--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -35,6 +35,7 @@ from Quartz import (
 )
 import Foundation
 import threading
+from time import time
 import collections
 from plover.oslayer import mac_keycode
 
@@ -441,6 +442,11 @@ class KeyboardEmulation(object):
                 goal_flags = (event_flags & ~KeyboardEmulation.MODS_MASK) | mods_flags
                 if event_flags != goal_flags:
                     CGEventSetFlags(event, goal_flags)
+
+                # Half millisecond pause after keydown
+                deadline = time() + 0.0005
+                while time() < deadline:
+                    pass
 
             CGEventPost(kCGSessionEventTap, event)
 


### PR DESCRIPTION
### About

Explicitly remove mask flags that we *don't* want, if they are not properly set. This extends the already present functionality. The results is that complex strings like `>µ>µ>µ>µ` work, where before they would come out as `≥Â˘Â˘Â˘Â˘µ>` or similar.

The change to HIDSystemEvent also fixes this case in KDiff3 and other legacy applications.

Also add a delay to output when sending key sequences, may fix the transposition issue.