### PR TITLE
Dictionary entry for lowercase "east"

### DIFF
--- a/plover/assets/main.json
+++ b/plover/assets/main.json
@@ -8175,7 +8175,7 @@
 "AOEFS/TKROP/*ER": "eavesdropper",
 "AOEFS/TKROP/PER": "eaves-dropper",
 "AOEFS/TKROPG": "eavesdropping",
-"AOEFT": "East",
+"AOEFT": "east",
 "AOEFT/*ER": "Easter",
 "AOEFT/*ER/SUPBD": "Easter Sunday",
 "AOEFT/*PLT": "easement",

--- a/plover/assets/main.json
+++ b/plover/assets/main.json
@@ -42773,7 +42773,7 @@
 "KRAOBGD/-PBS": "crookedness",
 "KRAOBGD/HREU": "crookedly",
 "KRAOBGS": "crooks",
-"KRAOE": "cree",
+"KRAOE": "CEO",
 "KRAOE/AEU/T*EUF": "creative",
 "KRAOE/AEU/T*EUF/TEU": "creativity",
 "KRAOE/AEU/TOR": "creator",


### PR DESCRIPTION
Just changing this entry:

"AOEFT": "East",

to:

"AOEFT": "east",

so that there is an entry for lowercase "east".

(Issue #400: Dictionary errors)