### PR TITLE
steno_dictionary: add optional target dictionary to set

### DIFF
--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -90,6 +90,7 @@ class StenoDictionary(collections.MutableMapping):
 
 
 class StenoDictionaryCollection(object):
+
     def __init__(self):
         self.dicts = []
         self.filters = []
@@ -140,9 +141,12 @@ class StenoDictionaryCollection(object):
             if key:
                 return key
 
-    def set(self, key, value):
-        if self.dicts:
-            self.dicts[0][key] = value
+    def set(self, key, value, dictionary=None):
+        if dictionary is None:
+            d = self.dicts[0]
+        else:
+            d = self.get_by_path(dictionary)
+        d[key] = value
 
     def save(self, path_list=None):
         '''Save the dictionaries in <path_list>.

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -55,9 +55,11 @@ class StenoDictionaryTestCase(unittest.TestCase):
         d1 = StenoDictionary()
         d1[('S',)] = 'a'
         d1[('T',)] = 'b'
+        d1.set_path('d1')
         d2 = StenoDictionary()
         d2[('S',)] = 'c'
         d2[('W',)] = 'd'
+        d2.set_path('d2')
         dc.set_dicts([d1, d2])
         self.assertEqual(dc.lookup(('S',)), 'c')
         self.assertEqual(dc.lookup(('W',)), 'd')
@@ -79,6 +81,11 @@ class StenoDictionaryTestCase(unittest.TestCase):
         
         dc.set(('S',), 'e')
         self.assertEqual(dc.lookup(('S',)), 'e')
+        self.assertEqual(d2[('S',)], 'e')
+
+        dc.set(('S',), 'f', dictionary='d1')
+        self.assertEqual(dc.lookup(('S',)), 'e')
+        self.assertEqual(d1[('S',)], 'f')
         self.assertEqual(d2[('S',)], 'e')
 
     def test_dictionary_collection_longest_key(self):


### PR DESCRIPTION
Will be used by the new UI to allow selecting the target dictionary when using the "Add translation" dialog.

