### PR TITLE
Improve OSX `send_key_combination`

### DIFF
--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -44,7 +44,7 @@ from time import sleep
 import collections
 
 from plover.oslayer import mac_keycode
-from plover.key_combo import add_modifiers_aliases, parse_key_combo
+from plover.key_combo import add_modifiers_aliases, parse_key_combo, KEYNAME_TO_CHAR
 import plover.log
 
 
@@ -95,22 +95,6 @@ KEYNAME_TO_KEYCODE = {
 for name, code in NX_KEYS.iteritems():
     KEYNAME_TO_KEYCODE[name.lower()] = code + NX_KEY_OFFSET
 add_modifiers_aliases(KEYNAME_TO_KEYCODE)
-
-KEYNAME_TO_CHAR = {
-    'ampersand': '&', 'apostrophe': '\'', 'asciitilde': '~',
-    'asterisk': '*', 'at': '@', 'backslash': '\'',
-    'braceleft': '{', 'braceright': '}', 'bracketleft': '[',
-    'bracketright': ']', 'colon': ':', 'comma': ',', 'division': '÷',
-    'dollar': '$', 'equal': '=', 'exclam': '!', 'greater': '>',
-    'hyphen': '-', 'less': '<', 'minus': '-', 'multiply': '×',
-    'numbersign': '#', 'parenleft': '(', 'parenright': ')',
-    'percent': '%', 'period': '.', 'plus': '+',
-    'question': '?', 'quotedbl': '"', 'quoteleft': '‘',
-    'quoteright': '’', 'semicolon': ';', 'slash': '/', 'space': ' ',
-    'underscore': '_',
-    'grave': '`', 'asciicircum': '^',
-    'bar': '|',
-}
 
 
 def down(seq):

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -124,32 +124,6 @@ def up(seq):
 def down_up(seq):
     return down(seq) + up(seq)
 
-# Maps from literal characters to their key names.
-LITERALS = collections.defaultdict(str, {
-    '0': '0', '1': '1', '2': '2', '3': '3', '4': '4', '5': '5', '6': '6',
-    '7': '7', '8': '8', '9': '9',
-
-    'a': 'a', 'b': 'b', 'c': 'c', 'd': 'd', 'e': 'e', 'f': 'f', 'g': 'g',
-    'h': 'h', 'i': 'i', 'j': 'j', 'k': 'k', 'l': 'l', 'm': 'm', 'n': 'n',
-    'o': 'o', 'p': 'p', 'q': 'q', 'r': 'r', 's': 's', 't': 't', 'u': 'u',
-    'v': 'v', 'w': 'w', 'x': 'x', 'y': 'y', 'z': 'z',
-
-    'A': 'A', 'B': 'B', 'C': 'C', 'D': 'D', 'E': 'E', 'F': 'F', 'G': 'G',
-    'H': 'H', 'I': 'I', 'J': 'J', 'K': 'K', 'L': 'L', 'M': 'M', 'N': 'N',
-    'O': 'O', 'P': 'P', 'Q': 'Q', 'R': 'R', 'S': 'S', 'T': 'T', 'U': 'U',
-    'V': 'V', 'W': 'W', 'X': 'X', 'Y': 'Y', 'Z': 'Z',
-
-    '`': 'grave', '~': 'asciitilde', '!': 'exclam', '@': 'at',
-    '#': 'numbersign', '$': 'dollar', '%': 'percent', '^': 'asciicircum',
-    '&': 'ampersand', '*': 'asterisk', '(': 'parenleft', ')': 'parenright',
-    '-': 'minus', '_': 'underscore', '=': 'equal', '+': 'plus',
-    '[': 'bracketleft', ']': 'bracketright', '{': 'braceleft',
-    '}': 'braceright', '\\': 'backslash', '|': 'bar', ';': 'semicolon',
-    ':': 'colon', '\'': 'apostrophe', '"': 'quotedbl', ',': 'comma',
-    '<': 'less', '.': 'period', '>': 'greater', '/': 'slash',
-    '?': 'question', '\t': 'Tab', ' ': 'space'
-})
-
 # Maps from keycodes to corresponding event masks.
 MODIFIER_KEYS_TO_MASKS = {
     58: kCGEventFlagMaskAlternate,


### PR DESCRIPTION
Use `key_combo.KEYNAME_TO_CHAR`. This address the last point of #533.

Note: untested!