### PR TITLE
OSX: Add special media keys, extend Windows' Media Keys

### DIFF
--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -162,9 +162,15 @@ class WindowsKeyboardLayout:
     # No letters yet, those are customized per-layout.
     keyname_to_keycode = collections.defaultdict(list, {
         # Adding media controls for windows
+        'Standby': [0x5F],
+        'Back': [0xA6], 'Forward': [0xA7], 'Refresh': [0xA8], 'Stop': [0xA9],
+        'Search': [0xAA], 'Favorites': [0xAB], 'HomePage': [0xAC], 'WWW': [0xAC],
         'AudioMute': [0xAD], 'AudioLowerVolume': [0xAE], 'AudioRaiseVolume': [0xAF],
         'AudioNext': [0xB0], 'AudioPrev': [0xB1], 'AudioStop': [0xB2],
-        'AudioPlay': [0xB3], 'Sleep': [0x5F],
+        'AudioPlay': [0xB3], 'AudioPause': [0xB3], 'AudioMedia': [0xB5],
+        'MyComputer': [0xB6], 'Calculator': [0xB7],
+
+        'Mail': [0xB4],
 
         'Alt_L': [0xA4], 'Alt_R': [0xA5], 'Control_L': [0xA2], 'Control_R': [0xA3],
         'Hyper_L': [], 'Hyper_R': [], 'Meta_L': [], 'Meta_R': [],


### PR DESCRIPTION
Add OSX media keys. Supported keys (x names):

```python
    "AudioRaiseVolume": 0,
    "AudioLowerVolume": 1,
    "MonBrightnessUp": 2,
    "MonBrightnessDown": 3,
    "AudioMute": 7,
    "Num_Lock": 10,
    "Eject": 14,
    "AudioPause": 16,
    "AudioPlay": 16,
    "AudioNext": 17,
    "AudioPrev": 18,
    "AudioRewind": 20,
```

I didn't include keyboard brightness up, down, and toggle. There doesn't seem to be an XF86 equivalent, and I'm not sure what the value of controlling keyboard brightness from the steno machine would be.

Also added the Fn modifier, but it's not exactly expected behavior because it is an external keyboard--the top-row equivalent of the Mac laptop keyboards won't occur.