### PR TITLE
travis: unshallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 install: true
 
 script:
-  - depth=50; while ! git describe --tag '--match=v[0-9]*'; do depth=$(($depth+10)); git fetch --depth $depth; done
+  - git fetch --unshallow
   - python setup.py patch_version
   - python setup.py test
   - |


### PR DESCRIPTION
Needed so `git describe --tags` output is consistent (only fetching down to the last accessible tag is not enough).