### PR TITLE
travis: speedup builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ script:
   - git fetch --unshallow
   - ./setup.py patch_version
   - ./setup.py test
+
+before_deploy:
   - |
     case "$TRAVIS_OS_NAME" in
     osx)


### PR DESCRIPTION
Since Travis CI does not store artifacts, there is no point in generating them when no deployment is triggered.