### PR TITLE
travis: speed up OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ before_install:
       ;;
     esac &&
     ./setup.py write_requirements &&
+    # Manually install Cython if not already to speedup hidapi build.
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --user Cython &&
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt &&
     # We need to downgrade setuptools for py2app to work correctly...
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2' &&


### PR DESCRIPTION
Now that Cython is not required at install by hidapi anymore (see [PR](https://github.com/trezor/cython-hidapi/pull/30)), the OSX build takes longer because Cython is automatically compiled by hidapi `setup.py` at installation. Speed up the build by manually installing Cython with pip (which will use a wheel if one is available, and cache the result).