### PR TITLE
Revert "output from machine thread"

### DIFF
--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -363,13 +363,13 @@ class Output(object):
         self.engine = engine
 
     def send_backspaces(self, b):
-        self.keyboard_control.send_backspaces(b)
+        wx.CallAfter(self.keyboard_control.send_backspaces, b)
 
     def send_string(self, t):
-        self.keyboard_control.send_string(t)
+        wx.CallAfter(self.keyboard_control.send_string, t)
 
     def send_key_combination(self, c):
-        self.keyboard_control.send_key_combination(c)
+        wx.CallAfter(self.keyboard_control.send_key_combination, c)
 
     # TODO: test all the commands now
     def send_engine_command(self, c):


### PR DESCRIPTION
### About

Turns out outputting from the machine thread doesn't work with bulk sending of key codes.

### Issues

Fixes #444 

This reverts commit 03a89bb62bef7834f5c696c00c326f2e83e012dc, reversing
changes made to 11d2a2fe6c5cc6dc428baf63e01d464af8ee88b6.
