### PR TITLE
steno: optimize normalize_steno

### DIFF
--- a/test/test_steno.py
+++ b/test/test_steno.py
@@ -11,33 +11,47 @@ from plover.steno import normalize_steno, Stroke
 class StenoTestCase(unittest.TestCase):
     def test_normalize_steno(self):
         cases = (
-        
-        # TODO: More cases
-        ('S', 'S'),
-        ('S-', 'S'),
-        ('-S', '-S'),
-        ('ES', 'ES'),
-        ('-ES', 'ES'),
-        ('TW-EPBL', 'TWEPBL'),
-        ('TWEPBL', 'TWEPBL'),
-        ('19', '1-9'),
-        ('14', '14'),
-        ('146', '14-6'),
-        ('67', '-67'),
-        ('6', '-6'),
-        ('9', '-9'),
-        ('5', '5'),
-        ('0', '0'),
-        ('456', '456'),
-        ('46', '4-6'),
-        ('4*6', '4*6'),
-        ('456', '456'),
-        ('S46', 'S4-6'),
+            # TODO: More cases
+            ('S', 'S'),
+            ('S-', 'S'),
+            ('-S', '-S'),
+            ('ES', 'ES'),
+            ('-ES', 'ES'),
+            ('TW-EPBL', 'TWEPBL'),
+            ('TWEPBL', 'TWEPBL'),
+            ('19', '1-9'),
+            ('14', '14'),
+            ('146', '14-6'),
+            ('67', '-67'),
+            ('6', '-6'),
+            ('9', '-9'),
+            ('5', '5'),
+            ('0', '0'),
+            ('456', '456'),
+            ('46', '4-6'),
+            ('4*6', '4*6'),
+            ('456', '456'),
+            ('S46', 'S4-6'),
+            # Number key.
+            ('#S', '#S'),
+            ('#A', '#A'),
+            ('#0', '0'),
+            ('#6', '-6'),
+            # Implicit hyphens.
+            ('SA-', 'SA'),
+            ('SA-R', 'SAR'),
+            ('-O', 'O'),
+            ('S*-R', 'S*R'),
+            ('S-*R', 'S*R'),
         )
-        
+
         for arg, expected in cases:
-            self.assertEqual('/'.join(normalize_steno(arg)), expected)
-            
+            result = '/'.join(normalize_steno(arg))
+            msg = 'normalize_steno(%r)=%r != %r' % (
+                arg, result, expected,
+            )
+            self.assertEqual(result, expected, msg=msg)
+
     def test_steno(self):
         self.assertEqual(Stroke(['S-']).rtfcre, 'S')
         self.assertEqual(Stroke(['S-', 'T-']).rtfcre, 'ST')


### PR DESCRIPTION
Test code:

```python
import timeit

from plover.dictionary.base import load_dictionary

def instrumented():
    load_dictionary('main.json')

# Note: timeit disables garbage collection, don't set number to high!
print '%.3fs' % timeit.timeit(instrumented, number=20)
```

On my machine (Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz), the results are:
* master: 44.549s
* this branch: 22.421s
* with `normalize_steno = lambda s: tuple(s.split('/'))`: 10.997s
