### PR TITLE
gui/dictionary_editor: remove filter thread

### DIFF
--- a/plover/gui/dictionary_editor.py
+++ b/plover/gui/dictionary_editor.py
@@ -1,4 +1,3 @@
-import threading
 import wx
 from wx.lib.utils import AdjustRectToScreen
 import plover.gui.util as util
@@ -135,9 +134,6 @@ class DictionaryEditor(wx.Dialog):
         self.last_window = util.GetForegroundWindow()
 
     def _do_filter(self, event=None):
-        threading.Thread(target=self._do_filter_thread).start()
-
-    def _do_filter_thread(self):
         self.store.ApplyFilter(self.filter_by_stroke.GetValue(),
                                self.filter_by_translation.GetValue())
         self.grid.RefreshView()


### PR DESCRIPTION
It's too buggy:
- it does concurrent accesses to the GUI, a recipe for crashes on Linux with GTK
- it allows starting multiple concurrent filter threads
- just moving the mouse over the table will generate a bunch of calls to the dictionary store, so if you do that while the filter thread is doing it's thing, you get a bunch of errors

This should fix #540.

Tested on Arch Linux.