### PR TITLE
test: remove default mains

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,13 +5,16 @@
 
 import os.path
 import unittest
-from mock import patch
-from collections import namedtuple
 import os
-import plover.config as config
+from collections import namedtuple
 from cStringIO import StringIO
+
+from mock import patch
+
+import plover.config as config
 from plover.machine.registry import Registry
 from plover.oslayer.config import CONFIG_DIR
+
 
 class ConfigTestCase(unittest.TestCase):
 
@@ -251,6 +254,3 @@ class ConfigTestCase(unittest.TestCase):
                               for d, v in enumerate(filenames, start=1))
         self.assertEqual(f.getvalue(), 
                          '[%s]\n%s\n\n' % (section, value))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_default_dict.py
+++ b/test/test_default_dict.py
@@ -4,6 +4,7 @@
 import json
 import unittest
 
+
 DICT_NAMES = ['main.json',
               'commands.json',
               'user.json']

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -3,8 +3,10 @@
 
 """Unit tests for formatting.py."""
 
-from plover import formatting
 import unittest
+
+from plover import formatting
+
 
 # Add tests with partial output specified.
 
@@ -1175,6 +1177,3 @@ class FormatterTestCase(unittest.TestCase):
             formatter.format([], undo, None)
             formatter.format(undo, do, None)
             self.assertEqual(output.instructions, expected_instructions)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_json_dict.py
+++ b/test/test_json_dict.py
@@ -6,8 +6,10 @@
 
 import StringIO
 import unittest
+
 from plover.dictionary.json_dict import load_dictionary
 from plover.dictionary.base import DictionaryLoaderException
+
 
 def make_dict(contents):
     d = StringIO.StringIO(contents)
@@ -32,6 +34,3 @@ class JsonDictionaryTestCase(unittest.TestCase):
         
         with self.assertRaises(DictionaryLoaderException):
             load_dictionary(make_dict('foo'))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_loading_manager.py
+++ b/test/test_loading_manager.py
@@ -5,7 +5,9 @@
 
 from collections import defaultdict
 import unittest
+
 from mock import patch
+
 import plover.dictionary.loading_manager as loading_manager
 
 
@@ -34,7 +36,3 @@ class DictionaryLoadingManagerTestCase(unittest.TestCase):
             self.assertTrue(all(x == 1 for x in loader.load_counts.values()))
             # Dropped superfluous files.
             self.assertEqual(['b', 'c'], sorted(manager.dictionaries.keys()))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -3,11 +3,13 @@
 
 import os
 import unittest
-from mock import patch
 from logging import Handler
 from collections import defaultdict
 
+from mock import patch
+
 from plover import log
+
 
 class FakeHandler(Handler):
     
@@ -87,6 +89,3 @@ class LoggerTestCase(unittest.TestCase):
         self.logger.enable_translation_logging(False)
         self.logger.translation(['e'], ['f'], None)
         self.assertEqual(FakeHandler.get_output(), {stroke_filename: ['*c', 'd']})
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_orthography.py
+++ b/test/test_orthography.py
@@ -4,6 +4,7 @@
 from plover.orthography import add_suffix
 import unittest
 
+
 class OrthographyTestCase(unittest.TestCase):
 
     def test_add_suffix(self):
@@ -116,6 +117,3 @@ class OrthographyTestCase(unittest.TestCase):
                 word, suffix, result, expected,
             )
             self.assertEqual(result, expected, msg=msg)
-        
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_passport.py
+++ b/test/test_passport.py
@@ -77,6 +77,3 @@ class TestCase(unittest.TestCase):
                     time.sleep(0.00001)
                 m.stop_capture()
                 self.assertEqual(actual, expected)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -4,7 +4,9 @@
 """Unit tests for registry.py."""
 
 import unittest
+
 from plover.machine.registry import Registry, machine_registry, NoSuchMachineException
+
 
 class RegistryClassTestCase(unittest.TestCase):
     def test_lookup(self):
@@ -43,6 +45,3 @@ class MachineRegistryTestCase(unittest.TestCase):
     def test_unknown_machine(self):
         with self.assertRaises(NoSuchMachineException):
             machine_registry.get('No such machine')
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -1,10 +1,13 @@
 # Copyright (c) 2013 Hesky Fisher
 # See LICENSE.txt for details.
 
-from plover.dictionary.rtfcre_dict import load_dictionary, TranslationConverter, format_translation, save_dictionary
-import mock
 import unittest
 from StringIO import StringIO
+
+import mock
+
+from plover.dictionary.rtfcre_dict import load_dictionary, TranslationConverter, format_translation, save_dictionary
+
 
 class TestCase(unittest.TestCase):
     
@@ -207,7 +210,3 @@ class TestCase(unittest.TestCase):
         save_dictionary(d, f)
         expected = '{\\rtf1\\ansi{\\*\\cxrev100}\\cxdict{\\*\\cxsystem Plover}{\\stylesheet{\\s0 Normal;}}\r\n{\\*\\cxs S///T}pre\\cxds \r\n}\r\n' 
         self.assertEqual(f.getvalue(), expected)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_steno.py
+++ b/test/test_steno.py
@@ -4,7 +4,9 @@
 """Unit tests for steno.py."""
 
 import unittest
+
 from plover.steno import normalize_steno, Stroke
+
 
 class StenoTestCase(unittest.TestCase):
     def test_normalize_steno(self):
@@ -37,6 +39,3 @@ class StenoTestCase(unittest.TestCase):
         self.assertEqual(Stroke(['-P', '-P']).rtfcre, '-P')
         self.assertEqual(Stroke(['-P', 'X-']).rtfcre, 'X-P')
         self.assertEqual(Stroke(['#', 'S-', '-T']).rtfcre, '1-9')
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -4,7 +4,9 @@
 """Unit tests for steno_dictionary.py."""
 
 import unittest
+
 from plover.steno_dictionary import StenoDictionary, StenoDictionaryCollection
+
 
 class StenoDictionaryTestCase(unittest.TestCase):
 
@@ -75,6 +77,3 @@ class StenoDictionaryTestCase(unittest.TestCase):
         dc.set(('S',), 'e')
         self.assertEqual(dc.lookup(('S',)), 'e')
         self.assertEqual(d2[('S',)], 'e')
-        
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_stentura.py
+++ b/test/test_stentura.py
@@ -529,6 +529,3 @@ class TestCase(unittest.TestCase):
             self.assertTrue(ready_called[0])
 
 # TODO: add a test on the machine itself with mocks
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -4,14 +4,17 @@
 """Unit tests for translation.py."""
 
 from collections import namedtuple
+import unittest
 import copy
+import sys
+
 from mock import patch
+
 from plover.steno_dictionary import StenoDictionary, StenoDictionaryCollection
 from plover.translation import Translation, Translator, _State
 from plover.translation import escape_translation, unescape_translation
-import unittest
-import sys
 from plover.steno import Stroke, normalize_steno
+
 
 def stroke(s):
     keys = []
@@ -750,7 +753,3 @@ class TranslationEscapeTest(unittest.TestCase):
             self.assertEqual(result, raw, msg='unescape_translation(%r)=%r != %r' % (escaped, result, raw))
             result = escape_translation(raw)
             self.assertEqual(result, escaped, msg='escape_translation(%r)=%r != %r' % (raw, result, escaped))
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
It's easier and better to always use the test launcher, as this will make sure the environment (path, metadata, ...) is setup correctly.