### PR TITLE
fix for PyPI release

### DIFF
--- a/osx/makefile
+++ b/osx/makefile
@@ -7,9 +7,9 @@ builddir = $(topdir)/build
 distdir = $(topdir)/dist
 
 VER := $(shell cd $(topdir) && $(PYTHON) setup.py --version)
-TMP_APP := $(distdir)/Plover.app
-APP := $(distdir)/Plover-$(VER).app
-DMG := $(distdir)/Plover-$(VER).dmg
+TMP_APP := $(distdir)/plover.app
+APP := $(distdir)/plover-$(VER).app
+DMG := $(distdir)/plover-$(VER).dmg
 
 .PHONY: all app dmg clean
 
@@ -28,8 +28,8 @@ $(DMG): $(APP)
 	hdiutil resize -size 100m tmp/plover_template.dmg 
 	mkdir tmp/plover_mountpoint
 	hdiutil attach tmp/plover_template.dmg -noautoopen -quiet -mountpoint tmp/plover_mountpoint
-	rm -rf tmp/plover_mountpoint/Plover.app
-	ditto $(APP) tmp/plover_mountpoint/Plover.app
+	rm -rf tmp/plover_mountpoint/plover.app
+	ditto $(APP) tmp/plover_mountpoint/plover.app
 	hdiutil detach $$(hdiutil info | grep plover_mountpoint | grep Apple_HFS | cut -f1)
 	rmdir tmp/plover_mountpoint
 	hdiutil convert tmp/plover_template.dmg -format UDZO -imagekey zlib-level=9 -o $(DMG)

--- a/plover/__init__.py
+++ b/plover/__init__.py
@@ -15,7 +15,7 @@ __credits__ = ['Founded by stenographer Mirabai Knight.\n\nDevelopers:'
                '\nand many more on GitHub: \n<https://github.com/openstenoproject/plover>'
                ]
 __license__ = 'GNU General Public License, version 2'
-__description__ = 'Open Source Stenography Software',
+__description__ = 'Open Source Stenography Software'
 __long_description__ = """\
 Plover is a free open source program intended to bring realtime
 stenographic technology not just to stenographers, but also to

--- a/setup.py
+++ b/setup.py
@@ -348,6 +348,7 @@ if __name__ == '__main__':
         ],
         platforms=[
             'Operating System :: POSIX :: Linux',
+            'Operating System :: MacOS :: MacOS X',
             'Operating System :: Microsoft :: Windows',
         ],
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ def write_requirements(extra_features=()):
 
 if __name__ == '__main__':
 
-    if sys.argv[1] == 'write_requirements':
+    if len(sys.argv) > 1 and sys.argv[1] == 'write_requirements':
         write_requirements(extra_features=sys.argv[2:])
         sys.exit(0)
 

--- a/setup.py
+++ b/setup.py
@@ -346,11 +346,6 @@ if __name__ == '__main__':
             ('share/applications', ['application/Plover.desktop']),
             ('share/pixmaps', ['plover/assets/plover.png']),
         ],
-        platforms=[
-            'Operating System :: POSIX :: Linux',
-            'Operating System :: MacOS :: MacOS X',
-            'Operating System :: Microsoft :: Windows',
-        ],
         classifiers=[
             'Programming Language :: Python',
             'License :: OSI Approved :: GNU General Public License (GPL)',
@@ -359,6 +354,8 @@ if __name__ == '__main__':
             'Intended Audience :: End Users/Desktop',
             'Natural Language :: English',
             'Operating System :: POSIX :: Linux',
+            'Operating System :: MacOS :: MacOS X',
+            'Operating System :: Microsoft :: Windows',
             'Topic :: Adaptive Technologies',
             'Topic :: Desktop Environment',
         ],

--- a/setup.py
+++ b/setup.py
@@ -347,10 +347,12 @@ if __name__ == '__main__':
             ('share/pixmaps', ['plover/assets/plover.png']),
         ],
         classifiers=[
-            'Programming Language :: Python',
+            'Programming Language :: Python :: 2.7',
             'License :: OSI Approved :: GNU General Public License (GPL)',
             'Development Status :: 4 - Beta',
             'Environment :: X11 Applications',
+            'Environment :: MacOS X',
+            'Environment :: Win32 (MS Windows)',
             'Intended Audience :: End Users/Desktop',
             'Natural Language :: English',
             'Operating System :: POSIX :: Linux',

--- a/setup.py
+++ b/setup.py
@@ -349,7 +349,7 @@ if __name__ == '__main__':
         classifiers=[
             'Programming Language :: Python :: 2.7',
             'License :: OSI Approved :: GNU General Public License (GPL)',
-            'Development Status :: 4 - Beta',
+            'Development Status :: 5 - Production/Stable',
             'Environment :: X11 Applications',
             'Environment :: MacOS X',
             'Environment :: Win32 (MS Windows)',

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ from plover import (
 from utils.metadata import copy_metadata
 
 
-package_name = __software_name__.capitalize()
-
-
 def get_version():
     if not os.path.exists('.git'):
         return None
@@ -48,7 +45,7 @@ def pyinstaller(*args):
         '--additional-hooks-dir=windows',
         '--paths=.',
         '--name=%s-%s' % (
-            __software_name__.capitalize(),
+            __software_name__,
             __version__,
         ),
         '--noconfirm',
@@ -207,12 +204,12 @@ class BinaryDistApp(setuptools.Command):
         # Make sure metadata are up-to-date first.
         self.run_command('egg_info')
         self.run_command('py2app')
-        app = 'dist/%s-%s.app' % (package_name, __version__)
+        app = 'dist/%s-%s.app' % (__software_name__, __version__)
         libdir = '%s/Contents/Resources/lib/python2.7' % app
         sitezip = '%s/site-packages.zip' % libdir
         # Add version to filename and strip other architectures.
         # (using py2app --arch is not enough).
-        tmp_app = 'dist/%s.app' % package_name
+        tmp_app = 'dist/%s.app' % __software_name__
         cmd = 'ditto --arch x86_64 %s %s' % (tmp_app, app)
         log.info('running %s', cmd)
         subprocess.check_call(cmd.split())
@@ -246,7 +243,7 @@ if sys.platform.startswith('darwin'):
         'argv_emulation': False,
         'iconfile': 'osx/plover.icns',
         'plist': {
-            'CFBundleName': package_name,
+            'CFBundleName': __software_name__.capitalize(),
             'CFBundleShortVersionString': __version__,
             'CFBundleVersion': __version__,
             'CFBundleIdentifier': 'org.openstenoproject.plover',
@@ -315,7 +312,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     setuptools.setup(
-        name=package_name,
+        name=__software_name__,
         version=__version__,
         description=__description__,
         long_description=__long_description__,

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ install_requires = [
 
 extras_require = {
     ':"win32" in sys_platform': [
-        'pyhook>=1.5.1',
+        'pyHook>=1.5.1',
         'pywin32>=219',
         # Can't reliably require wxPython
     ],

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -23,16 +23,6 @@ sys.path.insert(0, TOP_DIR)
 os.chdir(TOP_DIR)
 
 
-from plover import (
-    __name__ as __software_name__,
-    __version__,
-)
-
-APPNAME = __software_name__.capitalize()
-VERSION = __version__
-ICON = os.path.join(TOP_DIR, __software_name__, 'assets', '%s.ico' % __software_name__)
-
-
 if sys.stdout.isatty() and not sys.platform.startswith('win32'):
 
     def info(fmt, *args):

--- a/windows/hook-plover.py
+++ b/windows/hook-plover.py
@@ -13,7 +13,7 @@ datas = []
 hiddenimports = []
 
 distribution = list(pkg_resources.find_distributions('.', only=True))[0]
-assert distribution.project_name == 'Plover'
+assert distribution.project_name == 'plover'
 
 metadata_list = collect_metadata(distribution)
 log.info('adding metadata: %s', metadata_list)


### PR DESCRIPTION
I had to change back the project name to lower case, to match the existing name used on PyPI.

Note to devs: make sure to delete `Plover.egg-info` from you tree to avoid duplicate distributions info.