### PR TITLE
move the Windows keyboard capture to its own process

### DIFF
--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -287,7 +287,6 @@ class MainFrame(wx.Frame):
             machine_name = machine_registry.resolve_alias(
                 self.config.get_machine_type())
             self.machine_status_text.SetLabel('%s: %s' % (machine_name, state))
-            self.reconnect_button.Show(state == STATE_ERROR)
             self.spinner.Show(state == STATE_INITIALIZING)
             self.connection_ctrl.Show(state != STATE_INITIALIZING)
             if state == STATE_INITIALIZING:

--- a/plover/oslayer/keyboardcontrol.py
+++ b/plover/oslayer/keyboardcontrol.py
@@ -84,11 +84,7 @@ if __name__ == '__main__':
     kc.start()
     print 'Press CTRL-c to quit.'
     try:
-        if sys.platform.startswith('win32'):
-            while True:
-                pythoncom.PumpWaitingMessages()
-        else:
-            while True:
-                time.sleep(1)
+        while True:
+            time.sleep(1)
     except KeyboardInterrupt:
         kc.cancel()

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def pyinstaller(*args):
         '--onefile'
     ]
     py_args.extend(args)
-    py_args.append('plover/main.py')
+    py_args.append('windows/main.py')
     main = pkg_resources.load_entry_point('PyInstaller', 'console_scripts', 'pyinstaller')
     main(py_args)
 

--- a/windows/main.py
+++ b/windows/main.py
@@ -1,0 +1,45 @@
+
+import multiprocessing
+import os
+import sys
+
+
+# Module multiprocessing is organized differently in Python 3.4+
+try:
+    # Python 3.4+
+    if sys.platform.startswith('win'):
+        import multiprocessing.popen_spawn_win32 as forking
+    else:
+        import multiprocessing.popen_fork as forking
+except ImportError:
+    import multiprocessing.forking as forking
+
+if sys.platform.startswith('win'):
+    # First define a modified version of Popen.
+    class _Popen(forking.Popen):
+        def __init__(self, *args, **kw):
+            if hasattr(sys, 'frozen'):
+                # We have to set original _MEIPASS2 value from sys._MEIPASS
+                # to get --onefile mode working.
+                os.putenv('_MEIPASS2', sys._MEIPASS)
+            try:
+                super(_Popen, self).__init__(*args, **kw)
+            finally:
+                if hasattr(sys, 'frozen'):
+                    # On some platforms (e.g. AIX) 'os.unsetenv()' is not
+                    # available. In those cases we cannot delete the variable
+                    # but only set it to the empty string. The bootloader
+                    # can handle this case.
+                    if hasattr(os, 'unsetenv'):
+                        os.unsetenv('_MEIPASS2')
+                    else:
+                        os.putenv('_MEIPASS2', '')
+
+    # Second override 'Popen' class with our modified version.
+    forking.Popen = _Popen
+
+
+if __name__ == '__main__':
+    multiprocessing.freeze_support()
+    from plover.main import main
+    main()


### PR DESCRIPTION
This allow the use of `pythoncom.PumpWaitingMessages` without interfering with the GUI loop, and ensure the keyboard hook is run in a timely manner: no competition with other threads and captured key events are posted to queue without further processing. This fixes #454 on Windows.

Note: a custom main with a set of specific workarounds must be used for correct multi-processing support when using PyInstaller, especially with '--onefile'. See: https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Multiprocessing

Tested with a Windows 10 VM: the easiest way to reproduce the bug is to keep a key pressed during Plover startup.
