### PR TITLE
Ubuntu related tweaks

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -17,11 +17,13 @@ All dependencies can be installed with pacman:
 
 ### Ubuntu
 
-Most dependencies can be installed with APT:
+The latest stable release should be installable by the using the following PPA: [ppa:benoit.pierre/plover](https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover).
+
+For the development version, most dependencies can be installed with APT:
 
 `sudo apt-get install cython libusb-1.0-0-dev libudev-dev python-appdirs python-mock python-pip python-pytest python-serial python-setuptools python-wxgtk3.0 python-xlib wmctrl`
 
-Note: `python-wxgtk3.0` is only available starting with Ubuntu 15.10 (Wily Werewolf). It can be installed on older versions, like Ubuntu 14.04 LTS (Trusty Tahr), by using the following PPA: `ppa:adamwolf/kicad-trusty-backports`.
+Note: `python-wxgtk3.0` is only available starting with Ubuntu 15.10 (Wily Werewolf). It can be installed on older versions, like Ubuntu 14.04 LTS (Trusty Tahr), by using the aforementioned PPA: [ppa:benoit.pierre/plover](https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover).
 
 For the missing dependencies, follow the generic procedure.
 

--- a/setup.py
+++ b/setup.py
@@ -266,8 +266,8 @@ setup_requires.append('pytest')
 
 install_requires = [
     'setuptools',
-    'pyserial>=2.7',
-    'appdirs>=1.4.0',
+    'pyserial>=2.6',
+    'appdirs>=1.3.0',
     'hidapi',
 ]
 

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -23,7 +23,13 @@ def get_metadata(distribution):
     if metadata is None:
         metadata = '%s/%s' % (distribution.location, egg_info)
         if not os.path.exists(metadata):
-            return None
+            metadata = '%s/%s-%s.egg-info' % (
+                distribution.location,
+                pkg_resources.to_filename(distribution.project_name),
+                pkg_resources.to_filename(distribution.version),
+            )
+            if not os.path.exists(metadata):
+                return None
     return (metadata, egg_info)
 
 def collect_metadata(distribution):


### PR DESCRIPTION
I created some Ubuntu packages, PPA here: https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover

I had to tweak `utils/metadata` and relax the version requirements for `appdirs` and `pyserial` to support Ubuntu 14.04 LTS (Trusty).

I also backported `wxpython3.0` to this PPA, and so updated `linux/README.md` to use it, this way only one extra PPA needs to be configured.