### PR TITLE
Improve logging

### DIFF
--- a/plover/log.py
+++ b/plover/log.py
@@ -14,7 +14,7 @@ from logging import DEBUG, INFO, WARNING, ERROR
 from plover.oslayer.config import CONFIG_DIR
 
 
-LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
+LOG_FORMAT = '%(asctime)s [%(threadName)s] %(levelname)s: %(message)s'
 LOG_FILENAME = os.path.realpath(os.path.join(CONFIG_DIR, 'plover.log'))
 LOG_MAX_BYTES = 10000000
 LOG_COUNT = 9

--- a/plover/main.py
+++ b/plover/main.py
@@ -76,7 +76,10 @@ def main():
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('--version', action='version', version='%s %s'
                         % (__software_name__.capitalize(), __version__))
+    parser.add_argument('-l', '--log-level', choices=['debug', 'info', 'warning', 'error'],
+                        default='warning', help='set log level')
     args = parser.parse_args(args=sys.argv[1:])
+    log.set_level(args.log_level.upper())
     try:
         # Ensure only one instance of Plover is running at a time.
         with plover.oslayer.processlock.PloverLock():


### PR DESCRIPTION
* add thread name to default log formatter
* add command line switch to change log level

Note: the default level has been reduced from *INFO* to *WARNING*.