### PR TITLE
Fix insertion of implicit hyphen in normalize steno

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -17,11 +17,13 @@ All dependencies can be installed with pacman:
 
 ### Ubuntu
 
-Most dependencies can be installed with APT:
+The latest stable release should be installable by the using the following PPA: [ppa:benoit.pierre/plover](https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover).
+
+For the development version, most dependencies can be installed with APT:
 
 `sudo apt-get install cython libusb-1.0-0-dev libudev-dev python-appdirs python-mock python-pip python-pytest python-serial python-setuptools python-wxgtk3.0 python-xlib wmctrl`
 
-Note: `python-wxgtk3.0` is only available starting with Ubuntu 15.10 (Wily Werewolf). It can be installed on older versions, like Ubuntu 14.04 LTS (Trusty Tahr), by using the following PPA: `ppa:adamwolf/kicad-trusty-backports`.
+Note: `python-wxgtk3.0` is only available starting with Ubuntu 15.10 (Wily Werewolf). It can be installed on older versions, like Ubuntu 14.04 LTS (Trusty Tahr), by using the aforementioned PPA: [ppa:benoit.pierre/plover](https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover).
 
 For the missing dependencies, follow the generic procedure.
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -49,7 +49,7 @@ To run from source, use: `./launch.sh`.
 
 A self-contained executable egg can be created with: `./setup.py bdist_egg`. The egg will be created in `dist`, `chmod +x` it and you can run Plover directly from it:
 
-`chmod +x dist/Plover-2.5.8-py2.7.egg && ./dist/Plover-2.5.8-py2.7.egg`
+`chmod +x dist/Plover-3.0.0-py2.7.egg && ./dist/Plover-3.0.0-py2.7.egg`
 
 Note: the egg file can be moved, but it cannot however be renamed (as the package version is encoded in the name).
 
@@ -57,7 +57,7 @@ Note: the egg file can be moved, but it cannot however be renamed (as the packag
 
 A wheel file can be created with: `./setup.py bdist_wheel`. The resulting file can then be installed using pip, e.g. for a user install:
 
-`pip2 install dist/Plover-2.5.8-py2-none-any.whl`
+`pip2 install dist/Plover-3.0.0-py2-none-any.whl`
 
 ### Using `setup.py`
 

--- a/plover/__init__.py
+++ b/plover/__init__.py
@@ -3,7 +3,7 @@
 
 """Plover: Open Source Stenography Software"""
 
-__version__ = '2.5.8'
+__version__ = '3.0.0'
 __copyright__ = '(C) Open Steno Project'
 __url__ = 'http://www.openstenoproject.org/'
 __download_url__ = 'http://www.openstenoproject.org/plover'

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -29,7 +29,7 @@ def normalize_steno(strokes_string):
             if not re.search('[0-9]', stroke):
                 stroke = system.NUMBER_KEY + stroke
         # Insert dash when dealing with 'explicit' numbers
-        if re.search('[1-4][6-9]', stroke):
+        if re.search('(^|[1-4])[6-9]', stroke):
             start = re.search('[6-9]', stroke).start()
             stroke = stroke[:start] + '-' + stroke[start:]
         has_implicit_dash = bool(set(stroke) & system.IMPLICIT_HYPHENS)

--- a/setup.py
+++ b/setup.py
@@ -266,8 +266,8 @@ setup_requires.append('pytest')
 
 install_requires = [
     'setuptools',
-    'pyserial>=2.7',
-    'appdirs>=1.4.0',
+    'pyserial>=2.6',
+    'appdirs>=1.3.0',
     'hidapi',
 ]
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1090,5 +1090,87 @@ class FormatterTestCase(unittest.TestCase):
                  ('word.', 'word.')]
         self.check(formatting._rightmost_word, cases)
 
+    def test_replace(self):
+        for translations, expected_instructions in (
+            # Check that 'replace' does not unconditionally erase
+            # the previous character if it does not match.
+            ([
+                translation(english='{MODE:SET_SPACE:}'),
+                translation(english='foobar'),
+                translation(english='{^}{#Return}{^}{-|}'),
+
+            ], [('s', 'foobar'), ('c', 'Return')]),
+            # Check 'replace' correctly takes into account
+            # the previous translation.
+            ([
+                translation(english='test '),
+                translation(english='{^,}'),
+
+            ], [('s', 'test '), ('b', 1), ('s', ', ')]),
+            # While the previous translation must be taken into account,
+            # any meta-command must not be fired again.
+            ([
+                translation(english='{#Return}'),
+                translation(english='test'),
+
+            ], [('c', 'Return'), ('s', 'test ')]),
+        ):
+            output = CaptureOutput()
+            formatter = formatting.Formatter()
+            formatter.set_output(output)
+            formatter.set_space_placement('After Output')
+            prev = None
+            for t in translations:
+                formatter.format([], [t], prev)
+                prev = t
+            self.assertEqual(output.instructions, expected_instructions)
+
+    def test_undo_replace(self):
+            # Undoing a replace....
+            output = CaptureOutput()
+            formatter = formatting.Formatter()
+            formatter.set_output(output)
+            formatter.set_space_placement('After Output')
+            prev = translation(english='test')
+            formatter.format([], [prev], None)
+            undo = translation(english='{^,}')
+            formatter.format([], [undo], prev)
+            # Undo.
+            formatter.format([undo], [], prev)
+            self.assertEqual(output.instructions, [
+                ('s', 'test '), ('b', 1), ('s', ', '), ('b', 2), ('s', ' '),
+            ])
+
+    def test_output_optimisation(self):
+        for undo, do, expected_instructions in (
+            # No change.
+            ([
+                translation(english='noop'),
+            ], [
+                translation(english='noop'),
+
+            ], [('s', ' noop')]),
+            # Append only.
+            ([
+                translation(english='test'),
+            ], [
+                translation(english='testing'),
+
+            ], [('s', ' test'), ('s', 'ing')]),
+            # Chained meta-commands.
+            ([
+                translation(english='{#a}'),
+            ], [
+                translation(english='{#a}{#b}'),
+
+            ], [('c', 'a'), ('c', 'b')]),
+        ):
+            output = CaptureOutput()
+            formatter = formatting.Formatter()
+            formatter.set_output(output)
+            formatter.format([], undo, None)
+            formatter.format(undo, do, None)
+            self.assertEqual(output.instructions, expected_instructions)
+
 if __name__ == '__main__':
     unittest.main()

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -23,7 +23,13 @@ def get_metadata(distribution):
     if metadata is None:
         metadata = '%s/%s' % (distribution.location, egg_info)
         if not os.path.exists(metadata):
-            return None
+            metadata = '%s/%s-%s.egg-info' % (
+                distribution.location,
+                pkg_resources.to_filename(distribution.project_name),
+                pkg_resources.to_filename(distribution.version),
+            )
+            if not os.path.exists(metadata):
+                return None
     return (metadata, egg_info)
 
 def collect_metadata(distribution):


### PR DESCRIPTION
Fix #490, essentially the user can now define a stroke with 6-9 in it as strokes and normalize steno will interpret the stroke as `-6` through `-9` as is proper.