### PR TITLE
support embedded \n \r \t in translations

### DIFF
--- a/plover/dictionary_editor_store.py
+++ b/plover/dictionary_editor_store.py
@@ -1,5 +1,6 @@
 from plover.steno import normalize_steno
 from plover.gui.util import shorten_unicode
+from plover.translation import escape_translation, unescape_translation
 
 STROKE = "STROKE"
 TRANSLATION = "TRANSLATION"
@@ -58,7 +59,7 @@ class DictionaryEditorStore():
             for dk, translation in dictionary.iteritems():
                 joined = '/'.join(dk)
                 item = DictionaryItem(joined,
-                                      translation,
+                                      escape_translation(translation),
                                       dictionary,
                                       item_id)
                 self.all_keys.append(item)
@@ -145,13 +146,13 @@ class DictionaryEditorStore():
 
         # Creates
         for item in self.added_items:
-            item.dictionary[normalize_steno(item.stroke)] = item.translation
+            item.dictionary[normalize_steno(item.stroke)] = unescape_translation(item.translation)
             needs_saving.add(item.dictionary.get_path())
 
         # Updates
         for item_id in self.modified_items:
             item = self.all_keys[item_id]
-            item.dictionary[normalize_steno(item.stroke)] = item.translation
+            item.dictionary[normalize_steno(item.stroke)] = unescape_translation(item.translation)
             needs_saving.add(item.dictionary.get_path())
 
         # Deletes

--- a/plover/gui/add_translation.py
+++ b/plover/gui/add_translation.py
@@ -3,8 +3,11 @@
 
 import wx
 from wx.lib.utils import AdjustRectToScreen
+
 from plover.steno import normalize_steno
 import plover.gui.util as util
+from plover.translation import escape_translation, unescape_translation
+
 
 TITLE = 'Plover: Add Translation'
 
@@ -132,7 +135,7 @@ class AddTranslationDialog(wx.Dialog):
         strokes = self._normalized_strokes()
         translation = self.translation_text.GetValue().strip()
         if strokes and translation:
-            d.set(strokes, translation)
+            d.set(strokes, unescape_translation(translation))
             d.save(path_list=(d.dicts[0].get_path(),))
         self.Close()
 
@@ -153,7 +156,7 @@ class AddTranslationDialog(wx.Dialog):
             translation = d.raw_lookup(key)
             strokes = '/'.join(key)
             if translation:
-                label = '%s maps to %s' % (strokes, translation)
+                label = '%s maps to %s' % (strokes, escape_translation(translation))
             else:
                 label = '%s is not in the dictionary' % strokes
             label = util.shorten_unicode(label)
@@ -168,7 +171,7 @@ class AddTranslationDialog(wx.Dialog):
         translation = event.GetString().strip()
         if translation:
             d = self.engine.get_dictionary()
-            strokes_list = d.reverse_lookup(translation)
+            strokes_list = d.reverse_lookup(unescape_translation(translation))
             if strokes_list:
                 strokes = ', '.join('/'.join(x) for x in strokes_list)
                 label = '%s is mapped from %s' % (translation, strokes)

--- a/plover/gui/lookup.py
+++ b/plover/gui/lookup.py
@@ -3,8 +3,11 @@
 
 import wx
 from wx.lib.utils import AdjustRectToScreen
+
 from plover.steno import normalize_steno
 import plover.gui.util as util
+from plover.translation import unescape_translation
+
 
 TITLE = 'Plover: Lookup'
 
@@ -109,7 +112,7 @@ class LookupDialog(wx.Dialog):
         self.listbox.Clear()
         if translation:
             d = self.engine.get_dictionary()
-            strokes_list = d.reverse_lookup(translation)
+            strokes_list = d.reverse_lookup(unescape_translation(translation))
             if strokes_list:
                 entries = ('/'.join(x) for x in strokes_list)
                 for str in entries:

--- a/plover/oslayer/mac_keycode.py
+++ b/plover/oslayer/mac_keycode.py
@@ -160,6 +160,10 @@ def parselayout(buf, ktype):
             mapping.setdefault(ch, ((dj, dmod), (j, mod)))
             revmapping[(dj, dmod), (j, mod)] = ch
 
+    mapping[u'\n'] = (36, 0)
+    mapping[u'\r'] = (36, 0)
+    mapping[u'\t'] = (48, 0)
+
     return mapping, revmapping, modmapping
 
 def getlayout():

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1062,6 +1062,10 @@ def uchr_to_keysym(char):
     # Latin-1 characters: direct, 1:1 mapping.
     if is_latin1(code):
         return code
+    if 0x09 == code:
+        return XK.XK_Tab
+    if 0x0a == code or 0x0d == code:
+        return XK.XK_Return
     return UCS_TO_KEYSYM.get(code, code | 0x01000000)
 
 def keysym_to_string(keysym):

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -18,10 +18,38 @@ emits one or more Translation objects based on a greedy conversion algorithm.
 
 import itertools
 import sys
+import re
 
 from plover.steno import Stroke
 from plover.steno_dictionary import StenoDictionaryCollection
 from plover import system
+
+
+_ESCAPE_RX = re.compile('(\\\\[nrt]|[\n\r\t])')
+_ESCAPE_REPLACEMENTS = {
+    '\n': r'\n',
+    '\r': r'\r',
+    '\t': r'\t',
+    r'\n': r'\\n',
+    r'\r': r'\\r',
+    r'\t': r'\\t',
+}
+
+def escape_translation(translation):
+    return _ESCAPE_RX.sub(lambda m: _ESCAPE_REPLACEMENTS[m.group(0)], translation)
+
+_UNESCAPE_RX = re.compile(r'((?<!\\)|\\)\\([nrt])')
+_UNESCAPE_REPLACEMENTS = {
+    r'\\n': r'\n',
+    r'\\r': r'\r',
+    r'\\t': r'\t',
+    r'\n' : '\n',
+    r'\r' : '\r',
+    r'\t' : '\t',
+}
+
+def unescape_translation(translation):
+    return _UNESCAPE_RX.sub(lambda m: _UNESCAPE_REPLACEMENTS[m.group(0)], translation)
 
 
 class Translation(object):


### PR DESCRIPTION
It turns out that we already support a kind of undo-able return (at least on Windows): manually editing the JSON dictionary to change "{^}{#Return}{^}{-|}" to "{^\n^}{-|}" work. It's however not possible to add such an entry through Plover's GUI, and Linux and Mac OS X don't handle those embedded \n \r \t, which is what this PR is about.

Linux and OS X respective implementations have been fixed, and two helpers have been added to the `translation` module: `escape_translation` and `unescape_translation`:

* `escape_translation` is used when displaying a translation to the user (lookup / add translation dialogs...)
* `unescape_translation` is used on the user input (add translation dialog), to get the raw translation

Note:

1. the special case: `r'\\n' -> r'\n'`, so a literal "\n" can be entered (same for \t \r, but elsewhere `r'\\'` is left unchanged)
1. naively replacing "{^}{#Return}{^}{-|}" by "{^}\n{^}{-|}" will not work, as translations atoms are stripped
1. this does not change the format of the dictionaries in anyway
1. in the RTF/CRE dictionary, `r'\\\r|\\\n'` is replaced by `'{#Return}{#Return}'`, should this be replaced by `'{\n}'`? (Also why 2 returns?)
1. missing from this PR: I'm going to update the dictionary editor too
