### PR TITLE
a few dictionary related changes

### DIFF
--- a/plover/dictionary_editor_store.py
+++ b/plover/dictionary_editor_store.py
@@ -141,7 +141,7 @@ class DictionaryEditorStore():
             dict = (self.engine
                         .get_dictionary()
                         .get_by_path(added_item.dictionary))
-            dict.__setitem__(self._splitStrokes(added_item.stroke),
+            dict.__setitem__(normalize_steno(added_item.stroke),
                              added_item.translation)
 
         # Updates
@@ -150,7 +150,7 @@ class DictionaryEditorStore():
             dict = (self.engine
                         .get_dictionary()
                         .get_by_path(modified_item.dictionary))
-            dict.__setitem__(self._splitStrokes(modified_item.stroke),
+            dict.__setitem__(normalize_steno(modified_item.stroke),
                              modified_item.translation)
 
         # Deletes
@@ -158,7 +158,7 @@ class DictionaryEditorStore():
             dict = (self.engine
                         .get_dictionary()
                         .get_by_path(deleted_item.dictionary))
-            dict.__delitem__(self._splitStrokes(deleted_item.stroke))
+            dict.__delitem__(normalize_steno(deleted_item.stroke))
 
         self.engine.get_dictionary().save_all()
 
@@ -226,7 +226,3 @@ class DictionaryEditorStore():
                                           reverse=reverse_sort)
         else:
             self.sorted_keys = self.filtered_keys[:]
-
-    def _splitStrokes(self, strokes_string):
-        result = normalize_steno(strokes_string.upper())
-        return result

--- a/plover/dictionary_editor_store.py
+++ b/plover/dictionary_editor_store.py
@@ -54,12 +54,12 @@ class DictionaryEditorStore():
 
         self.pending_changes = False
 
-        for dict in reversed(self.engine.get_dictionary().dicts):
-            for dk, translation in dict.iteritems():
+        for dictionary in reversed(self.engine.get_dictionary().dicts):
+            for dk, translation in dictionary.iteritems():
                 joined = '/'.join(dk)
                 item = DictionaryItem(joined,
                                       translation,
-                                      dict.get_path(),
+                                      dictionary,
                                       item_id)
                 self.all_keys.append(item)
                 item_id += 1
@@ -78,7 +78,7 @@ class DictionaryEditorStore():
         elif col is COL_TRANSLATION:
             result = shorten_unicode(item.translation)
         elif col is COL_DICTIONARY:
-            result = item.dictionary
+            result = item.dictionary.get_path()
         return result
 
     def SetValue(self, row, col, value):
@@ -137,28 +137,17 @@ class DictionaryEditorStore():
         self.pending_changes = False
 
         # Creates
-        for added_item in self.added_items:
-            dict = (self.engine
-                        .get_dictionary()
-                        .get_by_path(added_item.dictionary))
-            dict.__setitem__(normalize_steno(added_item.stroke),
-                             added_item.translation)
+        for item in self.added_items:
+            item.dictionary[normalize_steno(item.stroke)] = item.translation
 
         # Updates
-        for modified_item_id in self.modified_items:
-            modified_item = self.all_keys[modified_item_id]
-            dict = (self.engine
-                        .get_dictionary()
-                        .get_by_path(modified_item.dictionary))
-            dict.__setitem__(normalize_steno(modified_item.stroke),
-                             modified_item.translation)
+        for item_id in self.modified_items:
+            item = self.all_keys[item_id]
+            item.dictionary[normalize_steno(item.stroke)] = item.translation
 
         # Deletes
-        for deleted_item in self.deleted_items:
-            dict = (self.engine
-                        .get_dictionary()
-                        .get_by_path(deleted_item.dictionary))
-            dict.__delitem__(normalize_steno(deleted_item.stroke))
+        for item in self.deleted_items:
+            del item.dictionary[normalize_steno(item.stroke)]
 
         self.engine.get_dictionary().save_all()
 

--- a/plover/dictionary_editor_store.py
+++ b/plover/dictionary_editor_store.py
@@ -66,6 +66,10 @@ class DictionaryEditorStore():
         self.filtered_keys = self.all_keys[:]
         self.sorted_keys = self.filtered_keys[:]
 
+    def is_row_read_only(self, row):
+        item = self.sorted_keys[row]
+        return item.dictionary.save is None
+
     def GetNumberOfRows(self):
         return len(self.sorted_keys)
 

--- a/plover/dictionary_editor_store.py
+++ b/plover/dictionary_editor_store.py
@@ -136,20 +136,26 @@ class DictionaryEditorStore():
     def SaveChanges(self):
         self.pending_changes = False
 
+        # Set of dictionaries (paths) that needs saving.
+        needs_saving = set()
+
         # Creates
         for item in self.added_items:
             item.dictionary[normalize_steno(item.stroke)] = item.translation
+            needs_saving.add(item.dictionary.get_path())
 
         # Updates
         for item_id in self.modified_items:
             item = self.all_keys[item_id]
             item.dictionary[normalize_steno(item.stroke)] = item.translation
+            needs_saving.add(item.dictionary.get_path())
 
         # Deletes
         for item in self.deleted_items:
             del item.dictionary[normalize_steno(item.stroke)]
+            needs_saving.add(item.dictionary.get_path())
 
-        self.engine.get_dictionary().save_all()
+        self.engine.get_dictionary().save(needs_saving)
 
     def Sort(self, column):
         if column is not COL_STROKE and column is not COL_TRANSLATION:

--- a/plover/gui/add_translation.py
+++ b/plover/gui/add_translation.py
@@ -133,7 +133,7 @@ class AddTranslationDialog(wx.Dialog):
         translation = self.translation_text.GetValue().strip()
         if strokes and translation:
             d.set(strokes, translation)
-            d.save()
+            d.save(path_list=(d.dicts[0].get_path(),))
         self.Close()
 
     def on_close(self, event=None):

--- a/plover/gui/add_translation.py
+++ b/plover/gui/add_translation.py
@@ -233,7 +233,7 @@ class AddTranslationDialog(wx.Dialog):
         self.SetTransparent(alpha_byte)
 
     def _normalized_strokes(self):
-        strokes = self.strokes_text.GetValue().upper().replace('/', ' ').split()
+        strokes = self.strokes_text.GetValue().replace('/', ' ').split()
         strokes = normalize_steno('/'.join(strokes))
         return strokes
 

--- a/plover/gui/dictionary_editor.py
+++ b/plover/gui/dictionary_editor.py
@@ -91,12 +91,6 @@ class DictionaryEditor(wx.Dialog):
         self.grid.SetColSize(COL_TRANSLATION, 250)
         self.grid.SetColSize(COL_DICTIONARY, 150)
 
-        read_only_right_aligned = wx.grid.GridCellAttr()
-        read_only_right_aligned.SetReadOnly(True)
-        read_only_right_aligned.SetAlignment(wx.ALIGN_RIGHT, wx.ALIGN_CENTRE)
-        self.grid.SetColAttr(COL_DICTIONARY, read_only_right_aligned)
-        self.grid.SetColAttr(COL_SPACER, read_only_right_aligned)
-
         global_sizer.Add(self.grid, 1, wx.EXPAND)
 
         buttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -301,6 +295,18 @@ class DictionaryEditorGridTable(PyGridTableBase):
 
     def SetValue(self, row, col, value):
         self.store.SetValue(row, col, value)
+
+    def GetAttr(self, row, col, params):
+        if col in (COL_DICTIONARY, COL_SPACER):
+            attr = wx.grid.GridCellAttr()
+            attr.SetReadOnly(True)
+            attr.SetAlignment(wx.ALIGN_RIGHT, wx.ALIGN_CENTRE)
+            return attr
+        if self.store.is_row_read_only(row):
+            attr = wx.grid.GridCellAttr()
+            attr.SetReadOnly(True)
+            return attr
+        return None
 
     def ResetView(self, grid):
 

--- a/plover/gui/dictionary_editor.py
+++ b/plover/gui/dictionary_editor.py
@@ -358,4 +358,4 @@ def Show(parent, engine, config):
                                                 clear_instance)
     Show.dialog_instance.Show()
     Show.dialog_instance.Raise()
-    util.SetTopApp()
+    util.SetTopApp(Show.dialog_instance)

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -51,15 +51,14 @@ class StenoDictionary(collections.MutableMapping):
 
     def __setitem__(self, key, value):
         self._longest_key = max(self._longest_key, len(key))
-        self._dict.__setitem__(key, value)
+        self._dict[key] = value
         self.reverse[value].append(key)
         # Case-insensitive reverse dict
         self.casereverse[value.lower()].add(value)
 
     def __delitem__(self, key):
-        value = self._dict[key]
+        value = self._dict.pop(key)
         self.reverse[value].remove(key)
-        self._dict.__delitem__(key)
         if len(key) == self.longest_key:
             if self._dict:
                 self._longest_key = max(len(x) for x in self._dict.iterkeys())
@@ -67,10 +66,9 @@ class StenoDictionary(collections.MutableMapping):
                 self._longest_key = 0
 
     def __contains__(self, key):
-        contained = self._dict.__contains__(key)
-        if not contained:
+        value = self._dict.get(key)
+        if value is None:
             return False
-        value = self._dict[key]
         for f in self.filters:
             if f(key, value):
                 return False
@@ -138,7 +136,7 @@ class StenoDictionaryCollection(object):
 
     def lookup(self, key):
         for d in self.dicts:
-            value = d.get(key, None)
+            value = d.get(key)
             if value:
                 for f in self.filters:
                     if f(key, value):
@@ -147,19 +145,19 @@ class StenoDictionaryCollection(object):
 
     def raw_lookup(self, key):
         for d in self.dicts:
-            value = d.get(key, None)
+            value = d.get(key)
             if value:
                 return value
 
     def reverse_lookup(self, value):
         for d in self.dicts:
-            key = d.reverse.get(value, None)
+            key = d.reverse.get(value)
             if key:
                 return key
 
     def casereverse_lookup(self, value):
         for d in self.dicts:
-            key = d.casereverse.get(value, None)
+            key = d.casereverse.get(value)
             if key:
                 return key
 

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -167,13 +167,19 @@ class StenoDictionaryCollection(object):
         if self.dicts:
             self.dicts[0][key] = value
 
-    def save(self):
-        if self.dicts:
-            self.dicts[0].save()
+    def save(self, path_list=None):
+        '''Save the dictionaries in <path_list>.
 
-    def save_all(self):
-        for dict in self.dicts:
-            dict.save()
+        If <path_list> is None, all writable dictionaries are saved'''
+        if path_list is None:
+            dict_list = [dictionary
+                         for dictionary in self.dicts
+                         if dictionary.save is not None]
+        else:
+            dict_list = [self.get_by_path(path)
+                         for path in path_list]
+        for dictionary in dict_list:
+            dictionary.save()
 
     def get_by_path(self, path):
         for d in self.dicts:


### PR DESCRIPTION
2 sets of changes:
* changes that I think should be part of the next release:
 - fix call to `util.SetTopApp`
 - change steno dictionary save API, so the dictionary editor can be made to only save back those dictionaries that have been modified (instead of always saving **all** dictionaries)
* preliminary changes for multilingual/plugins support (if deemed too risky, I'll rewrite the PR to remove those, and defer them after the release):
 - don't uppercase strokes in the add translation dialog or dictionary editor: some systems use lower case letters too (e.g. Italian)
 - better handle *read-only* dictionaries, i.e. if a dictionary's `save` field is `None`; this will be needed for proper support of Python dictionaries and dictionaries loaded directly from assets