### PR TITLE
Improve dictionaries handling

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -187,8 +187,6 @@ class StenoEngine(object):
 
     def set_dictionaries(self, file_names):
         dictionary = self.translator.get_dictionary()
-        if tuple(file_names) == tuple(d.get_path() for d in dictionary.dicts):
-            return
         dicts = dict_manager.load(file_names)
         dictionary.set_dicts(dicts)
 

--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -24,7 +24,7 @@ dictionaries = {
 def load_dictionary(filename):
     """Load a dictionary from a file."""
     extension = splitext(filename)[1].lower()
-    
+
     try:
         dict_type = dictionaries[extension]
     except KeyError:
@@ -32,14 +32,10 @@ def load_dictionary(filename):
             'Unsupported extension for dictionary: %s. Supported extensions: %s' %
             (extension, ', '.join(dictionaries.keys())))
 
-    loader = dict_type.load_dictionary
-
     try:
-        with open(filename, 'rb') as fp:
-            d = loader(fp)
-    except IOError as e:
-        raise DictionaryLoaderException(unicode(e))
-
+        d = dict_type.load_dictionary(filename)
+    except Exception as e:
+        raise DictionaryLoaderException('loading \'%s\' failed: %s' % (filename, str(e)))
     d.set_path(filename)
     d.save = ThreadedSaver(d, filename, dict_type.save_dictionary)
     return d

--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -9,6 +9,7 @@
 
 from os.path import splitext
 import shutil
+import sys
 import threading
 
 import plover.dictionary.json_dict as json_dict
@@ -35,7 +36,8 @@ def load_dictionary(filename):
     try:
         d = dict_type.load_dictionary(filename)
     except Exception as e:
-        raise DictionaryLoaderException('loading \'%s\' failed: %s' % (filename, str(e)))
+        ne = DictionaryLoaderException('loading \'%s\' failed: %s' % (filename, str(e)))
+        raise type(ne), ne, sys.exc_info()[2]
     d.set_path(filename)
     d.save = ThreadedSaver(d, filename, dict_type.save_dictionary)
     return d

--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -5,31 +5,33 @@
 
 """
 
-from plover.steno_dictionary import StenoDictionary
-from plover.steno import normalize_steno
-from plover.exception import DictionaryLoaderException
+import io
 
 try:
     import simplejson as json
 except ImportError:
     import json
-    
 
-def load_dictionary(fp):
-    """Load a json dictionary from a string."""
+from plover.steno_dictionary import StenoDictionary
+from plover.steno import normalize_steno
 
-    def h(pairs):
-        return StenoDictionary((normalize_steno(x[0]), x[1]) for x in pairs)
 
-    data = fp.read()
-    try:
+def load_dictionary(filename):
+
+    for encoding in ('utf-8', 'latin-1'):
         try:
-            return json.loads(data, object_pairs_hook=h)
+            with io.open(filename, 'r', encoding=encoding) as fp:
+                d = json.load(fp)
+                break
         except UnicodeDecodeError:
-            return json.loads(data, 'latin-1', object_pairs_hook=h)
-    except ValueError as e:
-        raise DictionaryLoaderException('\'%s\' is not valid json: %s' % (fp.name, str(e)))
-        
+            continue
+    else:
+        raise ValueError('\'%s\' encoding could not be determined' % (filename,))
+
+    return StenoDictionary((normalize_steno(x[0]), x[1])
+                           for x in dict(d).iteritems())
+
+
 # TODO: test this
 def save_dictionary(d, fp):
     d = dict(('/'.join(k), v) for k, v in d.iteritems())

--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -15,6 +15,8 @@ except ImportError:
 from plover.steno_dictionary import StenoDictionary
 from plover.steno import normalize_steno
 
+def create_dictionary():
+    return StenoDictionary()
 
 def load_dictionary(filename):
 

--- a/plover/dictionary/loading_manager.py
+++ b/plover/dictionary/loading_manager.py
@@ -3,50 +3,55 @@
 
 """Centralized place for dictionary loading operation."""
 
+import sys
 import threading
+
 from plover.dictionary.base import load_dictionary
 from plover.exception import DictionaryLoaderException
 
+
 class DictionaryLoadingManager(object):
+
     def __init__(self):
         self.dictionaries = {}
-        
+
     def start_loading(self, filename):
-        if filename in self.dictionaries:
+        op = self.dictionaries.get(filename)
+        if op is not None:
             return self.dictionaries[filename]
         op = DictionaryLoadingOperation(filename)
         self.dictionaries[filename] = op
         return op
-        
+
     def load(self, filenames):
         self.dictionaries = {f: self.start_loading(f) for f in filenames}
-        # Result must be in order given so can't just use values().
-        ops = [self.dictionaries[f] for f in filenames]
-        results = [op.get() for op in ops]
         dicts = []
-        for d, e in results:
-            if e:
-                raise e
+        for f in filenames:
+            d, exc_info = self.dictionaries[f].get()
+            if exc_info is not None:
+                raise exc_info[0], exc_info[1], exc_info[2]
             dicts.append(d)
         return dicts
-        
-        
+
+
 class DictionaryLoadingOperation(object):
+
     def __init__(self, filename):
         self.loading_thread = threading.Thread(target=self.load)
         self.filename = filename
-        self.exception = None
+        self.exc_info = None
         self.dictionary = None
         self.loading_thread.start()
-        
+
     def load(self):
         try:
             self.dictionary = load_dictionary(self.filename)
-        except DictionaryLoaderException as e:
-            self.exception = e
-        
+        except DictionaryLoaderException:
+            self.exc_info = sys.exc_info()
+
     def get(self):
         self.loading_thread.join()
-        return self.dictionary, self.exception
+        return self.dictionary, self.exc_info
+
 
 manager = DictionaryLoadingManager()

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -282,9 +282,10 @@ def load_stylesheet(s):
     """Returns a dictionary mapping a number to a style name."""
     return dict((int(k), v) for k, v in STYLESHEET_RE.findall(s))
 
-def load_dictionary(fp):
+def load_dictionary(filename):
     """Load an RTF/CRE dictionary."""
-    s = fp.read()
+    with open(filename, 'rb') as fp:
+        s = fp.read()
     styles = load_stylesheet(s)
     d = {}
     converter = TranslationConverter(styles)

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -336,3 +336,6 @@ def save_dictionary(d, fp):
         fp.write(entry)
 
     fp.write("}\r\n")
+
+def create_dictionary():
+    return StenoDictionary()

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -180,7 +180,10 @@ class StenoDictionaryCollection(object):
         self.longest_key_callbacks.remove(callback)
     
     def _longest_key_listener(self, ignored=None):
-        new_longest_key = max(d.longest_key for d in self.dicts)
+        if self.dicts:
+            new_longest_key = max(d.longest_key for d in self.dicts)
+        else:
+            new_longest_key = 0
         if new_longest_key != self.longest_key:
             self.longest_key = new_longest_key
             for c in self.longest_key_callbacks:

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -46,7 +46,7 @@ class StenoDictionaryTestCase(unittest.TestCase):
         
         self.assertEqual(StenoDictionary([('a', 'b')]).items(), [('a', 'b')])
         self.assertEqual(StenoDictionary(a='b').items(), [('a', 'b')])
-        
+
     def test_dictionary_collection(self):
         dc = StenoDictionaryCollection()
         d1 = StenoDictionary()
@@ -77,3 +77,39 @@ class StenoDictionaryTestCase(unittest.TestCase):
         dc.set(('S',), 'e')
         self.assertEqual(dc.lookup(('S',)), 'e')
         self.assertEqual(d2[('S',)], 'e')
+
+    def test_dictionary_collection_longest_key(self):
+
+        k1 = ('S',)
+        k2 = ('S', 'T')
+        k3 = ('S', 'T' , 'R')
+
+        dc = StenoDictionaryCollection()
+        self.assertEqual(dc.longest_key, 0)
+
+        d1 = StenoDictionary()
+        d1._path = 'd1'
+        d1.save = lambda: None
+        d1[k1] = 'a'
+
+        dc.set_dicts([d1])
+        self.assertEqual(dc.longest_key, 1)
+
+        d1[k2] = 'a'
+        self.assertEqual(dc.longest_key, 2)
+
+        d2 = StenoDictionary()
+        d2._path = 'd2'
+        d2[k3] = 'c'
+
+        dc.set_dicts([d1, d2])
+        self.assertEqual(dc.longest_key, 3)
+
+        del d1[k2]
+        self.assertEqual(dc.longest_key, 3)
+
+        dc.set_dicts([d1])
+        self.assertEqual(dc.longest_key, 1)
+
+        dc.set_dicts([])
+        self.assertEqual(dc.longest_key, 0)


### PR DESCRIPTION
## Change the load API

Pass a filename instead of a file like-object:

- this let each format implementation deals with the file open mode (and potentially the encoding), since it knows best.

- it allows for more powerful format implementations, e.g. a new "Python dictionary" format will want to use something like imp.load_source, as this will take care of byte-compiling the "dictionary" source code as needed.

## Improve exception handling

Forward original exception traceback so the final one is actually useful when debugging.

Example when loading an bad JSON dictionary; before:

```
  File "/home/bpierre/progs/src/plover/plover/dictionary/loading_manager.py", line 29, in load
    raise e
DictionaryLoaderException: '/home/bpierre/progs/src/plover/invalid.json' is not valid json: Expecting property name enclosed in double quotes: line 3 column 1 (char 16)
```

After:

```
  File "/home/bpierre/progs/src/plover/plover/dictionary/json_dict.py", line 26, in load_dictionary
    d = json.load(fp)
  File "/usr/lib/python2.7/site-packages/simplejson/__init__.py", line 459, in load
    use_decimal=use_decimal, **kw)
  File "/usr/lib/python2.7/site-packages/simplejson/__init__.py", line 516, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/site-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/usr/lib/python2.7/site-packages/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
DictionaryLoaderException: loading '/home/bpierre/progs/src/plover/invalid.json' failed: Expecting property name enclosed in double quotes: line 3 column 1 (char 16)
```

## Add support for creation to the API

Example use case; converting a dictionary to another format:

```python
from plover.dictionary.base import create_dictionary, load_dictionary

id = load_dictionary(input)
# Like for load_dictionary, format is inferred by the extension.
od = create_dictionary(output)
od.update(id)
od.save()
```