### PR TITLE
travis: fix possible OSX build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,12 @@ before_install:
       ;;
     esac &&
     ./setup.py write_requirements &&
+    # Upgrade setuptools, we need at least 19.6 to prevent issues with Cython patched 'build_ext' command.
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools>=19.6' &&
     # Manually install Cython if not already to speedup hidapi build.
     pip --disable-pip-version-check --timeout=5 --retries=2 install --user Cython &&
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt &&
-    # We need to downgrade setuptools for py2app to work correctly...
+    # And now downgrade setuptools so py2app works correctly...
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2' &&
     pip --disable-pip-version-check list &&
     true


### PR DESCRIPTION
Building pyobjc-framework-Cocoa fails if Cython is installed, see: https://github.com/pypa/setuptools/issues/488

This is fixed by upgrading setuptools to >=19.6.