### PR TITLE
Improve macOS keyboard watching support

### DIFF
--- a/plover/oslayer/osxkeyboardlayout.py
+++ b/plover/oslayer/osxkeyboardlayout.py
@@ -132,11 +132,12 @@ class KeyboardLayout(object):
 
         center = Foundation.NSDistributedNotificationCenter.defaultCenter()
         watcher_callback = LayoutWatchingCallback.new()
-        center.addObserver_selector_name_object_(
+        center.addObserver_selector_name_object_suspensionBehavior_(
             watcher_callback,
             'layoutChanged:',
-            'AppleSelectedInputSourcesChangedNotification',
-            None
+            'com.apple.Carbon.TISNotifySelectedKeyboardInputSourceChanged',
+            None,
+            Foundation.NSNotificationSuspensionBehaviorDeliverImmediately
         )
         AppHelper.runConsoleEventLoop(installInterrupt=True)
 


### PR DESCRIPTION
@Achim63 noticed that keyboard watching wasn't working on his system. I believe the notification I was using was not fired in all cases, whereas the legacy Carbon API is always fired.

I also noticed that I forgot to set the visibility of some internal functions and that has been cleaned up.