### PR TITLE
Reduce timeout for TX Bolt protocol

### DIFF
--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -66,7 +66,7 @@ class TxBolt(plover.machine.base.SerialStenotypeBase):
     def run(self):
         """Overrides base class run method. Do not call directly."""
         settings = self.serial_port.getSettingsDict()
-        settings['timeout'] = 0.1 # seconds
+        settings['timeout'] = 0.015 # seconds
         self.serial_port.applySettingsDict(settings)
         self._ready()
         while not self.finished.isSet():


### PR DESCRIPTION
I was speaking with a stenograph dev and he said that our TX bolt timeout is excessive…

> I assume if we're running at 9600 baud and 10 bits/byte (one start, 8 data, one stop) that's just over 1ms/byte (960 bytes/second - 1.042 ms/byte) - so no need to wait more than 1 or 2 ms - not sure what is in the code at the moment 

His own code uses 15 milliseconds. I discovered that I can put my Infinity Ergonomic into TX bolt mode and so I switched the timeout to 15 milliseconds and ran it for a couple days. No stroke splitting issues and the output is noticeably snappier.