### PR TITLE
osx: optimize dmg size

### DIFF
--- a/osx/makefile
+++ b/osx/makefile
@@ -18,6 +18,7 @@ dmg: $(DMG)
 
 $(APP):
 	cd $(topdir) && $(PYTHON) setup.py py2app
+	zip -d $(APP)/Contents/Resources/lib/python2.7/site-packages.zip 'plover/assets/*'
 	ditto --arch x86_64 $(APP) $(APP:%.app=%Stripped.app)
 	rm -rf $(APP)
 	mv $(APP:%.app=%Stripped.app) $(APP)


### PR DESCRIPTION
Remove unused duplicate copy of assets directory:
```shell
> ls Plover.app/Contents/Resources/
american_english_words.txt  __error__.sh  plover.ico       site.pyc
__boot__.py                 include/      plover-icon.svg  spinner.gif
commands.json               launch.py     plover.png       up.png
connected.png               lib/          refresh.png      user.json
disconnected.png            main.json     remove.png
down.png                    plover.icns   share/
> unzip -l Plover.app/Contents/Resources/lib/python2.7/site-packages.zip 'plover/assets/*'
Archive:  Plover.app/Contents/Resources/lib/python2.7/site-packages.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2016-03-12 18:26   plover/assets/
  4491762  2016-03-12 18:18   plover/assets/american_english_words.txt
      952  2016-03-12 18:18   plover/assets/commands.json
     1011  2016-03-12 18:18   plover/assets/connected.png
      908  2016-03-12 18:18   plover/assets/disconnected.png
      670  2016-03-12 18:18   plover/assets/down.png
  4094182  2016-03-12 18:18   plover/assets/main.json
     1474  2016-03-12 18:18   plover/assets/plover-icon.svg
   104076  2016-03-12 18:18   plover/assets/plover.ico
    10767  2016-03-12 18:18   plover/assets/plover.png
     1421  2016-03-12 18:18   plover/assets/refresh.png
      256  2016-03-12 18:18   plover/assets/remove.png
      673  2016-03-12 18:18   plover/assets/spinner.gif
      655  2016-03-12 18:18   plover/assets/up.png
        3  2016-03-12 18:18   plover/assets/user.json
---------                     -------
  8708810                     15 files
```