### PR TITLE
formatting: check an action word too when handling replace

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -158,7 +158,11 @@ class OutputHelper(object):
         for a in action_list:
             if a.replace and text.endswith(a.replace):
                 text = text[:-len(a.replace)]
-            if a.text:
+            # With numbers, it's possible to have a.text='2' with a.word='1.2'
+            # folowing by an action that replaces '1.2' by '$1.20'...
+            if len(a.word) > len(a.text) and a.word.endswith(text):
+                text = a.word
+            else:
                 text += a.text
         return text
 
@@ -186,8 +190,7 @@ class OutputHelper(object):
         for a in do:
             if a.replace and self.after.endswith(a.replace):
                 self.after = self.after[:-len(a.replace)]
-            if a.text:
-                self.after += a.text
+            self.after += a.text
             if a.combo:
                 self.commit()
                 self.output.send_key_combination(a.combo)

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1,0 +1,60 @@
+
+import unittest
+
+from plover.steno import Stroke
+from plover.formatting import Formatter
+from plover.translation import Translator
+from plover.steno_dictionary import StenoDictionary
+
+
+class CaptureOutput(object):
+
+    def __init__(self):
+        self.instructions = []
+        self.text = u''
+
+    def send_backspaces(self, n):
+        assert n <= len(self.text)
+        self.text = self.text[:-n]
+        self.instructions.append(('b', n))
+
+    def send_string(self, s):
+        self.text += s
+        self.instructions.append(('s', s))
+
+    def send_key_combination(self, c):
+        self.instructions.append(('c', c))
+
+    def send_engine_command(self, c):
+        self.instructions.append(('e', c))
+
+
+def steno_to_stroke(steno):
+    stroke = Stroke(())
+    stroke.rtfcre = steno
+    return stroke
+
+
+class BlackboxTest(unittest.TestCase):
+
+    def setUp(self):
+        self.output = CaptureOutput()
+        self.formatter = Formatter()
+        self.formatter.set_output(self.output)
+        self.translator = Translator()
+        self.translator.add_listener(self.formatter.format)
+        self.dictionary = self.translator.get_dictionary()
+        self.dictionary.set_dicts([StenoDictionary()])
+
+    def test_bug535(self):
+        self.dictionary.set(('P-P',), '{^.^}')
+        self.dictionary.set(('KR*UR',), '{*($c)}')
+        for steno in (
+            '1',
+            'P-P',
+            '2',
+            'KR*UR',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u' $1.20')


### PR DESCRIPTION
Fix #535.

Use case: when `{*($c)}` is used after stroking `1.2` (with 3 separate strokes), the formatter will try to undo 1 action only with `text` set to `2` and `word` set to `1.2`, with one action replacing `1.2` by `$1.20`. So we need to take `action.word` into account when rendering the initial (previous) text. 

