### PR TITLE
Allow non-ASCII non-control characters when saving a JSON dictionary

### DIFF
--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -34,7 +34,6 @@ def load_dictionary(filename):
                            for x in dict(d).iteritems())
 
 
-# TODO: test this
 def save_dictionary(d, fp):
     d = dict(('/'.join(k), v) for k, v in d.iteritems())
     json.dump(d, fp, sort_keys=True, indent=0, separators=(',', ': '))

--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -35,5 +35,7 @@ def load_dictionary(filename):
 
 
 def save_dictionary(d, fp):
-    d = dict(('/'.join(k), v) for k, v in d.iteritems())
-    json.dump(d, fp, sort_keys=True, indent=0, separators=(',', ': '))
+    contents = json.dumps(dict(('/'.join(k), v) for k, v in d.iteritems()),
+                          ensure_ascii=False, sort_keys=True,
+                          indent=0, separators=(',', ': '))
+    fp.write(contents.encode('utf-8'))

--- a/test/test_json_dict.py
+++ b/test/test_json_dict.py
@@ -57,20 +57,20 @@ class JsonDictionaryTestCase(unittest.TestCase):
         for contents, expected in (
             # Simple test.
             ({('S', ): 'a'},
-             b'{\n"S": "a"\n}'),
+             u'{\n"S": "a"\n}'),
             # Check strokes format: '/' separated.
             ({('SAPL', '-PL'): u'sample'},
-             b'{\n"SAPL/-PL": "sample"\n}'),
-            # Non-ASCII characters are escaped.
+             u'{\n"SAPL/-PL": "sample"\n}'),
+            # Contents should be saved as UTF-8, no escaping.
             ({('S', ): u'café'},
-             b'{\n"S": "caf\\u00e9"\n}'),
+             u'{\n"S": "café"\n}'),
             # Keys are sorted on save.
             ({('B', ): u'bravo', ('A', ): u'alpha', ('C', ): u'charlie'},
-             b'{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}'),
+             u'{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}'),
         ):
             with make_dict('foo') as filename:
                 with open(filename, 'wb') as fp:
                     save_dictionary(contents, fp)
                 with open(filename, 'rb') as fp:
-                    contents = fp.read()
+                    contents = fp.read().decode('utf-8')
                 self.assertEqual(contents, expected)


### PR DESCRIPTION
This make it easier to externally edit such dictionaries.