### PR TITLE
Support --help and --version arguments to the plover binary.

### DIFF
--- a/plover/main.py
+++ b/plover/main.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import traceback
+import argparse
 
 WXVER = '3.0'
 if not hasattr(sys, 'frozen'):
@@ -22,6 +23,8 @@ import plover.oslayer.processlock
 from plover.oslayer.config import CONFIG_DIR, ASSETS_DIR
 from plover.config import CONFIG_FILE, DEFAULT_DICTIONARIES, Config
 from plover import log
+from plover import __name__ as __software_name__
+from plover import __version__
 
 def show_error(title, message):
     """Report error to the user.
@@ -69,6 +72,11 @@ def init_config_dir():
 
 def main():
     """Launch plover."""
+    usage = "usage: plover"
+    description = "Run the plover stenotype engine. This is a graphical application."
+    parser = argparse.ArgumentParser(usage=usage, description=description, prog=__software_name__.capitalize())
+    parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
+    args =  parser.parse_args(args=sys.argv[1:])
     try:
         # Ensure only one instance of Plover is running at a time.
         with plover.oslayer.processlock.PloverLock():


### PR DESCRIPTION
### About

This adds support for the `--help` and `--version` arguments when running plover at the cli.

### Reason

I ran plover with `--help` and was rather surprised that it just ignored the argument and launched.

### Tested Platforms

Linux