### PR TITLE
formatting: rework handling of actions 'replace'

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -95,7 +95,7 @@ class Formatter(object):
         rendered translations. If there is no context then this may be None.
 
         """
-        prev_formatting = prev.formatting if prev else None
+        prev_formatting = prev.formatting if prev else []
 
         for t in do:
             last_action = self._get_last_action(prev.formatting if prev else None)
@@ -110,10 +110,20 @@ class Formatter(object):
         old = [a for t in undo for a in t.formatting]
         new = [a for t in do for a in t.formatting]
 
+        min_length = min(len(old), len(new))
+        for i in xrange(min_length):
+            if old[i] != new[i]:
+                break
+        else:
+            i = min_length
+
         for callback in self._listeners:
             callback(old, new)
 
-        OutputHelper(self._output, prev_formatting).render(old, new)
+        if i > 0:
+            prev_formatting = prev_formatting + old[:i]
+
+        OutputHelper(self._output, prev_formatting).render(old[i:], new[i:])
 
     def _get_last_action(self, actions):
         """Return last action in actions if possible or return a default action."""

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -95,6 +95,8 @@ class Formatter(object):
         rendered translations. If there is no context then this may be None.
 
         """
+        prev_formatting = prev.formatting if prev else None
+
         for t in do:
             last_action = self._get_last_action(prev.formatting if prev else None)
             if t.english:
@@ -108,17 +110,10 @@ class Formatter(object):
         old = [a for t in undo for a in t.formatting]
         new = [a for t in do for a in t.formatting]
 
-        min_length = min(len(old), len(new))
-        for i in xrange(min_length):
-            if old[i] != new[i]:
-                break
-        else:
-            i = min_length
-
         for callback in self._listeners:
             callback(old, new)
 
-        OutputHelper(self._output).render(old[i:], new[i:])
+        OutputHelper(self._output, prev_formatting).render(old, new)
 
     def _get_last_action(self, actions):
         """Return last action in actions if possible or return a default action."""
@@ -134,9 +129,13 @@ class OutputHelper(object):
     optimizes away extra backspaces and typing.
 
     """
-    def __init__(self, output):
-        self.before = ''
-        self.after = ''
+    def __init__(self, output, initial_state=None):
+        if initial_state is None:
+            self.before = ''
+            self.after = ''
+        else:
+            self.before = self._actions_to_text(initial_state)
+            self.after = self.before[:]
         self.output = output
 
     def commit(self):
@@ -154,32 +153,22 @@ class OutputHelper(object):
         self.before = ''
         self.after = ''
 
+    @staticmethod
+    def _actions_to_text(action_list):
+        text = u''
+        for a in action_list:
+            if a.replace and text.endswith(a.replace):
+                text = text[:-len(a.replace)]
+            if a.text:
+                text += a.text
+        return text
+
     def render(self, undo, do):
-        for a in undo:
-            if a.replace:
-                if len(a.replace) >= len(self.before):
-                    self.before = ''
-                else:
-                    self.before = self.before[:-len(a.replace)]
-            if a.text:
-                self.before += a.text
-
-        self.after = self.before
-
-        for a in reversed(undo):
-            if a.text:
-                self.after = self.after[:-len(a.text)]
-            if a.replace:
-                self.after += a.replace
+        self.before += self._actions_to_text(undo)
 
         for a in do:
-            if a.replace:
-                if len(a.replace) > len(self.after):
-                    self.before = a.replace[
-                        :len(a.replace)-len(self.after)] + self.before
-                    self.after = ''
-                else:
-                    self.after = self.after[:-len(a.replace)]
+            if a.replace and self.after.endswith(a.replace):
+                self.after = self.after[:-len(a.replace)]
             if a.text:
                 self.after += a.text
             if a.combo:

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -164,8 +164,7 @@ class OutputHelper(object):
         self.after = ''
 
     @staticmethod
-    def _actions_to_text(action_list):
-        text = u''
+    def _actions_to_text(action_list, text=u''):
         for a in action_list:
             if a.replace and text.endswith(a.replace):
                 text = text[:-len(a.replace)]
@@ -174,7 +173,7 @@ class OutputHelper(object):
         return text
 
     def render(self, undo, do):
-        self.before += self._actions_to_text(undo)
+        self.before = self._actions_to_text(undo, self.before)
 
         for a in do:
             if a.replace and self.after.endswith(a.replace):

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1125,5 +1125,36 @@ class FormatterTestCase(unittest.TestCase):
                 prev = t
             self.assertEqual(output.instructions, expected_instructions)
 
+    def test_output_optimisation(self):
+        for undo, do, expected_instructions in (
+            # No change.
+            ([
+                translation(english='noop'),
+            ], [
+                translation(english='noop'),
+
+            ], [('s', ' noop')]),
+            # Append only.
+            ([
+                translation(english='test'),
+            ], [
+                translation(english='testing'),
+
+            ], [('s', ' test'), ('s', 'ing')]),
+            # Chained meta-commands.
+            ([
+                translation(english='{#a}'),
+            ], [
+                translation(english='{#a}{#b}'),
+
+            ], [('c', 'a'), ('c', 'b')]),
+        ):
+            output = CaptureOutput()
+            formatter = formatting.Formatter()
+            formatter.set_output(output)
+            formatter.format([], undo, None)
+            formatter.format(undo, do, None)
+            self.assertEqual(output.instructions, expected_instructions)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1099,21 +1099,21 @@ class FormatterTestCase(unittest.TestCase):
                 translation(english='foobar'),
                 translation(english='{^}{#Return}{^}{-|}'),
 
-            ], [('s', u'foobar'), ('c', 'Return')]),
+            ], [('s', 'foobar'), ('c', 'Return')]),
             # Check 'replace' correctly takes into account
             # the previous translation.
             ([
                 translation(english='test '),
                 translation(english='{^,}'),
 
-            ], [('s', 'test '), ('b', 1), ('s', u', ')]),
+            ], [('s', 'test '), ('b', 1), ('s', ', ')]),
             # While the previous translation must be taken into account,
             # any meta-command must not be fired again.
             ([
                 translation(english='{#Return}'),
                 translation(english='test'),
 
-            ], [('c', 'Return'), ('s', u'test ')]),
+            ], [('c', 'Return'), ('s', 'test ')]),
         ):
             output = CaptureOutput()
             formatter = formatting.Formatter()
@@ -1124,6 +1124,22 @@ class FormatterTestCase(unittest.TestCase):
                 formatter.format([], [t], prev)
                 prev = t
             self.assertEqual(output.instructions, expected_instructions)
+
+    def test_undo_replace(self):
+            # Undoing a replace....
+            output = CaptureOutput()
+            formatter = formatting.Formatter()
+            formatter.set_output(output)
+            formatter.set_space_placement('After Output')
+            prev = translation(english='test')
+            formatter.format([], [prev], None)
+            undo = translation(english='{^,}')
+            formatter.format([], [undo], prev)
+            # Undo.
+            formatter.format([undo], [], prev)
+            self.assertEqual(output.instructions, [
+                ('s', 'test '), ('b', 1), ('s', ', '), ('b', 2), ('s', ' '),
+            ])
 
     def test_output_optimisation(self):
         for undo, do, expected_instructions in (


### PR DESCRIPTION
Don't honor `replace` if it does not match at the end of the previous
text. 

This is done by providing the previous translation formatting to the `OutputHelper` class so it can render the initial text (so the matching actually be done when the first undo/to translation action uses `replace`).

This fixes #476.

