### PR TITLE
app: improve Engine.set_machine

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -172,16 +172,17 @@ class StenoEngine(object):
             self.machine = None
         if machine_class is not None:
             log.debug('starting machine: %s', machine_class.__name__)
-            self.machine = machine_class(machine_options)
+            machine = machine_class(machine_options)
             if machine_mappings is not None:
-                self.machine.set_mappings(machine_mappings)
-            self.machine.add_state_callback(self._machine_state_callback)
-            self.machine.add_stroke_callback(log.stroke)
-            self.machine.add_stroke_callback(self._translator_machine_callback)
-            self.machine.start_capture()
+               machine.set_mappings(machine_mappings)
+            machine.add_state_callback(self._machine_state_callback)
+            machine.add_stroke_callback(log.stroke)
+            machine.add_stroke_callback(self._translator_machine_callback)
+            self.machine = machine
             self.machine_class = machine_class
             self.machine_options = machine_options
             self.machine_mappings = machine_mappings
+            self.machine.start_capture()
             is_running = self.is_running
         else:
             is_running = False

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -78,6 +78,12 @@ class EngineTestCase(unittest.TestCase):
             ])
             self.assertIsInstance(self.engine.machine, FakeMachine)
 
+    def test_engine_bad_mappings(self):
+        with self._setup(system_keymap='invalid'):
+            with self.assertRaises(Exception):
+                app.init_engine(self.engine, self.cfg)
+            self.assertEqual(self.engine.machine, None)
+
     def test_engine_auto_start(self):
         with self._setup(auto_start=True):
             app.init_engine(self.engine, self.cfg)


### PR DESCRIPTION
Make sure 'machine_class/machine_options/machine_mappings' members are only set if 'machine' is. 

Use case: both machine_class/machine_options are valid and the machine instance is correctly initialized, but setting the mappings fails.