### PR TITLE
gui/log_dbus: fix possible crash

### DIFF
--- a/plover/gui/log_dbus.py
+++ b/plover/gui/log_dbus.py
@@ -1,7 +1,14 @@
 
-from plover import log, __name__ as __software_name__
-import pynotify
 import logging
+
+# Fix a possible crash...
+# See: http://trac.wxwidgets.org/ticket/15898
+import gtk
+gtk.remove_log_handlers()
+
+import pynotify
+
+from plover import log, __name__ as __software_name__
 
 
 pynotify.init(__software_name__.capitalize())


### PR DESCRIPTION
pynotify uses gtk, and importing gtk before wx can trigger a crash:
see http://trac.wxwidgets.org/ticket/15898