### PR TITLE
oslayer/winkeyboardcontrol: fix support for embedded \n \r

### DIFF
--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -222,7 +222,7 @@ class WindowsKeyboardLayout:
         '}': 'braceright', '\\': 'backslash', '|': 'bar', ';': 'semicolon',
         ':': 'colon', '\'': 'apostrophe', '"': 'quotedbl', ',': 'comma',
         '<': 'less', '.': 'period', '>': 'greater', '/': 'slash',
-        '?': 'question', '\t': 'Tab', ' ': 'space'
+        '?': 'question', '\t': 'Tab', ' ': 'space', '\n': 'Return', '\r': 'Return',
     })
 
     def __init__(self, layout_id=None):


### PR DESCRIPTION
Using "{^\n^}" was not working in dialogs, fix that.