### PR TITLE
treal: automatically reconnect

### DIFF
--- a/plover/machine/registry.py
+++ b/plover/machine/registry.py
@@ -8,14 +8,7 @@ from plover.machine.txbolt import Stenotype as txbolt
 from plover.machine.keyboard import Stenotype as keyboard
 from plover.machine.stentura import Stenotype as stentura
 from plover.machine.passport import Stenotype as passport
-from plover import log
-
-try:
-    from plover.machine.treal import Stenotype as treal
-except Exception as e:
-    log.info('Unable to use Treal on this machine: %s', str(e))
-    treal = None
-
+from plover.machine.treal import Stenotype as treal
 
 class NoSuchMachineException(Exception):
     def __init__(self, id):

--- a/plover/machine/treal.py
+++ b/plover/machine/treal.py
@@ -6,16 +6,10 @@
 
 "Thread-based monitoring of a stenotype machine using the Treal machine."
 
-import sys
-from plover import log
 from time import sleep
-
-if sys.platform.startswith('win32'):
-    from plover.machine.base import StenotypeBase
-    from pywinusb import hid
-else:
-    from plover.machine.base import ThreadedStenotypeBase as StenotypeBase
-    import hid
+import hid
+from plover import log
+from plover.machine.base import ThreadedStenotypeBase
 
 STENO_KEY_CHART = (('K-', 'W-', 'R-', '*2', '-R', '-B', '-G', '-S'),
                    ('*1', '-F', '-P', '-L', '-T', '-D', 'X2-', 'S2-'),
@@ -55,7 +49,7 @@ class DataHandler(object):
             self._pressed = [x[0] | x[1] for x in zip(self._pressed, p)]
 
 
-class Stenotype(StenotypeBase):
+class Stenotype(ThreadedStenotypeBase):
 
     KEYS_LAYOUT = '''
         #1  #2  #3 #4 #5 #6 #7 #8 #9 #A #B
@@ -73,81 +67,58 @@ class Stenotype(StenotypeBase):
         if steno_keys:
             self._notify(steno_keys)
 
-    if sys.platform.startswith('win32'):
-
-        def start_capture(self):
-            """Begin listening for output from the stenotype machine."""
-            devices = hid.HidDeviceFilter(vendor_id=VENDOR_ID).get_devices()
-            if len(devices) == 0:
-                log.info('Treal: no devices with vendor id %s', str(VENDOR_ID))
-                log.warning('Treal not connected')
-                self._error()
-                return
-            self._machine = devices[0]
-            self._machine.open()
-            handler = DataHandler(self._on_stroke)
-
-            def callback(p):
-                if len(p) != 6: return
-                handler.update(p[1:])
-
-            self._machine.set_raw_data_handler(callback)
-            self._ready()
-
-    else:
-
-        def _connect(self):
-            connected = False
-            for product_id in PRODUCT_IDS:
-                try:
-                    if hasattr(hid.device, 'open'):
-                        self._machine = hid.device()
-                        self._machine.open(VENDOR_ID, product_id)
-                    else:
-                        self._machine = hid.device(VENDOR_ID, product_id)
-                except IOError as e:
-                    self._machine = None
+    def _connect(self):
+        connected = False
+        for product_id in PRODUCT_IDS:
+            try:
+                if hasattr(hid.device, 'open'):
+                    self._machine = hid.device()
+                    self._machine.open(VENDOR_ID, product_id)
                 else:
-                    self._machine.set_nonblocking(0)
-                    self._ready()
-                    connected = True
-                    break
+                    self._machine = hid.device(VENDOR_ID, product_id)
+            except IOError as e:
+                self._machine = None
+            else:
+                self._machine.set_nonblocking(0)
+                self._ready()
+                connected = True
+                break
 
-            return connected
+        return connected
 
-        def start_capture(self):
-            """Begin listening for output from the stenotype machine."""
-            if not self._connect():
-                log.warning('Treal is not connected')
-                self._error()
-                return
-            super(Stenotype, self).start_capture()
+    def start_capture(self):
+        """Begin listening for output from the stenotype machine."""
+        if not self._connect():
+            log.warning('Treal is not connected')
+            self._error()
+            return
+        super(Stenotype, self).start_capture()
 
-        def _reconnect(self):
-            self._machine = None
-            self._initializing()
+    def _reconnect(self):
+        self._machine = None
+        self._initializing()
 
+        connected = self._connect()
+        # Reconnect loop
+        while not self.finished.isSet() and not connected:
+            sleep(0.5)
             connected = self._connect()
-            # Reconnect loop
-            while not self.finished.isSet() and not connected:
-                sleep(0.5)
-                connected = self._connect()
-            return connected
+        return connected
 
-        def run(self):
-            handler = DataHandler(self._on_stroke)
-            self._ready()
-            while not self.finished.isSet():
-                try:
-                    packet = self._machine.read(5, 50)
-                except IOError:
-                    self._machine.close()
-                    log.warning('Treal disconnected, reconnecting…')
-                    if self._reconnect():
-                        log.warning('Treal reconnected.')
-                else:
-                    if len(packet) is 5:
-                        handler.update(packet)
+    def run(self):
+        handler = DataHandler(self._on_stroke)
+        self._ready()
+        while not self.finished.isSet():
+            try:
+                packet = self._machine.read(5, 100)
+            except IOError:
+                self._machine.close()
+                log.warning(u'Treal disconnected, reconnecting…')
+                if self._reconnect():
+                    log.warning('Treal reconnected.')
+            else:
+                if len(packet) is 5:
+                    handler.update(packet)
 
     def stop_capture(self):
         """Stop listening for output from the stenotype machine."""

--- a/setup.py
+++ b/setup.py
@@ -113,26 +113,24 @@ install_requires = [
     'setuptools',
     'pyserial>=2.7',
     'appdirs>=1.4.0',
+    'hidapi',
 ]
 
 extras_require = {
     ':"win32" in sys_platform': [
         'pyhook>=1.5.1',
         'pywin32>=219',
-        'pywinusb>=0.4.0',
         # Can't reliably require wxPython
     ],
     ':"linux" in sys_platform': [
         'python-xlib>=0.14',
         'wxPython>=3.0',
-        'hidapi',
     ],
     ':"darwin" in sys_platform': [
         'pyobjc-core>=3.0.3',
         'pyobjc-framework-Cocoa>=3.0.3',
         'pyobjc-framework-Quartz>=3.0.3',
         'wxPython>=3.0',
-        'hidapi',
     ],
 }
 

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -277,7 +277,6 @@ class Helper(object):
         # Note: '--always-unzip' is needed, as pyHook cannot work from a single egg file.
         ('pyhook'           , 'http://downloads.sourceforge.net/project/pyhook/pyhook/1.5.1/pyHook-1.5.1.win32-py2.7.exe'                         , '9afb7a5b2858a69c6b0f6d2cb1b2eb2a3f4183d2', 'easy_install', ('--always-unzip',), None),
         ('pywin32'          , 'http://downloads.sourceforge.net/project/pywin32/pywin32/Build 219/pywin32-219.win32-py2.7.exe'                    , '8bc39008383c646bed01942584117113ddaefe6b', 'easy_install', (), None),
-        ('pywinusb'         , 'pip:pywinusb'                                                                                                      , None                                      , None, (), None),
     )
 
     def __init__(self):

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -346,6 +346,7 @@ class Helper(object):
             '.msi'        : self._install_msi,
             '.rar'        : self._install_archive,
             '.zip'        : self._install_archive,
+            '.whl'        : self._pip_install,
         }
 
     def _rmtree(self, path):
@@ -584,6 +585,8 @@ class WineHelper(Helper):
 
     DEPENDENCIES = (
         ('Python', 'https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi', 'b14ebf1198fe4bbb940bcce90d910b8eddd60209', None, (), None),
+        ('Cython', 'https://pypi.python.org/packages/2.7/C/Cython/Cython-0.23.4-cp27-none-win32.whl', 'd7c1978fe2037674b151622158881c700ac2f06a', None, (), None),
+        ('VC for Python', 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi', '7800d037ba962f288f9b952001106d35ef57befe', None, (), None),
     ) + Helper.DEPENDENCIES
 
     def __init__(self):


### PR DESCRIPTION
- Add Treal reconnect, which starts after losing the connection.
- Try to connect to all 10 Treal devices, which can be switched using a switch on the bottom of the machine.
- Change to hidapi on Windows in order to unify modules cross platform.

Tested on OS X and Windows (used AppVeyor builds)