### PR TITLE
Use alternate suggestions in lookup window

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -24,6 +24,7 @@ import plover.steno as steno
 import plover.translation as translation
 from plover.exception import InvalidConfigurationError
 from plover.machine.registry import machine_registry, NoSuchMachineException
+from plover.suggestions import Suggestions
 from plover import log
 from plover.dictionary.loading_manager import manager as dict_manager
 from plover import system
@@ -138,6 +139,7 @@ class StenoEngine(object):
         self.machine_class = None
         self.machine_options = None
         self.machine_mappings = None
+        self.suggestions = None
         self.thread_hook = thread_hook
 
         self.translator = translation.Translator()
@@ -191,9 +193,13 @@ class StenoEngine(object):
         dictionary = self.translator.get_dictionary()
         dicts = dict_manager.load(file_names)
         dictionary.set_dicts(dicts)
+        self.suggestions = Suggestions(dictionary)
 
     def get_dictionary(self):
         return self.translator.get_dictionary()
+
+    def get_suggestions(self, translation):
+        return self.suggestions.find(translation)
 
     def set_is_running(self, value):
         if value != self.is_running:

--- a/plover/gui/lookup.py
+++ b/plover/gui/lookup.py
@@ -9,72 +9,52 @@ import plover.gui.util as util
 from plover.translation import escape_translation, unescape_translation
 
 TITLE = 'Plover: Lookup'
-
+CANCEL_BUTTON = 'Close'
 
 class LookupDialog(wx.Dialog):
 
     BORDER = 3
-    TRANSLATION_TEXT = 'Text:'
-    
+
     other_instances = []
-    
+
     def __init__(self, parent, engine, config):
-        pos = (config.get_lookup_frame_x(), 
+        pos = (config.get_lookup_frame_x(),
                config.get_lookup_frame_y())
-        wx.Dialog.__init__(self, parent, title=TITLE, pos=pos)
+        wx.Dialog.__init__(self, parent, title=TITLE, pos=pos,
+                           style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER)
 
         self.config = config
 
         # components
         self.translation_text = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
-        cancel = wx.Button(self, id=wx.ID_CANCEL, label='Cancel')
-        self.listbox = wx.ListBox(self, size=wx.Size(210, 200), style=wx.LB_HSCROLL)
-        
+        self.listbox = wx.ListBox(self, size=wx.Size(210, 200),
+                                  style=wx.LB_HSCROLL)
+        cancel = wx.Button(self, wx.ID_CANCEL, CANCEL_BUTTON)
+        cancel.Bind(wx.EVT_BUTTON, self.on_close)
         # layout
         global_sizer = wx.BoxSizer(wx.VERTICAL)
-        
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        label = wx.StaticText(self, label=self.TRANSLATION_TEXT)
-        sizer.Add(label, 
-                  flag=wx.TOP | wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL, 
-                  border=self.BORDER)
-        sizer.Add(self.translation_text, 
-                  flag=wx.TOP | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL, 
-                  border=self.BORDER)
-        sizer.Add(cancel, 
-                  flag=wx.TOP | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL, 
-                  border=self.BORDER)
-        global_sizer.Add(sizer)
-        
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(self.listbox,
-                  flag=wx.ALL | wx.FIXED_MINSIZE,
-                  border=self.BORDER)
 
-        global_sizer.Add(sizer)
-        
+        global_sizer.Add(self.translation_text, 0, wx.ALL | wx.EXPAND,
+                         self.BORDER)
+        global_sizer.Add(self.listbox, 1, wx.ALL & ~wx.TOP | wx.EXPAND,
+                         self.BORDER)
+        global_sizer.Add(cancel, 0, wx.ALL & ~wx.TOP | wx.EXPAND, self.BORDER)
+
         self.SetAutoLayout(True)
         self.SetSizer(global_sizer)
         global_sizer.Fit(self)
         global_sizer.SetSizeHints(self)
         self.Layout()
         self.SetRect(AdjustRectToScreen(self.GetRect()))
-        
-        # events
 
-        # The reason for the focus event here is to skip focus on tab traversal
-        # of the buttons. But it seems that on windows this prevents the button
-        # from being pressed. Leave this commented out until that problem is
-        # resolved.
-        #button.Bind(wx.EVT_SET_FOCUS, self.on_button_gained_focus)
-        cancel.Bind(wx.EVT_BUTTON, self.on_close)
-        #cancel.Bind(wx.EVT_SET_FOCUS, self.on_button_gained_focus)
+        # events
         self.translation_text.Bind(wx.EVT_TEXT, self.on_translation_change)
         self.translation_text.Bind(wx.EVT_SET_FOCUS, self.on_translation_gained_focus)
         self.translation_text.Bind(wx.EVT_KILL_FOCUS, self.on_translation_lost_focus)
         self.Bind(wx.EVT_CLOSE, self.on_close)
+
         self.Bind(wx.EVT_MOVE, self.on_move)
-        
+
         self.engine = engine
         
         # TODO: add functions on engine for state

--- a/plover/gui/lookup.py
+++ b/plover/gui/lookup.py
@@ -72,7 +72,6 @@ class LookupDialog(wx.Dialog):
         self.translation_text.Bind(wx.EVT_TEXT, self.on_translation_change)
         self.translation_text.Bind(wx.EVT_SET_FOCUS, self.on_translation_gained_focus)
         self.translation_text.Bind(wx.EVT_KILL_FOCUS, self.on_translation_lost_focus)
-        self.translation_text.Bind(wx.EVT_TEXT_ENTER, self.on_close)
         self.Bind(wx.EVT_CLOSE, self.on_close)
         self.Bind(wx.EVT_MOVE, self.on_move)
         

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -1,0 +1,53 @@
+import collections
+
+Suggestion = collections.namedtuple('Suggestion', 'text steno_list')
+
+
+class Suggestions(object):
+    def __init__(self, dictionary):
+        self.dictionary = dictionary
+
+    def find(self, translation):
+        suggestions = []
+
+        mods = [
+            u'%s',  # Same
+            u'{^%s}',  # Prefix
+            u'{^}%s',
+            u'{^%s^}',  # Infix
+            u'{^}%s{^}',
+            u'{%s^}',  # Suffix
+            u'%s{^}',
+            u'{&%s}',  # Fingerspell
+            u'{#%s}',  # Command
+        ]
+
+        possible_translations = set([translation])
+
+        # Only strip spaces, so patterns with \n or \t are correctly handled.
+        stripped_translation = translation.strip(' ')
+        if stripped_translation and stripped_translation != translation:
+            possible_translations.add(stripped_translation)
+
+        lowercase_translation = translation.lower()
+        if lowercase_translation != translation:
+            possible_translations.add(lowercase_translation)
+
+        similar_words = self.dictionary.casereverse_lookup(translation.lower())
+        if similar_words:
+            possible_translations |= similar_words
+
+        for t in possible_translations:
+            for modded_translation in [mod % t for mod in mods]:
+                strokes_list = self.dictionary.reverse_lookup(modded_translation)
+                if not strokes_list:
+                    continue
+                # Return suggestions, sorted by fewest strokes, then fewest keys
+                strokes_list = sorted(
+                    strokes_list,
+                    key=lambda x: (len(x), sum(map(len, x)))
+                )
+                suggestion = Suggestion(modded_translation, strokes_list)
+                suggestions.append(suggestion)
+
+        return suggestions


### PR DESCRIPTION
Fixes two pet peeves of mine: #527 lookup window tooks things too literally and made finding translations a chore.

Now the lookup and suggestions windows will find text like " Pre-" as "{pre-^}"

Lookup window also can horizontally scroll (needs to be tested for behavior on Linux)