### PR TITLE
Avoid exceptions while retro delete spacing undefined entries

### DIFF
--- a/plover/translation.py
+++ b/plover/translation.py
@@ -313,9 +313,9 @@ class Translator(object):
             english = []
             for t in replaced:
                 for r in t.replaced:
-                    english.append(r.english)
+                    english.append(r.english or r.rtfcre[0])
             if len(english) > 0:
-                english.append(self._lookup([lookup_stroke]))
+                english.append(self._lookup([lookup_stroke]) or lookup_stroke.rtfcre)
                 t = Translation([stroke], ' '.join(english))
                 t.replaced = replaced
                 t.is_retrospective_command = True

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -621,6 +621,24 @@ class TranslateStrokeTestCase(unittest.TestCase):
         self.assertTranslations(do)
         self.assertOutput(undo, do, None)
 
+    def test_retrospective_insert_space_undefined(self):
+        # Should work when beginning or ending strokes aren't defined
+        self.define('T/E/S/T', 'a longer key')
+        self.define('STWR/STWR', 'test')
+        self.define('SP*', '{*?}')
+        self.translate(stroke('STWR'))
+        self.translate(stroke('STWR'))
+        self.translate(stroke('SP*'))
+        lt = self.lt('STWR')
+        undo = self.lt('STWR/STWR')
+        undo[0].replaced = lt
+        do = self.lt('SP*')
+        do[0].english = 'STWR STWR'
+        do[0].is_retrospective_command = True
+        do[0].replaced = undo
+        self.assertTranslations(do)
+        self.assertOutput(undo, do, None)
+
     def test_retrospective_delete_space(self):
         self.define('T/E/S/T', 'a longer key')
         self.define('K', 'kick')


### PR DESCRIPTION
Fix #496 by just outputting raw if the translation isn't defined.

Note that this is pretty workaround worthy. Retro-delete-space won't be useful in the example given in the issue because the final TEPL won't be composable into future stroke. However, that just the nature of how RDS was implemented.