### PR TITLE
Disable App Nap on OSX

### DIFF
--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -69,7 +69,7 @@ class TxBolt(plover.machine.base.SerialStenotypeBase):
         while not self.finished.isSet():
             # Grab data from the serial port, or wait for timeout if none available.
             raw = self.serial_port.read(max(1, self.serial_port.inWaiting()))
-            
+
             # XXX : work around for python 3.1 and python 2.6 differences
             if isinstance(raw, str):
                 raw = [ord(x) for x in raw]
@@ -88,6 +88,6 @@ class TxBolt(plover.machine.base.SerialStenotypeBase):
                     if (byte >> i) & 1:
                         self._pressed_keys.append(
                             STENO_KEY_CHART[(key_set * 6) + i])
-                if 6 == key_set:
+                if 3 == key_set:
                     # Last possible set, the stroke is finished.
                     self._finish_stroke()

--- a/plover/main.py
+++ b/plover/main.py
@@ -14,6 +14,8 @@ if not hasattr(sys, 'frozen'):
     import wxversion
     wxversion.ensureMinimal(WXVER)
 
+if sys.platform.startswith('darwin'):
+    import appnope
 import wx
 import json
 
@@ -85,6 +87,8 @@ def main():
     try:
         # Ensure only one instance of Plover is running at a time.
         with plover.oslayer.processlock.PloverLock():
+            if sys.platform.startswith('darwin'):
+                appnope.nope()
             init_config_dir()
             # This must be done after calling init_config_dir, so
             # Plover's configuration directory actually exists.

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -40,7 +40,7 @@ from Quartz import (
 import Foundation
 import threading
 import Queue
-from time import time
+from time import sleep
 import collections
 
 from plover.oslayer import mac_keycode
@@ -537,9 +537,7 @@ class KeyboardEmulation(object):
                         CGEventSetFlags(event, goal_flags)
 
                     # Half millisecond pause after key down.
-                    deadline = time() + 0.0005
-                    while time() < deadline:
-                        pass
+                    sleep(0.0005)
                 if key_down and keycode in MODIFIER_KEYS_TO_MASKS:
                     mods_flags |= MODIFIER_KEYS_TO_MASKS[keycode]
 

--- a/setup.py
+++ b/setup.py
@@ -284,6 +284,7 @@ extras_require = {
         'pyobjc-framework-Cocoa>=3.0.3',
         'pyobjc-framework-Quartz>=3.0.3',
         'wxPython>=3.0',
+        'appnope>=0.1.0',
     ],
 }
 


### PR DESCRIPTION
Fixes #189 #258 

App Nap slows down apps when they aren't in the foreground, which really messes up Plover's sleeps. With appnope, we tell the OS that we don't want to be slowed down, and in turn our sleeps no longer "get long" after not being the foreground application for a time.

The result is that the TX Bolt strokes are no longer "held back" and also the output code can use a regular sleep instead of the hacky busy loop.
