### PR TITLE
setup: add 'launch' command and associated scripts

### DIFF
--- a/launch.bat
+++ b/launch.bat
@@ -1,0 +1,3 @@
+@pushd %~dp0
+python.exe setup.py launch -- %*
+@popd

--- a/launch.py
+++ b/launch.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
-from plover.main import main
-
-main()
-

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd "$(dirname "$(readlink -e "$0")")" &&
+exec ./setup.py launch -- "$@"

--- a/linux/README.md
+++ b/linux/README.md
@@ -39,7 +39,7 @@ Note: if your version of pip is too old, you may get parsing errors on the lines
 
 ## Running from source
 
-To run from source, use: `./launch.py`.
+To run from source, use: `./launch.sh`.
 
 ## Installing and running
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -28,7 +28,7 @@ Root doesn't need permission to use event taps,
 so during development, you can avoid this rigmarole by running Plover via:
 
 ```
-sudo python2 launch.py
+sudo ./launch.sh
 ```
 
 

--- a/plover/main.py
+++ b/plover/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013 Hesky Fisher
 # See LICENSE.txt for details.
 

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,27 @@ class BinaryDistWin(PyInstallerDist):
     ]
 
 
+class Launch(setuptools.Command):
+
+    description = 'run %s from source' % __software_name__.capitalize()
+    command_consumes_arguments = True
+    user_options = []
+
+    def initialize_options(self):
+        self.args = None
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        # Make sure metadata are up-to-date first.
+        self.run_command('egg_info')
+        reload(pkg_resources)
+        from plover.main import main
+        sys.argv = [' '.join(sys.argv[0:2]) + ' --'] + self.args
+        main()
+
+
 class PatchVersion(setuptools.Command):
 
     description = 'patch package version from VCS'
@@ -168,6 +189,7 @@ class BinaryDistApp(setuptools.Command):
 
 
 cmdclass = {
+    'launch': Launch,
     'patch_version': PatchVersion,
     'tag_weekly': TagWeekly,
 }
@@ -191,7 +213,7 @@ if sys.platform.startswith('darwin'):
             }
         }
     # Py2app will not look at entry_points.
-    kwargs['app'] = 'launch.py',
+    kwargs['app'] = 'plover/main.py',
     cmdclass['bdist_app'] = BinaryDistApp
 
 if sys.platform.startswith('win32'):

--- a/windows/README.md
+++ b/windows/README.md
@@ -31,7 +31,7 @@ Most dependencies can be retrieved with pip:
 
 ### Running Plover in development
 
-To run from source, from the root of the Git repository, use `python launch.py`.
+To run from source, from the root of the Git repository, use `launch.bat`.
 
 ### Building
 


### PR DESCRIPTION
Will make sure metadata is up-to-date before starting Plover, as running `python2 -m plover.main` without Plover installed results in an exception in `oslayer/config.py`:
```
pkg_resources.DistributionNotFound: The 'plover' distribution was not found and is required by the application
```
