### PR TITLE
Add display configuration to start Plover minimized

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -40,6 +40,10 @@ DEFAULT_ENABLE_STROKE_LOGGING = False
 ENABLE_TRANSLATION_LOGGING_OPTION = 'enable_translation_logging'
 DEFAULT_ENABLE_TRANSLATION_LOGGING = False
 
+STARTUP_SECTION = 'Startup'
+START_MINIMIZED_OPTION = 'Start Minimized'
+DEFAULT_START_MINIMIZED = False
+
 STROKE_DISPLAY_SECTION = 'Stroke Display'
 STROKE_DISPLAY_SHOW_OPTION = 'show'
 DEFAULT_STROKE_DISPLAY_SHOW = False
@@ -289,6 +293,13 @@ class Config(object):
     def get_auto_start(self):
         return self._get_bool(MACHINE_CONFIG_SECTION, MACHINE_AUTO_START_OPTION, 
                               DEFAULT_MACHINE_AUTO_START)
+
+    def set_start_minimized(self, b):
+        self._set(STARTUP_SECTION, START_MINIMIZED_OPTION, b)
+
+    def get_start_minimized(self):
+        return self._get_bool(STARTUP_SECTION, START_MINIMIZED_OPTION,
+                              DEFAULT_START_MINIMIZED)
 
     def set_show_stroke_display(self, b):
         self._set(STROKE_DISPLAY_SECTION, STROKE_DISPLAY_SHOW_OPTION, b)

--- a/plover/gui/config.py
+++ b/plover/gui/config.py
@@ -462,6 +462,7 @@ class LoggingConfig(wx.Panel):
 
 class DisplayConfig(wx.Panel):
 
+    START_MINIMIZED_TEXT = "Start Plover minimized"
     SHOW_STROKES_TEXT = "Open stroke display on startup"
     SHOW_STROKES_BUTTON_TEXT = "Open stroke display"
     SHOW_SUGGESTIONS_TEXT = "Open stroke suggestions on startup"
@@ -482,6 +483,11 @@ class DisplayConfig(wx.Panel):
         self.config = config
         self.engine = engine
         sizer = wx.BoxSizer(wx.VERTICAL)
+
+        self.start_minimized = wx.CheckBox(self, label=self.START_MINIMIZED_TEXT)
+        self.start_minimized.SetValue(config.get_start_minimized())
+
+        sizer.Add(self.start_minimized, border=UI_BORDER, flag=wx.ALL)
 
         # SHOW STROKES:
         #  [ Open stroke display ]
@@ -585,10 +591,12 @@ class DisplayConfig(wx.Panel):
 
     def save(self):
         """Write all parameters to the config."""
+        should_start_minimized = self.start_minimized.GetValue()
         should_show_strokes = self.show_strokes.GetValue()
         should_show_suggestions = self.show_suggestions.GetValue()
         translation_opacity = self.\
             translation_opacity_slider.GetValue()
+        self.config.set_start_minimized(should_start_minimized)
         self.config.set_show_stroke_display(should_show_strokes)
         self.config.set_show_suggestions_display(should_show_suggestions)
         self.config.set_translation_frame_opacity(

--- a/plover/gui/main.py
+++ b/plover/gui/main.py
@@ -54,7 +54,13 @@ class PloverGUI(wx.App):
         from plover.gui import log as gui_log
         frame = MainFrame(self.config)
         self.SetTopWindow(frame)
+
+        osx = sys.platform.startswith('darwin')
+        if not osx:
+            frame.Iconize(self.config.get_start_minimized())
         frame.Show()
+        if osx:
+            frame.Iconize(self.config.get_start_minimized())
         return True
 
 


### PR DESCRIPTION
Fix #475, add config to start Plover minimized.

![Screenshot of the configuration option to start Plover minimized](https://cloud.githubusercontent.com/assets/5840970/15034173/e4c249e8-1240-11e6-8db2-2e240b6e3a90.png)
