### PR TITLE
more preliminary "safe" changes for Python 3 support 

### DIFF
--- a/plover/app.py
+++ b/plover/app.py
@@ -28,15 +28,7 @@ from plover.suggestions import Suggestions
 from plover import log
 from plover.dictionary.loading_manager import manager as dict_manager
 from plover import system
-
-# Because 2.7 doesn't have this yet.
-class SimpleNamespace(object):
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-    def __repr__(self):
-        keys = sorted(self.__dict__)
-        items = ("{}={!r}".format(k, self.__dict__[k]) for k in keys)
-        return "{}({})".format(type(self).__name__, ", ".join(items))
+from plover.misc import SimpleNamespace
 
 
 def init_engine(engine, config):
@@ -58,7 +50,7 @@ def update_engine(engine, config, reset_machine=False):
     try:
         machine_class = machine_registry.get(machine_type)
     except NoSuchMachineException as e:
-        raise InvalidConfigurationError(unicode(e))
+        raise InvalidConfigurationError(str(e))
     machine_options = config.get_machine_specific_options(machine_type)
     machine_mappings = config.get_system_keymap(machine_type)
     engine.set_machine(machine_class, machine_options, machine_mappings,

--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -12,6 +12,9 @@ import shutil
 import sys
 import threading
 
+# Python 2/3 compatibility.
+from six import reraise
+
 import plover.dictionary.json_dict as json_dict
 import plover.dictionary.rtfcre_dict as rtfcre_dict
 from plover.config import JSON_EXTENSION, RTF_EXTENSION
@@ -47,7 +50,7 @@ def create_dictionary(filename):
         d = dictionary_module.create_dictionary()
     except Exception as e:
         ne = DictionaryLoaderException('creating %s failed: %s' % (filename, str(e)))
-        raise type(ne), ne, sys.exc_info()[2]
+        reraise(type(ne), ne, sys.exc_info()[2])
     d.set_path(filename)
     d.save = ThreadedSaver(d, filename, dictionary_module.save_dictionary)
     return d
@@ -62,7 +65,7 @@ def load_dictionary(filename):
         d = dictionary_module.load_dictionary(filename)
     except Exception as e:
         ne = DictionaryLoaderException('loading \'%s\' failed: %s' % (filename, str(e)))
-        raise type(ne), ne, sys.exc_info()[2]
+        reraise(type(ne), ne, sys.exc_info()[2])
     d.set_path(filename)
     d.save = ThreadedSaver(d, filename, dictionary_module.save_dictionary)
     return d

--- a/plover/dictionary/loading_manager.py
+++ b/plover/dictionary/loading_manager.py
@@ -6,6 +6,9 @@
 import sys
 import threading
 
+# Python 2/3 compatibility.
+from six import reraise
+
 from plover.dictionary.base import load_dictionary
 from plover.exception import DictionaryLoaderException
 from plover import log
@@ -31,7 +34,7 @@ class DictionaryLoadingManager(object):
         for f in filenames:
             d, exc_info = self.dictionaries[f].get()
             if exc_info is not None:
-                raise exc_info[0], exc_info[1], exc_info[2]
+                reraise(*exc_info)
             dicts.append(d)
         return dicts
 

--- a/plover/key_combo.py
+++ b/plover/key_combo.py
@@ -135,7 +135,7 @@ CHAR_TO_KEYNAME = {
 }
 
 
-_SPLIT_RX = re.compile(ur'(\s+|(?:\w+(?:\s*\()?)|.)')
+_SPLIT_RX = re.compile(r'(\s+|(?:\w+(?:\s*\()?)|.)')
 
 def parse_key_combo(combo_string, key_name_to_key_code=None):
 
@@ -163,7 +163,7 @@ def parse_key_combo(combo_string, key_name_to_key_code=None):
         if token.isspace():
             pass
 
-        elif re.match(ur'\w', token):
+        elif re.match(r'\w', token):
 
             if token.endswith(u'('):
                 key_name = token[:-1].rstrip().lower()

--- a/plover/machine/geminipr.py
+++ b/plover/machine/geminipr.py
@@ -3,6 +3,9 @@
 
 """Thread-based monitoring of a Gemini PR stenotype machine."""
 
+# Python 2/3 compatibility.
+from six import iterbytes
+
 import plover.machine.base
 
 # In the Gemini PR protocol, each packet consists of exactly six bytes
@@ -51,13 +54,9 @@ class GeminiPr(plover.machine.base.SerialStenotypeBase):
             if not raw:
                 continue
 
-            # XXX : work around for python 3.1 and python 2.6 differences
-            if isinstance(raw, str):
-                raw = [ord(x) for x in raw]
-
             # Convert the raw to a list of steno keys.
             steno_keys = []
-            for i, b in enumerate(raw):
+            for i, b in enumerate(iterbytes(raw)):
                 for j in range(1, 8):
                     if (b & (0x80 >> j)):
                         steno_keys.append(STENO_KEY_CHART[i * 7 + j - 1])

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -32,7 +32,7 @@ class Keyboard(StenotypeBase):
 
     def _update_bindings(self):
         self._bindings = dict(self.keymap.get_bindings())
-        for key, mapping in self._bindings.items():
+        for key, mapping in list(self._bindings.items()):
             if 'no-op' == mapping:
                 self._bindings[key] = None
             elif 'arpeggiate' == mapping:

--- a/plover/machine/keymap.py
+++ b/plover/machine/keymap.py
@@ -1,6 +1,11 @@
 import json
 from collections import defaultdict, OrderedDict
+
+# Python 2/3 compatibility.
+from six import string_types
+
 from plover import log
+
 
 class Keymap(object):
 
@@ -29,7 +34,7 @@ class Keymap(object):
     def set_mappings(self, mappings):
         # When setting from a string, assume a list of mappings:
         # [[action1, [key1, key2]], [action2, [key3]], ...]
-        if isinstance(mappings, basestring):
+        if isinstance(mappings, string_types):
             mappings = json.loads(mappings)
         mappings = dict(mappings)
         # Set from:
@@ -48,7 +53,7 @@ class Keymap(object):
                 # so it's shown in the configurator.
                 self._mappings[action] = ()
                 continue
-            if isinstance(key_list, basestring):
+            if isinstance(key_list, string_types):
                 key_list = (key_list,)
             self._mappings[action] = tuple(sorted(key_list, key=self._keys.get))
             for key in key_list:
@@ -59,7 +64,7 @@ class Keymap(object):
                 self._bindings[key] = action
         for action in (set(mappings) - set(self._actions)):
             key_list = mappings.get(action)
-            if isinstance(key_list, basestring):
+            if isinstance(key_list, string_types):
                 key_list = (key_list,)
             errors.append('invalid action %s mapped to key(s) %s' % (action, ' '.join(key_list)))
         for key, action_list in bound_keys.items():

--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -3,7 +3,8 @@
 
 "Thread-based monitoring of a stenotype machine using the passport protocol."
 
-from itertools import izip_longest
+# Python 2/3 compatibility.
+from six.moves import zip_longest
 
 from plover.machine.base import SerialStenotypeBase
 
@@ -79,5 +80,5 @@ def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
     # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
     args = [iter(iterable)] * n
-    return izip_longest(fillvalue=fillvalue, *args)
+    return zip_longest(fillvalue=fillvalue, *args)
 

--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -3,6 +3,9 @@
 
 "Thread-based monitoring of a stenotype machine using the TX Bolt protocol."
 
+# Python 2/3 compatibility.
+from six import iterbytes
+
 import plover.machine.base
 
 # In the TX Bolt protocol, there are four sets of keys grouped in
@@ -70,15 +73,11 @@ class TxBolt(plover.machine.base.SerialStenotypeBase):
             # Grab data from the serial port, or wait for timeout if none available.
             raw = self.serial_port.read(max(1, self.serial_port.inWaiting()))
 
-            # XXX : work around for python 3.1 and python 2.6 differences
-            if isinstance(raw, str):
-                raw = [ord(x) for x in raw]
-
             if not raw and len(self._pressed_keys) > 0:
                 self._finish_stroke()
                 continue
 
-            for byte in raw:
+            for byte in iterbytes(raw):
                 key_set = byte >> 6
                 if (key_set <= self._last_key_set
                     and len(self._pressed_keys) > 0):

--- a/plover/misc.py
+++ b/plover/misc.py
@@ -1,6 +1,29 @@
 # Copyright (c) 2016 Open Steno Project
 # See LICENSE.txt for details.
 
+# Python 2/3 compatibility.
+from six import PY3
+
+
+if PY3:
+
+    from types import SimpleNamespace
+
+else:
+
+    class SimpleNamespace(object):
+
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        def __repr__(self):
+            keys = sorted(self.__dict__)
+            items = ("{}={!r}".format(k, self.__dict__[k]) for k in keys)
+            return "{}({})".format(type(self).__name__, ", ".join(items))
+
+        def __eq__(self, other):
+            return self.__dict__ == other.__dict__
+
 
 def popcount_8(v):
     """Population count for an 8 bit integer"""

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -18,9 +18,11 @@ import multiprocessing
 import os
 import threading
 import time
-import _winreg as winreg
 
 from ctypes import windll, wintypes
+
+# Python 2/3 compatibility.
+from six.moves import winreg
 
 import win32api
 

--- a/setup.py
+++ b/setup.py
@@ -302,6 +302,7 @@ def write_requirements(extra_features=()):
                 requirements.append('%s; %s' % (require, condition))
         elif feature in extra_features:
             requirements.extend(dependencies)
+    requirements = sorted(set(requirements))
     with open('requirements.txt', 'w') as fp:
         fp.write('\n'.join(requirements))
         fp.write('\n')

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,16 @@ from plover import (
 from utils.metadata import copy_metadata
 
 
+def reload_module(mod):
+    # Python 2/3 compatibility.
+    from six.moves import reload_module as _reload
+    _reload(mod)
+
+
 def get_version():
     if not os.path.exists('.git'):
         return None
-    version = subprocess.check_output('git describe --tags --match=v[0-9]*'.split()).strip()
+    version = subprocess.check_output('git describe --tags --match=v[0-9]*'.split()).strip().decode()
     m = re.match(r'^v(\d[\d.]*)(-\d+-g[a-f0-9]*)?$', version)
     assert m is not None, version
     version = m.group(1)
@@ -98,7 +104,7 @@ class Launch(setuptools.Command):
     def run(self):
         # Make sure metadata are up-to-date first.
         self.run_command('egg_info')
-        reload(pkg_resources)
+        reload_module(pkg_resources)
         from plover.main import main
         sys.argv = [' '.join(sys.argv[0:2]) + ' --'] + self.args
         sys.exit(main())
@@ -164,7 +170,7 @@ class Test(setuptools.Command):
     def run(self):
         # Make sure metadata are up-to-date first.
         self.run_command('egg_info')
-        reload(pkg_resources)
+        reload_module(pkg_resources)
         test_dir = os.path.join(os.path.dirname(__file__), 'test')
         # Remove __pycache__ directory so pytest does not freak out
         # when switching between the Linux/Windows versions.
@@ -233,7 +239,7 @@ cmdclass = {
     'tag_weekly': TagWeekly,
     'test': Test,
 }
-setup_requires = []
+setup_requires = ['six']
 options = {}
 kwargs = {}
 

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -16,19 +16,18 @@ class FakeConfig(object):
 
     def __init__(self, **kwargs):
         for name, default in (
-            ('auto_start'                , False                                ),
-            ('machine_type'              , 'Fake'                               ),
-            ('machine_specific_options'  , {}                                   ),
-            ('system_keymap'             , json.dumps([(k, k) for k in
-                                                       system.KEY_ORDER.keys()])),
-            ('dictionary_file_names'     , []                                   ),
-            ('log_file_name'             , os.devnull                           ),
-            ('enable_stroke_logging'     , False                                ),
-            ('enable_translation_logging', False                                ),
-            ('space_placement'           , 'Before Output'                      ),
-            ('undo_levels'               , 10                                   ),
-            ('start_capitalized'         , True                                 ),
-            ('start_attached'            , False                                ),
+            ('auto_start'                , False                             ),
+            ('machine_type'              , 'Fake'                            ),
+            ('machine_specific_options'  , {}                                ),
+            ('system_keymap'             , [(k, k) for k in system.KEY_ORDER]),
+            ('dictionary_file_names'     , []                                ),
+            ('log_file_name'             , os.devnull                        ),
+            ('enable_stroke_logging'     , False                             ),
+            ('enable_translation_logging', False                             ),
+            ('space_placement'           , 'Before Output'                   ),
+            ('undo_levels'               , 10                                ),
+            ('start_capitalized'         , True                              ),
+            ('start_attached'            , False                             ),
         ):
             value = kwargs.get(name, default)
             self.__dict__['get_%s' % name] = partial(lambda v, *a: v, value)

--- a/test/test_json_dict.py
+++ b/test/test_json_dict.py
@@ -29,7 +29,7 @@ class JsonDictionaryTestCase(unittest.TestCase):
             self.assertEqual(a._dict, b)
 
         for contents, expected in (
-            (u'{"S": "a"}'       , {('S', ): 'a'    }),
+            (u'{"S": "a"}'.encode('utf-8'), {('S', ): u'a'}),
             # Default encoding is utf-8.
             (u'{"S": "café"}'.encode('utf-8'), {('S', ): u'café'}),
             # But if that fails, the implementation
@@ -49,7 +49,7 @@ class JsonDictionaryTestCase(unittest.TestCase):
             # Ditto.
             (u'4.2', TypeError),
         ):
-            with make_dict(contents) as filename:
+            with make_dict(contents.encode('utf-8')) as filename:
                 self.assertRaises(exception, load_dictionary, filename)
 
     def test_save_dictionary(self):
@@ -63,11 +63,14 @@ class JsonDictionaryTestCase(unittest.TestCase):
             # Contents should be saved as UTF-8, no escaping.
             ({('S', ): u'café'},
              u'{\n"S": "café"\n}'),
+            # Check escaping of special characters.
+            ({('S', ): u'{^"\n\t"^}'},
+             u'{\n"S": "' + r'{^\"\n\t\"^}' + u'"\n}'),
             # Keys are sorted on save.
             ({('B', ): u'bravo', ('A', ): u'alpha', ('C', ): u'charlie'},
              u'{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}'),
         ):
-            with make_dict('foo') as filename:
+            with make_dict(b'foo') as filename:
                 with open(filename, 'wb') as fp:
                     save_dictionary(contents, fp)
                 with open(filename, 'rb') as fp:

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -44,8 +44,8 @@ class StenoDictionaryTestCase(unittest.TestCase):
         self.assertEqual(d.longest_key, 2)
         self.assertEqual(notifications, [1, 4, 2, 0])
         
-        self.assertEqual(StenoDictionary([('a', 'b')]).items(), [('a', 'b')])
-        self.assertEqual(StenoDictionary(a='b').items(), [('a', 'b')])
+        self.assertEqual(list(StenoDictionary([('a', 'b')]).items()), [('a', 'b')])
+        self.assertEqual(list(StenoDictionary(a='b').items()), [('a', 'b')])
 
     def test_dictionary_collection(self):
         dc = StenoDictionaryCollection()


### PR DESCRIPTION
* fix `setup.py` so the testsuite can be run
* most of the testsuite is passing with Python 3; remaining things that need to fixed:
  * config
  * dictionary formats (JSON is no problem, RTF/CRE is the most problematic)
  * and the Stentura code: this one is a biggy...