### PR TITLE
Add Keywords to FreeDesktop application file

### DIFF
--- a/application/Plover.desktop
+++ b/application/Plover.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.2
+Version=1.1
 Type=Application
 Terminal=false
 Exec=plover

--- a/application/Plover.desktop
+++ b/application/Plover.desktop
@@ -7,4 +7,5 @@ Name=Plover
 Icon=plover
 Categories=Utility;Accessibility;
 Comment=stenographic input and translation
+Keywords=steno;input;keyboard;
 X-Unity-IconBackgroundColor=#414F4C


### PR DESCRIPTION
### About

Added Keywords to the FreeDesktop application file.

### Issues

N/A

### Reason
Patched as part of the Debian packaging effort, to close out lint warnings.

### Release Notes

Not significant enough to go to release notes.

### Tested Platforms
Tested with desktop-file-validate.
