### PR TITLE
log: tweak levels

### DIFF
--- a/plover/log.py
+++ b/plover/log.py
@@ -62,6 +62,7 @@ class Logger(object):
 
     def __init__(self):
         self._print_handler = PrintHandler()
+        self._print_handler.setLevel(WARNING)
         self._file_handler = None
         self._logger = logging.getLogger('plover')
         self._logger.addHandler(self._print_handler)
@@ -73,9 +74,16 @@ class Logger(object):
         self._log_strokes = False
         self._log_translations = False
 
+    def set_level(self, level):
+        self._print_handler.setLevel(level)
+        if self._file_handler is not None:
+            self._file_handler.setLevel(level)
+        self.setLevel(level)
+
     def setup_logfile(self):
         assert self._file_handler is None
         self._file_handler = FileHandler()
+        self._file_handler.setLevel(self.level)
         self._logger.addHandler(self._file_handler)
 
     def set_stroke_filename(self, filename=None):
@@ -129,7 +137,7 @@ debug = __logger.debug
 info = __logger.info
 warning = __logger.warning
 error = __logger.error
-set_level = __logger.setLevel
+set_level = __logger.set_level
 add_handler = __logger.addHandler
 remove_handler = __logger.removeHandler
 # Strokes/translation logging.

--- a/plover/main.py
+++ b/plover/main.py
@@ -78,9 +78,10 @@ def main():
     parser.add_argument('--version', action='version', version='%s %s'
                         % (__software_name__.capitalize(), __version__))
     parser.add_argument('-l', '--log-level', choices=['debug', 'info', 'warning', 'error'],
-                        default='warning', help='set log level')
+                        default=None, help='set log level')
     args = parser.parse_args(args=sys.argv[1:])
-    log.set_level(args.log_level.upper())
+    if args.log_level is not None:
+        log.set_level(args.log_level.upper())
     try:
         # Ensure only one instance of Plover is running at a time.
         with plover.oslayer.processlock.PloverLock():
@@ -88,6 +89,7 @@ def main():
             # This must be done after calling init_config_dir, so
             # Plover's configuration directory actually exists.
             log.setup_logfile()
+            log.info('Plover %s', __version__)
             config = Config()
             config.target_file = CONFIG_FILE
             gui = plover.gui.main.PloverGUI(config)


### PR DESCRIPTION
Default levels:
- log and file handler: info
- print and gui handlers: warning

When the command line switch is used, it changes the global log level as well as the print/file handlers level.

This way the log file will by default contains a few useful traces.