### PR TITLE
Last of the changes needed for core Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools>=19.6' &&
     # Manually install Cython if not already to speedup hidapi build.
     pip --disable-pip-version-check --timeout=5 --retries=2 install --user Cython &&
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt &&
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt -c requirements_constraints.txt &&
     # And now downgrade setuptools so py2app works correctly...
     pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2' &&
     pip --disable-pip-version-check list &&

--- a/linux/README.md
+++ b/linux/README.md
@@ -35,7 +35,7 @@ You can create a pip compatible requirements file with:
 
 And then using pip, e.g. for a user install:
 
-`pip2 install --user -r requirements.txt`
+`pip2 install --user -r requirements.txt -c requirements_constraints.txt`
 
 Notes:
 - if your version of pip is too old, you may get parsing errors on the lines with conditional directives (like `python-xlib>=0.14; "linux" in sys_platform`). You can fix those with the following sed command: `sed -i '/; "/{/; "linux" in sys_platform$/!d;s/; .*//}' requirements.txt`.

--- a/osx/bootstrap.sh
+++ b/osx/bootstrap.sh
@@ -93,7 +93,7 @@ EOT
 
     echo "$0: installing required libraries using pip"
     "$TOPDIR/setup.py" write_requirements &&
-    "$PIP" install -r "$TOPDIR/requirements.txt"
+    "$PIP" install -r "$TOPDIR/requirements.txt" -c "$TOPDIR/requirements_constraints.txt"
 }
 
 main

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -26,6 +26,9 @@ import string
 import select
 import threading
 
+# Python 2/3 compatibility.
+from six import text_type, unichr
+
 from Xlib import X, XK, display
 from Xlib.ext import xinput, xtest
 from Xlib.ext.ge import GenericEventCode
@@ -1050,7 +1053,7 @@ def is_latin1(code):
     return 0x20 <= code <= 0x7e or 0xa0 <= code <= 0xff
 
 def uchr_to_keysym(char):
-    assert isinstance(char, unicode)
+    assert isinstance(char, text_type)
     code = ord(char)
     # Latin-1 characters: direct, 1:1 mapping.
     if is_latin1(code):
@@ -1195,7 +1198,7 @@ class KeyboardEmulation(object):
         s -- The string to emulate.
 
         """
-        assert isinstance(s, unicode)
+        assert isinstance(s, text_type)
         for char in s:
             keysym = uchr_to_keysym(char)
             mapping = self._get_mapping(keysym)

--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,8 @@ if sys.platform.startswith('win32'):
 
 setup_requires.append('pytest')
 
+dependency_links = [
+]
 install_requires = [
     'six',
     'setuptools',
@@ -312,6 +314,9 @@ def write_requirements(extra_features=()):
     with open('requirements.txt', 'w') as fp:
         fp.write('\n'.join(requirements))
         fp.write('\n')
+    with open('requirements_constraints.txt', 'w') as fp:
+        fp.write('\n'.join(dependency_links))
+        fp.write('\n')
 
 
 if __name__ == '__main__':
@@ -339,6 +344,7 @@ if __name__ == '__main__':
         install_requires=install_requires,
         extras_require=extras_require,
         tests_require=tests_require,
+        dependency_links=dependency_links,
         entry_points={
             'console_scripts': ['plover=plover.main:main'],
             'setuptools.installation': ['eggsecutable=plover.main:main'],

--- a/setup.py
+++ b/setup.py
@@ -269,6 +269,7 @@ if sys.platform.startswith('win32'):
 setup_requires.append('pytest')
 
 dependency_links = [
+   'git+https://github.com/benoit-pierre/pyobjc.git@pyobjc-3.1.1+plover#egg=pyobjc-core&subdirectory=pyobjc-core',
 ]
 install_requires = [
     'six',
@@ -288,7 +289,7 @@ extras_require = {
         'wxPython>=3.0',
     ],
     ':"darwin" in sys_platform': [
-        'pyobjc-core>=3.0.3',
+        'pyobjc-core==3.1.1+plover',
         'pyobjc-framework-Cocoa>=3.0.3',
         'pyobjc-framework-Quartz>=3.0.3',
         'wxPython>=3.0',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,18 +3,24 @@
 
 """Unit tests for config.py."""
 
-import os.path
 import unittest
 import os
 import json
 from collections import namedtuple
-from cStringIO import StringIO
+
+# Python 2/3 compatibility.
+from six import BytesIO
 
 from mock import patch
 
-import plover.config as config
+from plover import config
 from plover.machine.registry import Registry
 from plover.oslayer.config import CONFIG_DIR
+
+
+def make_config(contents=''):
+    return BytesIO(b'\n'.join(line.strip().encode('utf-8')
+                              for line in contents.split('\n')))
 
 
 class ConfigTestCase(unittest.TestCase):
@@ -109,18 +115,18 @@ class ConfigTestCase(unittest.TestCase):
             # ...and make sure it is really set.
             self.assertEqual(getter(), case.value1)
             # Load from a file...
-            f = StringIO('[%s]\n%s: %s' % (case.section, case.option,
-                                           case.value2))
+            f = make_config('[%s]\n%s: %s' % (case.section, case.option,
+                                              case.value2))
             c.load(f)
             # ..and make sure the right value is set.
             self.assertEqual(getter(), case.value2)
             # Set a value...
             setter(case.value3)
-            f = StringIO()
+            f = make_config()
             # ...save it...
             c.save(f)
             # ...and make sure it's right.
-            self.assertEqual(f.getvalue(), 
+            self.assertEqual(f.getvalue().decode('utf-8'),
                              '[%s]\n%s = %s\n\n' % (case.section, case.option,
                                                     case.value3))
 
@@ -128,11 +134,11 @@ class ConfigTestCase(unittest.TestCase):
         s = '[%s]%s = %s\n\n' % (config.MACHINE_CONFIG_SECTION, 
                                  config.MACHINE_TYPE_OPTION, 'foo')
         c = config.Config()
-        c.load(StringIO(s))
-        f1 = StringIO()
+        c.load(make_config(s))
+        f1 = make_config()
         c.save(f1)
         c2 = c.clone()
-        f2 = StringIO()
+        f2 = make_config()
         c2.save(f2)
         self.assertEqual(f1.getvalue(), f2.getvalue())
 
@@ -170,14 +176,14 @@ class ConfigTestCase(unittest.TestCase):
             }
             c.set_machine_specific_options(machine_name, options)
             actual = c.get_machine_specific_options(machine_name)
-            expected = dict(defaults.items() + options.items())
+            expected = dict(list(defaults.items()) + list(options.items()))
             self.assertEqual(actual, expected)
             
             # Test loading a file. Unknown option is ignored.
             s = '\n'.join(('[machine foo]', 'stroption1 = foo', 
                            'intoption1 = 3', 'booloption1 = True', 
                            'booloption2 = False', 'unknown = True'))
-            f = StringIO(s)
+            f = make_config(s)
             c.load(f)
             expected = {
                 'stroption1': 'foo',
@@ -185,25 +191,25 @@ class ConfigTestCase(unittest.TestCase):
                 'booloption1': True,
                 'booloption2': False,
             }
-            expected = dict(defaults.items() + expected.items())
+            expected = dict(list(defaults.items()) + list(expected.items()))
             actual = c.get_machine_specific_options(machine_name)
             self.assertEqual(actual, expected)
             
             # Test saving a file.
-            f = StringIO()
+            f = make_config()
             c.save(f)
-            self.assertEqual(f.getvalue(), s + '\n\n')
+            self.assertEqual(f.getvalue().decode('utf-8'), s + '\n\n')
             
             # Test reading invalid values.
             s = '\n'.join(['[machine foo]', 'floatoption1 = None', 
                            'booloption2 = True'])
-            f = StringIO(s)
+            f = make_config(s)
             c.load(f)
             expected = {
                 'floatoption1': 1,
                 'booloption2': True,
             }
-            expected = dict(defaults.items() + expected.items())
+            expected = dict(list(defaults.items()) + list(expected.items()))
             actual = c.get_machine_specific_options(machine_name)
             self.assertEqual(actual, expected)
 
@@ -229,7 +235,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(c.get_dictionary_file_names(), filenames)
         # Load from a file encoded the old way...
         filename = os.path.abspath('/some_file')
-        f = StringIO('[%s]\n%s: %s' % (section, option, filename))
+        f = make_config('[%s]\n%s: %s' % (section, option, filename))
         c.load(f)
         # ..and make sure the right value is set.
         self.assertEqual(c.get_dictionary_file_names(), [filename])
@@ -238,7 +244,7 @@ class ConfigTestCase(unittest.TestCase):
                      for path in ('/b', '/a', '/d', '/c')]
         value = '\n'.join('%s%d: %s' % (option, d, v) 
                               for d, v in enumerate(filenames, start=1))
-        f = StringIO('[%s]\n%s' % (section, value))
+        f = make_config('[%s]\n%s' % (section, value))
         c.load(f)
         # ...and make sure the right value is set.
         self.assertEqual(c.get_dictionary_file_names(), filenames)
@@ -247,13 +253,13 @@ class ConfigTestCase(unittest.TestCase):
         
         # Set a value...
         c.set_dictionary_file_names(filenames)
-        f = StringIO()
+        f = make_config()
         # ...save it...
         c.save(f)
         # ...and make sure it's right.
         value = '\n'.join('%s%d = %s' % (option, d, v) 
                               for d, v in enumerate(filenames, start=1))
-        self.assertEqual(f.getvalue(), 
+        self.assertEqual(f.getvalue().decode('utf-8'),
                          '[%s]\n%s\n\n' % (section, value))
 
     def test_system_keymap(self):
@@ -279,7 +285,7 @@ class ConfigTestCase(unittest.TestCase):
         cfg.set_system_keymap(machine, mappings_list)
         self.assertEqual(cfg.get_system_keymap(machine), mappings_dict)
         def make_config_file(mappings):
-            return StringIO('[%s]\n%s = %s\n\n' % (section, option, json.dumps(mappings)))
+            return make_config('[%s]\n%s = %s\n\n' % (section, option, json.dumps(mappings)))
         # And the config format allow both.
         for mappings in (mappings_list, mappings_dict):
             cfg = config.Config()
@@ -289,6 +295,6 @@ class ConfigTestCase(unittest.TestCase):
         # (to reduce differences between saves)
         cfg = config.Config()
         cfg.set_system_keymap(machine, mappings_dict)
-        contents = StringIO()
+        contents = make_config()
         cfg.save(contents)
         self.assertEqual(contents.getvalue(), make_config_file(sorted(mappings_list)).getvalue())

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -2,10 +2,13 @@
 # See LICENSE.txt for details.
 
 import os
+import codecs
 import tempfile
 import unittest
 from contextlib import contextmanager
-from StringIO import StringIO
+
+# Python 2/3 compatibility.
+from six import BytesIO
 
 import mock
 
@@ -125,10 +128,11 @@ class TestCase(unittest.TestCase):
         @contextmanager
         def make_dict(contents):
             tf = tempfile.NamedTemporaryFile(delete=False)
+            writer = codecs.getwriter('cp1252')(tf)
             try:
-                tf.write(header)
-                tf.write(contents)
-                tf.write(footer)
+                writer.write(header)
+                writer.write(contents)
+                writer.write(footer)
                 tf.close()
                 yield tf.name
             finally:
@@ -207,10 +211,10 @@ class TestCase(unittest.TestCase):
             self.assertEqual(result, expected, msg=msg)
 
     def test_save_dictionary(self):
-        f = StringIO()
+        f = BytesIO()
         d = {
         'S/T': '{pre^}',
         }
         save_dictionary(d, f)
-        expected = '{\\rtf1\\ansi{\\*\\cxrev100}\\cxdict{\\*\\cxsystem Plover}{\\stylesheet{\\s0 Normal;}}\r\n{\\*\\cxs S///T}pre\\cxds \r\n}\r\n' 
+        expected = b'{\\rtf1\\ansi{\\*\\cxrev100}\\cxdict{\\*\\cxsystem Plover}{\\stylesheet{\\s0 Normal;}}\r\n{\\*\\cxs S///T}pre\\cxds \r\n}\r\n'
         self.assertEqual(f.getvalue(), expected)

--- a/windows/README.md
+++ b/windows/README.md
@@ -26,7 +26,7 @@ It is best to develop using 32 bit tools for Plover.
 Most dependencies can be retrieved with pip:
 
 - `python setup.py write_requirements`
-- `pip install -r requirements.txt`
+- `pip install -r requirements.txt -c requirements_constraints.txt`
 
 ### Running Plover in development
 

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -487,7 +487,7 @@ class Helper(object):
             self.install(name, src, checksum, handler_format=handler_format, handler_args=handler_args, path_dir=path_dir)
         info('install requirements')
         self._env.run(('python.exe', 'setup.py', 'write_requirements'))
-        self._pip_install('-r', 'requirements.txt')
+        self._pip_install('-r', 'requirements.txt', '-c', 'requirements_constraints.txt')
 
     def cmd_run(self, executable, *args):
         '''run command in environment


### PR DESCRIPTION
Note:

* configuration: the changes include making sure the configuration file is saved as UTF-8, and string options are returned as Unicode
* RTF/CRE dictionaries: for lack of better RTF file format support, assume the encoding of RTF/CRE dictionaries is cp1252
* Stentura: we can't just replace the use of `buffer` with `memoryview` in Python 3 because it does prevent us from resizing the original `bytearray` when needed