### PR TITLE
oslayer/winkeyboardcontrol: don't use pyHook anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,6 @@ install_requires = [
 
 extras_require = {
     ':"win32" in sys_platform': [
-        'pyHook>=1.5.1',
         'pywin32>=219',
         # Can't reliably require wxPython
     ],

--- a/windows/README.md
+++ b/windows/README.md
@@ -19,7 +19,6 @@ It is best to develop using 32 bit tools for Plover.
 - [Cython](http://cython.org/)
 - [Microsoft Visual C++ Compiler for Python 2.7](https://www.microsoft.com/en-us/download/details.aspx?id=44266)
 - [Python for Windows Extensions](http://sourceforge.net/projects/pywin32/)
-- [pyHook](http://sourceforge.net/projects/pyhook/)
 - [wxPython](http://www.wxpython.org/)
 
 #### Other dependencies

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -264,8 +264,6 @@ class Helper(object):
     DEPENDENCIES = (
         # Note: we force the installation directory, otherwise the installer gets confused when run under AppVeyor, and installs in the wrong directory...
         ('wxPython'         , 'http://downloads.sourceforge.net/wxpython/wxPython3.0-win32-3.0.2.0-py27.exe'                                      , '864d44e418a0859cabff71614a495bea57738c5d', None, ('/SP-', '/VERYSILENT', '/DIR=%s' % SITE_DIR), None),
-        # Note: '--always-unzip' is needed, as pyHook cannot work from a single egg file.
-        ('pyhook'           , 'http://downloads.sourceforge.net/project/pyhook/pyhook/1.5.1/pyHook-1.5.1.win32-py2.7.exe'                         , '9afb7a5b2858a69c6b0f6d2cb1b2eb2a3f4183d2', 'easy_install', ('--always-unzip',), None),
         ('pywin32'          , 'http://downloads.sourceforge.net/project/pywin32/pywin32/Build 219/pywin32-219.win32-py2.7.exe'                    , '8bc39008383c646bed01942584117113ddaefe6b', 'easy_install', (), None),
         ('Cython'           , 'https://pypi.python.org/packages/2.7/C/Cython/Cython-0.23.4-cp27-none-win32.whl'                                   , 'd7c1978fe2037674b151622158881c700ac2f06a', None, (), None),
         ('VC for Python'    , 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi'              , '7800d037ba962f288f9b952001106d35ef57befe', None, (), None),


### PR DESCRIPTION
This was originally done to make Python 3 support easier (no official Python 3 builds for PyHook), but turn out it also fixes #477, so...

Tested with a Windows 10 VM.