### PR TITLE
Fix x server backspace keycode.

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -125,7 +125,7 @@ KEYCODE_TO_KEY = {
     60: ".",
     61: "/",
     # Other keys.
-    66 : "BackSpace",
+    22 : "BackSpace",
     119: "Delete",
     116: "Down",
     115: "End",


### PR DESCRIPTION
This corrects the keycode for backspace on X server, previously it was set to left control's keycode.