### PR TITLE
Dictionary update: Fixed the entry for the backslash (`\`) symbol.

### DIFF
--- a/plover/assets/main.json
+++ b/plover/assets/main.json
@@ -98878,7 +98878,7 @@
 "SPWHAPBL": "substantial",
 "SPWHAUL": "small",
 "SPWHRA*R": "cerebellar",
-"SPWHRAERB": "{^}\\{^}",
+"SPWHRAERB": "{^\\^}",
 "SPWHRAL": "enthrall",
 "SPWHRAOEU": "blood supply",
 "SPWHRAOEUPL": "sublime",


### PR DESCRIPTION
Fix for the following issue in #400 

Incorrect entry for the backslash.

Old entry (results in `{^`):
```
"SPWHRAERB": "{^}\\{^}",
```
New entry (resulting in `\`):
```
"SPWHRAERB": "{^\\^}",
```