### PR TITLE
Small tweaks to improve debugging

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -159,17 +159,19 @@ class StenoEngine(object):
             self.machine_options == machine_options and
             self.machine_mappings == machine_mappings):
             return
-        self.machine_class = None
-        self.machine_options = None
-        self.machine_mappings = None
         if self.machine is not None:
+            log.debug('stopping machine: %s', self.machine_class.__name__)
             self.machine.remove_state_callback(self._machine_state_callback)
             self.machine.remove_stroke_callback(
                 self._translator_machine_callback)
             self.machine.remove_stroke_callback(log.stroke)
             self.machine.stop_capture()
-        self.machine = None
+            self.machine_class = None
+            self.machine_options = None
+            self.machine_mappings = None
+            self.machine = None
         if machine_class is not None:
+            log.debug('starting machine: %s', machine_class.__name__)
             self.machine = machine_class(machine_options)
             if machine_mappings is not None:
                 self.machine.set_mappings(machine_mappings)
@@ -194,6 +196,8 @@ class StenoEngine(object):
         return self.translator.get_dictionary()
 
     def set_is_running(self, value):
+        if value != self.is_running:
+            log.debug('%s output', 'enabling' if value else 'disabling')
         self.is_running = value
         if self.is_running:
             self.translator.set_state(self.running_state)

--- a/plover/dictionary/loading_manager.py
+++ b/plover/dictionary/loading_manager.py
@@ -8,6 +8,7 @@ import threading
 
 from plover.dictionary.base import load_dictionary
 from plover.exception import DictionaryLoaderException
+from plover import log
 
 
 class DictionaryLoadingManager(object):
@@ -19,6 +20,7 @@ class DictionaryLoadingManager(object):
         op = self.dictionaries.get(filename)
         if op is not None:
             return self.dictionaries[filename]
+        log.debug('loading dictionary: %s', filename)
         op = DictionaryLoadingOperation(filename)
         self.dictionaries[filename] = op
         return op

--- a/plover/gui/keyboard_config.py
+++ b/plover/gui/keyboard_config.py
@@ -8,7 +8,7 @@ from wx.lib.utils import AdjustRectToScreen
 import wx.lib.mixins.listctrl as listmix
 
 from plover.oslayer.keyboardcontrol import KeyboardCapture
-from plover.machine.keyboard import Stenotype as KeyboardMachine
+from plover.machine.keyboard import Keyboard
 from plover.machine.keymap import Keymap
 from plover import system
 
@@ -146,7 +146,7 @@ class KeyboardConfigDialog(wx.Dialog):
         sizer.AddF(self.arpeggiate_option, sizer_flags)
 
         # editable list for keymap bindings
-        self.keymap = Keymap(KeyboardMachine.KEYS_LAYOUT.split(), KeyboardMachine.ACTIONS)
+        self.keymap = Keymap(Keyboard.KEYS_LAYOUT.split(), Keyboard.ACTIONS)
         mappings = config.get_system_keymap('Keyboard')
         if mappings is not None:
             self.keymap.set_mappings(mappings)

--- a/plover/machine/geminipr.py
+++ b/plover/machine/geminipr.py
@@ -22,7 +22,7 @@ STENO_KEY_CHART = ("Fn", "#1", "#2", "#3", "#4", "#5", "#6",
 BYTES_PER_STROKE = 6
 
 
-class Stenotype(plover.machine.base.SerialStenotypeBase):
+class GeminiPr(plover.machine.base.SerialStenotypeBase):
     """Standard stenotype interface for a Gemini PR machine.
 
     This class implements the three methods necessary for a standard

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -8,7 +8,7 @@ from plover.machine.keymap import Keymap
 from plover.oslayer.keyboardcontrol import KeyboardCapture
 
 
-class Stenotype(StenotypeBase):
+class Keyboard(StenotypeBase):
     """Standard stenotype interface for a computer keyboard.
 
     This class implements the three methods necessary for a standard
@@ -22,7 +22,7 @@ class Stenotype(StenotypeBase):
 
     def __init__(self, params):
         """Monitor the keyboard's events."""
-        super(Stenotype, self).__init__()
+        super(Keyboard, self).__init__()
         self.arpeggiate = params['arpeggiate']
         self._bindings = {}
         self._down_keys = set()
@@ -45,7 +45,7 @@ class Stenotype(StenotypeBase):
                     del self._bindings[key]
 
     def set_mappings(self, mappings):
-        super(Stenotype, self).set_mappings(mappings)
+        super(Keyboard, self).set_mappings(mappings)
         self._update_bindings()
 
     def start_capture(self):

--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -10,7 +10,7 @@ from plover.machine.base import SerialStenotypeBase
 # Passport protocol is documented here:
 # http://www.eclipsecat.com/?q=system/files/Passport%20protocol_0.pdf
 
-class Stenotype(SerialStenotypeBase):
+class Passport(SerialStenotypeBase):
     """Passport interface."""
 
     KEYS_LAYOUT = '''
@@ -22,7 +22,7 @@ class Stenotype(SerialStenotypeBase):
     '''
 
     def __init__(self, params):
-        super(Stenotype, self).__init__(params)
+        super(Passport, self).__init__(params)
         self.packet = []
 
     def _read(self, b):

--- a/plover/machine/registry.py
+++ b/plover/machine/registry.py
@@ -3,12 +3,12 @@
 
 "Manager for stenotype machines types."
 
-from plover.machine.geminipr import Stenotype as geminipr
-from plover.machine.txbolt import Stenotype as txbolt
-from plover.machine.keyboard import Stenotype as keyboard
-from plover.machine.stentura import Stenotype as stentura
-from plover.machine.passport import Stenotype as passport
-from plover.machine.treal import Stenotype as treal
+from plover.machine.geminipr import GeminiPr
+from plover.machine.txbolt import TxBolt
+from plover.machine.keyboard import Keyboard
+from plover.machine.stentura import Stentura
+from plover.machine.passport import Passport
+from plover.machine.treal import Treal
 
 class NoSuchMachineException(Exception):
     def __init__(self, id):
@@ -44,13 +44,12 @@ class Registry(object):
             return name
 
 machine_registry = Registry()
-machine_registry.register('Keyboard', keyboard)
-machine_registry.register('Gemini PR', geminipr)
-machine_registry.register('TX Bolt', txbolt)
-machine_registry.register('Stentura', stentura)
-machine_registry.register('Passport', passport)
-if treal:
-    machine_registry.register('Treal', treal)
+machine_registry.register('Keyboard', Keyboard)
+machine_registry.register('Gemini PR', GeminiPr)
+machine_registry.register('TX Bolt', TxBolt)
+machine_registry.register('Stentura', Stentura)
+machine_registry.register('Passport', Passport)
+machine_registry.register('Treal', Treal)
 
 # Legacy configuration
 machine_registry.add_alias('Microsoft Sidewinder X4', 'Keyboard')

--- a/plover/machine/stentura.py
+++ b/plover/machine/stentura.py
@@ -632,7 +632,7 @@ def _loop(port, stop, callback, ready_callback, timeout=1):
             callback(stroke)
 
 
-class Stenotype(plover.machine.base.SerialStenotypeBase):
+class Stentura(plover.machine.base.SerialStenotypeBase):
     """Stentura interface.
 
     This class implements the three methods necessary for a standard

--- a/plover/machine/treal.py
+++ b/plover/machine/treal.py
@@ -52,7 +52,7 @@ class DataHandler(object):
             self._pressed = [x[0] | x[1] for x in zip(self._pressed, p)]
 
 
-class Stenotype(ThreadedStenotypeBase):
+class Treal(ThreadedStenotypeBase):
 
     KEYS_LAYOUT = '''
         #1  #2  #3 #4 #5 #6 #7 #8 #9 #A #B
@@ -62,7 +62,7 @@ class Stenotype(ThreadedStenotypeBase):
     '''
 
     def __init__(self, params):
-        super(Stenotype, self).__init__()
+        super(Treal, self).__init__()
         self._machine = None
 
     def _on_stroke(self, keys):
@@ -95,7 +95,7 @@ class Stenotype(ThreadedStenotypeBase):
             log.warning('Treal is not connected')
             self._error()
             return
-        super(Stenotype, self).start_capture()
+        super(Treal, self).start_capture()
 
     def _reconnect(self):
         self._machine = None
@@ -125,7 +125,7 @@ class Stenotype(ThreadedStenotypeBase):
 
     def stop_capture(self):
         """Stop listening for output from the stenotype machine."""
-        super(Stenotype, self).stop_capture()
+        super(Treal, self).stop_capture()
         if self._machine:
             self._machine.close()
         self._stopped()

--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -30,7 +30,7 @@ STENO_KEY_CHART = ("S-", "T-", "K-", "P-", "W-", "H-",  # 00
                    "-T", "-S", "-D", "-Z", "#")         # 11
 
 
-class Stenotype(plover.machine.base.SerialStenotypeBase):
+class TxBolt(plover.machine.base.SerialStenotypeBase):
     """TX Bolt interface.
 
     This class implements the three methods necessary for a standard
@@ -47,7 +47,7 @@ class Stenotype(plover.machine.base.SerialStenotypeBase):
     '''
 
     def __init__(self, params):
-        super(Stenotype, self).__init__(params)
+        super(TxBolt, self).__init__(params)
         self._reset_stroke_state()
 
     def _reset_stroke_state(self):

--- a/test/test_passport.py
+++ b/test/test_passport.py
@@ -10,7 +10,7 @@ import unittest
 
 from mock import patch
 
-from plover.machine.passport import Stenotype
+from plover.machine.passport import Passport
 from plover import system
 
 
@@ -64,12 +64,12 @@ class TestCase(unittest.TestCase):
             (('SfTf', 'Zf', 'QfLf'), [['S-', 'T-'], ['-Z',], ['-R', '-L']]),
         )
 
-        params = {k: v[0] for k, v in Stenotype.get_option_info().items()}
+        params = {k: v[0] for k, v in Passport.get_option_info().items()}
         with patch('plover.machine.base.serial.Serial', MockSerial) as mock:
             for inputs, expected in cases:
                 mock.inputs = list(map(p, inputs))
                 actual = []
-                m = Stenotype(params)
+                m = Passport(params)
                 m.add_stroke_callback(lambda s: actual.append(s))
                 m.set_mappings(system.KEYMAPS['Passport'])
                 m.start_capture()


### PR DESCRIPTION
* change machine classes names to be more descriptive (instead of using `Stenotype` for all classes)
* add a few engine debug traces (output enabled/disabled, machine stopped/started)
* add a trace on dictionary load