### PR TITLE
Fix osx/bootstrap.sh

### DIFF
--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -93,8 +93,9 @@ EOT
 
 
     echo "$0: installing required libraries using pip"
-    "$TOPDIR/setup.py" write_requirements &&
-    "$PIP" install -r "$TOPDIR/requirements.txt"
+    # Writes requirements to PWD, not setup.py's directory.
+    "$TOPDIR/setup.py" write_requirements \
+        && "$PIP" install -r requirements.txt
 }
 
 main

--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -9,7 +9,8 @@ EX_FAILURE_NO_CCTOOLS=1
 EX_FAILURE_NO_PYTHON=2
 EX_FAILURE_NO_WXPYTHON=3
 
-TOPDIR="$(dirname "$(readlink -e "$0")")"
+TOPDIR="$(dirname "$(realpath -e "$0")")"
+
 PYTHON=${PYTHON:=$(which python2)}
 PIP=${PIP:=$(which pip)}
 

--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -9,7 +9,7 @@ EX_FAILURE_NO_CCTOOLS=1
 EX_FAILURE_NO_PYTHON=2
 EX_FAILURE_NO_WXPYTHON=3
 
-TOPDIR="$(dirname "$(realpath -e "$0")")"
+TOPDIR="$(dirname "$(realpath -e "$0")")/.."
 
 PYTHON=${PYTHON:=$(which python2)}
 PIP=${PIP:=$(which pip)}

--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -8,6 +8,7 @@
 EX_FAILURE_NO_CCTOOLS=1
 EX_FAILURE_NO_PYTHON=2
 EX_FAILURE_NO_WXPYTHON=3
+EX_FAILURE_NO_SETUP_PY=4
 
 TOPDIR="$(dirname "$(realpath -e "$0")")/.."
 
@@ -18,6 +19,15 @@ REAL_PYTHON=$("$PYTHON" -c 'import sys; print sys.executable')
 
 echo "$0: using python: $PYTHON (executable: $REAL_PYTHON)"
 echo "$0: using pip: $PIP (version: $($PIP --version))"
+
+has_setup_py() {
+    echo "$0: checking for executable setup.py"
+    if [[ -x "$TOPDIR/setup.py" ]]; then
+        "true"
+    else
+        "false"
+    fi
+}
 
 
 has_cli_tools() {
@@ -91,6 +101,17 @@ EOT
         echo "$0: successfully imported wx"
     fi
 
+
+    if ! has_setup_py; then
+        cat 1>&2 <<EOT
+$0: either failed to find setup.py or setup.py not executable using:
+
+    $TOPDIR/setup.py
+EOT
+        exit $EX_FAILURE_NO_SETUP_PY
+    else
+        echo "$0: found executable setup.py"
+    fi
 
     echo "$0: installing required libraries using pip"
     # Writes requirements to PWD, not setup.py's directory.


### PR DESCRIPTION
### About
The bootstrap script was updated to gather requirements by running setup.py write_requirements. When I ran it to update dependencies following the addition of appnope, I found this didn't work due to several issues. This PR resolves those issues.

### Issues
None that I know of, but this might be what's broken the weeklies for OS X, which I believe @benoit-pierre mentioned as a new issue on Discord recently.

### Release Notes
None; this is a purely technical change to the dev & build process with no bearing on the operation of Plover itself.

### Tested Platforms
I tested it on OS X by running it to pull in the latest dependencies so I could run `sudo python setup.py launch` successfully again. This PR is platform-specific, so we should be good to go with having just tested on OS X.

### Other
I noticed that `python setup.py build` succeeded in spite of my not having appnope. This is worrisome, because it means we can unknowingly build a broken app.
