### PR TITLE
Fix Windows and Mac distributions so pkg_resources can be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
       true
       ;;
     esac &&
-    python setup.py write_requirements &&
+    ./setup.py write_requirements &&
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt &&
     # We need to downgrade setuptools for py2app to work correctly...
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2' &&
@@ -35,8 +35,8 @@ install: true
 
 script:
   - git fetch --unshallow
-  - python setup.py patch_version
-  - python setup.py test
+  - ./setup.py patch_version
+  - ./setup.py test
   - |
     case "$TRAVIS_OS_NAME" in
     osx)
@@ -44,8 +44,8 @@ script:
       true
       ;;
     linux)
-      python setup.py bdist_egg &&
-      python setup.py bdist_wheel &&
+      ./setup.py bdist_egg &&
+      ./setup.py bdist_wheel &&
       true
       ;;
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ script:
       ./setup.py bdist_wheel &&
       true
       ;;
-    esac
+    esac &&
+    du -hs dist/*
 
 deploy:
   provider: releases

--- a/linux/README.md
+++ b/linux/README.md
@@ -29,7 +29,7 @@ For the missing dependencies, follow the generic procedure.
 
 You can create a pip compatible requirements file with:
 
-`python2 setup.py write_requirements`
+`./setup.py write_requirements`
 
 And then using pip, e.g. for a user install:
 
@@ -39,13 +39,13 @@ Note: if your version of pip is too old, you may get parsing errors on the lines
 
 ## Running from source
 
-To run from source, use: `python2 launch.py`.
+To run from source, use: `./launch.py`.
 
 ## Installing and running
 
 ### Using an egg
 
-A self-contained executable egg can be created with: `python2 setup.py bdist_egg`. The egg will be created in `dist`, `chmod +x` it and you can run Plover directly from it:
+A self-contained executable egg can be created with: `./setup.py bdist_egg`. The egg will be created in `dist`, `chmod +x` it and you can run Plover directly from it:
 
 `chmod +x dist/Plover-2.5.8-py2.7.egg && ./dist/Plover-2.5.8-py2.7.egg`
 
@@ -53,12 +53,12 @@ Note: the egg file can be moved, but it cannot however be renamed (as the packag
 
 ### Using a wheel file with pip
 
-A wheel file can be created with: `python2 setup.py bdist_wheel`. The resulting file can then be installed using pip, e.g. for a user install:
+A wheel file can be created with: `./setup.py bdist_wheel`. The resulting file can then be installed using pip, e.g. for a user install:
 
 `pip2 install dist/Plover-2.5.8-py2-none-any.whl`
 
 ### Using `setup.py`
 
-You can install with `sudo python2 setup.py install --record install.txt`. The list of installed files will be saved to `install.txt`.
+You can install with `sudo ./setup.py install --record install.txt`. The list of installed files will be saved to `install.txt`.
 
 Note: this method is not recommended as it's harder to uninstall (you have to do it manually, with the help of `install.txt`) and can mess with your distribution files.

--- a/osx/makefile
+++ b/osx/makefile
@@ -19,9 +19,7 @@ app: $(APP)
 dmg: $(DMG)
 
 $(APP):
-	cd $(topdir) && $(PYTHON) setup.py py2app
-	zip -d $(TMP_APP)/Contents/Resources/lib/python2.7/site-packages.zip 'plover/assets/*'
-	rm -rf $(TMP_APP)
+	cd $(topdir) && $(PYTHON) setup.py bdist_app
 
 $(DMG): $(APP)
 	mkdir tmp

--- a/osx/makefile
+++ b/osx/makefile
@@ -21,7 +21,6 @@ dmg: $(DMG)
 $(APP):
 	cd $(topdir) && $(PYTHON) setup.py py2app
 	zip -d $(TMP_APP)/Contents/Resources/lib/python2.7/site-packages.zip 'plover/assets/*'
-	ditto --arch x86_64 $(TMP_APP) $(APP)
 	rm -rf $(TMP_APP)
 
 $(DMG): $(APP)

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -12,24 +12,15 @@ import sys
 
 # If plover is run from a pyinstaller binary.
 if hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
-    ASSETS_DIR = sys._MEIPASS
     PROGRAM_DIR = dirname(sys.executable)
 # If plover is run from an app bundle on Mac.
 elif (sys.platform.startswith('darwin') and '.app' in realpath(__file__)):
-    ASSETS_DIR = os.getcwd()
     PROGRAM_DIR = abspath(join(dirname(sys.executable), *[pardir] * 3))
 else:
-    ASSETS_DIR = join(dirname(dirname(realpath(__file__))), 'assets')
     PROGRAM_DIR = os.getcwd()
 
-try:
-    pkg_resources.require('plover')[0]
-    has_pkg_resources = True
-except pkg_resources.DistributionNotFound:
-    has_pkg_resources = False
-
-if has_pkg_resources:
-    ASSETS_DIR = pkg_resources.resource_filename('plover', 'assets')
+pkg_resources.require('plover')[0]
+ASSETS_DIR = pkg_resources.resource_filename('plover', 'assets')
 
 # If the program's directory has a plover.cfg file then run in "portable mode",
 # i.e. store all data in the same directory. This allows keeping all Plover

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -9,7 +9,6 @@ import os
 from os.path import realpath, join, dirname, abspath, isfile, pardir
 import sys
 
-bundle_type = None
 
 # If plover is run from a pyinstaller binary.
 if hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ kwargs = {}
 if sys.platform.startswith('darwin'):
     setup_requires.append('py2app')
     options['py2app'] = {
+        'arch': 'x86_64',
         'argv_emulation': False,
         'iconfile': 'osx/plover.icns',
         'resources': 'plover/assets/',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -145,10 +146,13 @@ class BinaryDistApp(setuptools.Command):
         app = 'dist/%s-%s.app' % (package_name, __version__)
         libdir = '%s/Contents/Resources/lib/python2.7' % app
         sitezip = '%s/site-packages.zip' % libdir
-        # Add version to filename.
+        # Add version to filename and strip other architectures.
+        # (using py2app --arch is not enough).
         tmp_app = 'dist/%s.app' % package_name
-        log.info('renaming %s to %s', tmp_app, app)
-        os.rename(tmp_app, app)
+        cmd = 'ditto --arch x86_64 %s %s' % (tmp_app, app)
+        log.info('running %s', cmd)
+        subprocess.check_call(cmd.split())
+        shutil.rmtree(tmp_app)
         # We can't access package resources from the site zip,
         # so extract module and package data to the lib directory.
         cmd = 'unzip -d %s %s plover/*' % (libdir, sitezip)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ from plover import (
 )
 
 
+package_name = __software_name__.capitalize()
+
+
 def get_version():
     if not os.path.exists('.git'):
         return None
@@ -90,7 +93,7 @@ if sys.platform.startswith('darwin'):
         'iconfile': 'osx/plover.icns',
         'resources': 'plover/assets/',
         'plist': {
-            'CFBundleName': __software_name__.capitalize(),
+            'CFBundleName': package_name,
             'CFBundleShortVersionString': __version__,
             'CFBundleVersion': __version__,
             'CFBundleIdentifier': 'org.openstenoproject.plover',
@@ -160,7 +163,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     setuptools.setup(
-        name=__software_name__.capitalize(),
+        name=package_name,
         version=__version__,
         description=__description__,
         long_description=__long_description__,

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python2
+
+import os
+import pkg_resources
+import sys
+import shutil
+
+
+def collect_requirements(distribution, requirements=None):
+    if requirements is None:
+        requirements = set()
+    for dependency in distribution.requires():
+        dependency = pkg_resources.get_distribution(dependency)
+        if dependency in requirements:
+            continue
+        requirements.add(dependency)
+        collect_requirements(dependency, requirements)
+    return requirements
+
+def get_metadata(distribution):
+    egg_info = '%s.egg-info' % distribution.egg_name()
+    metadata = distribution.egg_info
+    if metadata is None:
+        metadata = '%s/%s' % (distribution.location, egg_info)
+        if not os.path.exists(metadata):
+            return None
+    return (metadata, egg_info)
+
+def collect_metadata(distribution):
+    metadata_list = [ get_metadata(distribution) ]
+    requirements = collect_requirements(distribution)
+    requirements = sorted(requirements, key=lambda d: d.key)
+    for dependency in requirements:
+        metadata = get_metadata(dependency)
+        if metadata is None:
+            print 'no metadata for: %s' % dependency.project_name
+            continue
+        metadata_list.append(metadata)
+    return metadata_list
+
+def pack(root_dir, path, archive_name):
+    if os.path.isfile(path):
+        dest = '%s/%s' % (root_dir, archive_name)
+        dest_dir = os.path.dirname(dest)
+        if not os.path.isdir(dest_dir):
+            os.mkdir(dest_dir)
+        shutil.copy(path, dest)
+        return
+    for entry in os.listdir(path):
+        pack(root_dir,
+             '%s/%s' % (path, entry),
+             '%s/%s' % (archive_name, entry))
+
+def copy_metadata(source, destination):
+    distribution = list(pkg_resources.find_distributions(source, only=True))[0]
+    print 'adding metadata from %s (%s) to %s' % (
+        source,
+        distribution.project_name,
+        destination,
+    )
+    for metadata in collect_metadata(distribution):
+        print 'adding metadata: %s' % metadata[1]
+        pack(destination, metadata[0], metadata[1])
+
+if __name__ == '__main__':
+    source = sys.argv[1]
+    destination = sys.argv[2]
+    copy_metadata(source, destination)
+

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -536,17 +536,7 @@ class Helper(object):
         self._rmtree('build')
         self._rmtree('dist')
         info('creating distribution')
-        self._env.run(('pyinstaller.exe',
-                       '--log-level=WARN',
-                       '--specpath=build',
-                       '--additional-hooks-dir=%s' % WIN_DIR,
-                       '--name=%s' % APPNAME,
-                       '--icon=%s' % ICON,
-                       '--noconfirm',
-                       '--windowed',
-                       '--onefile',
-                       'launch.py'))
-        self._rename('dist/%s.exe' % APPNAME, 'dist/%s-%s.exe' % (APPNAME, VERSION))
+        self._env.run(('python.exe', 'setup.py', 'bdist_win'))
 
     def main(self, args):
         opts = self._parser.parse_args(args)

--- a/windows/hook-plover.py
+++ b/windows/hook-plover.py
@@ -1,6 +1,23 @@
 
+import pkg_resources
+
+from utils.metadata import collect_metadata
+
+from PyInstaller import log as logging
+
+
+log = logging.getLogger(__name__)
+log.info('hook-plover.py')
+
 datas = []
 hiddenimports = []
 
-datas.append(('plover/assets/*', '.'))
+distribution = list(pkg_resources.find_distributions('.', only=True))[0]
+assert distribution.project_name == 'Plover'
+
+metadata_list = collect_metadata(distribution)
+log.info('adding metadata: %s', metadata_list)
+datas.extend(metadata_list)
+
+datas.append(('plover/assets', 'plover/assets'))
 


### PR DESCRIPTION
Add the required packages metadata so `pkg_resources` can be used.

Tested with a Windows 10 VM.
