### PR TITLE
formatting: handle escape characters when creating atoms

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -355,7 +355,9 @@ def _translation_to_actions(translation, last_action, spaces_after):
         # If a translation is only digits then glue it to neighboring digits.
         atoms = [_apply_glue(translation)]
     else:
-        atoms = [x.strip() for x in META_RE.findall(translation) if x.strip()]
+        atoms = [
+            x.strip(' ') for x in META_RE.findall(translation) if x.strip(' ')
+        ]
 
     if not atoms:
         return [last_action.copy_state()]

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -58,3 +58,14 @@ class BlackboxTest(unittest.TestCase):
             stroke = steno_to_stroke(steno)
             self.translator.translate(stroke)
         self.assertEqual(self.output.text, u' $1.20')
+
+    def test_special_characters(self):
+        self.dictionary.set(('R-R',), '{^}\n{^}')
+        self.dictionary.set(('TAB',), '\t')
+        for steno in (
+            'R-R',
+            'TAB',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u'\n\t')


### PR DESCRIPTION
Found that entries with \n \r \t were not doing anything while working on my machine, made a failing test and fixed it.