### PR TITLE
Improve Linux keyboard support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,7 @@ extras_require = {
         # Can't reliably require wxPython
     ],
     ':"linux" in sys_platform': [
-        'python-xlib>=0.14',
+        'python-xlib>=0.16',
         'wxPython>=3.0',
     ],
     ':"darwin" in sys_platform': [


### PR DESCRIPTION
### Switch to XInput

Use XInput to capture keyboard events; this allow filtering-out the XTest keyboard, and only capture other keyboards when suppressing; which in turn will make it possible to use XTest for all simulated events (and not just for sending key combos).

### Use XTest for all simulated key events

This improve compatibility with with Qt5 applications (modifiers are now correctly handled), window managers (e.g. Awesome run prompt), Xterm (it's not necessary to use allowSendEvents anymore), ...
