### PR TITLE
add Python 3 (tests only) builds to AppVeyor and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,31 +25,31 @@ matrix:
 
 before_install:
   - |
+    (
+    set -e
     case "$TRAVIS_OS_NAME" in
     osx)
-      brew update &&
-      brew install python --framework &&
-      brew link --overwrite python &&
-      brew install wxpython &&
-      true
+      brew update
+      brew install python --framework
+      brew link --overwrite python
+      brew install wxpython
       ;;
     linux)
-      sudo apt-add-repository -y ppa:benoit.pierre/plover &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -y cython libudev-dev libusb-1.0-0-dev python-dev python-wxgtk3.0 python-xlib &&
-      true
+      sudo apt-add-repository -y ppa:benoit.pierre/plover
+      sudo apt-get update -qq
+      sudo apt-get install -y cython libudev-dev libusb-1.0-0-dev python-dev python-wxgtk3.0 python-xlib
       ;;
-    esac &&
-    ./setup.py write_requirements &&
+    esac
+    ./setup.py write_requirements
     # Upgrade setuptools, we need at least 19.6 to prevent issues with Cython patched 'build_ext' command.
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools>=19.6' &&
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools>=19.6'
     # Manually install Cython if not already to speedup hidapi build.
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --user Cython &&
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt -c requirements_constraints.txt &&
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --user Cython
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt -c requirements_constraints.txt
     # And now downgrade setuptools so py2app works correctly...
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2' &&
-    pip --disable-pip-version-check list &&
-    true
+    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2'
+    pip --disable-pip-version-check list
+    )
 
 install: true
 
@@ -60,18 +60,19 @@ script:
 
 before_deploy:
   - |
+    (
+    set -e
     case "$TRAVIS_OS_NAME" in
     osx)
-      make -C osx &&
-      true
+      make -C osx
       ;;
     linux)
-      ./setup.py bdist_egg &&
-      ./setup.py bdist_wheel &&
-      true
+      ./setup.py bdist_{egg,wheel}
       ;;
-    esac &&
-    du -hs dist/*
+    esac
+    # Not all builds will produce artifacts.
+    du -hs dist/* || true
+    )
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,15 @@ before_install:
       ;;
     esac
     ./setup.py write_requirements
+    pip() { python2 -m pip --disable-pip-version-check --timeout=5 --retries=2 "$@"; }
     # Upgrade setuptools, we need at least 19.6 to prevent issues with Cython patched 'build_ext' command.
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools>=19.6'
+    pip install --upgrade --user 'setuptools>=19.6'
     # Manually install Cython if not already to speedup hidapi build.
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --user Cython
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user -r requirements.txt -c requirements_constraints.txt
+    pip install --user Cython
+    pip install --upgrade --user -r requirements.txt -c requirements_constraints.txt
     # And now downgrade setuptools so py2app works correctly...
-    pip --disable-pip-version-check --timeout=5 --retries=2 install --upgrade --user 'setuptools==19.2'
-    pip --disable-pip-version-check list
+    pip install --upgrade --user 'setuptools==19.2'
+    pip list
     )
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,21 @@ language: generic
 
 matrix:
   include:
+    # Linux / Python 2
     - os: linux
+      env:
+        - CACHE_NAME=linux_py2
       dist: trusty
       sudo: required
-      # Disabled until Travis CI allows using a different cache ID for each OS.
-      # cache:
-      #   directories:
-      #     - $HOME/.cache/pip
-      # before_cache:
-      #   - rm -rf $HOME/.cache/pip/log
+      cache:
+        directories:
+          - $HOME/.cache/pip
+      before_cache:
+        - rm -rf $HOME/.cache/pip/log
+    # OSX / Python 2
     - os: osx
+      env:
+        - CACHE_NAME=osx_py2
       cache:
         directories:
           - /Users/travis/Library/Caches/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,20 @@ matrix:
     # Linux / Python 2
     - os: linux
       env:
+        - PYTHON=python2
         - CACHE_NAME=linux_py2
+      dist: trusty
+      sudo: required
+      cache:
+        directories:
+          - $HOME/.cache/pip
+      before_cache:
+        - rm -rf $HOME/.cache/pip/log
+    # Linux / Python 3
+    - os: linux
+      env:
+        - PYTHON=python3
+        - CACHE_NAME=linux_py3
       dist: trusty
       sudo: required
       cache:
@@ -16,7 +29,18 @@ matrix:
     # OSX / Python 2
     - os: osx
       env:
+        - PYTHON=python2
         - CACHE_NAME=osx_py2
+      cache:
+        directories:
+          - /Users/travis/Library/Caches/pip
+      before_cache:
+        - rm -rf /Users/travis/Library/Caches/pip/log
+    # OSX / Python 3
+    - os: osx
+      env:
+        - PYTHON=python3
+        - CACHE_NAME=osx_py3
       cache:
         directories:
           - /Users/travis/Library/Caches/pip
@@ -29,19 +53,60 @@ before_install:
     set -e
     case "$TRAVIS_OS_NAME" in
     osx)
+      python_package=''
+      packages=()
+      case $PYTHON in
+      python2)
+        python_package='python'
+        packages+=( \
+          wxpython \
+        )
+        ;;
+      python3)
+        python_package='python3'
+        packages+=( \
+        )
+        ;;
+      esac
       brew update
-      brew install python --framework
-      brew link --overwrite python
-      brew install wxpython
+      brew install $python_package --framework
+      brew link --overwrite $python_package
+      [ -n "$packages" ] && brew install "${packages[@]}"
       ;;
     linux)
       sudo apt-add-repository -y ppa:benoit.pierre/plover
       sudo apt-get update -qq
-      sudo apt-get install -y cython libudev-dev libusb-1.0-0-dev python-dev python-wxgtk3.0 python-xlib
+      packages=(libudev-dev libusb-1.0-0-dev)
+      case $PYTHON in
+      python2)
+        packages+=( \
+          cython \
+          python-dev \
+          python-pip \
+          python-pkg-resources \
+          python-wheel \
+          python-wxgtk3.0 \
+          python-xlib \
+        )
+        ;;
+      python3)
+        packages+=( \
+          cython3 \
+          python3-dev \
+          python3-pip \
+          python3-pkg-resources \
+          python3-wheel \
+          python3-xlib \
+        )
+        ;;
+      esac
+      [ -n "$packages" ] && sudo apt-get install -y "${packages[@]}"
       ;;
     esac
-    ./setup.py write_requirements
-    pip() { python2 -m pip --disable-pip-version-check --timeout=5 --retries=2 "$@"; }
+    $PYTHON setup.py write_requirements
+    pip() { $PYTHON -m pip --disable-pip-version-check --timeout=5 --retries=2 "$@"; }
+    # Update antiquated version of pip on Ubuntu...
+    $PYTHON -m pip install --upgrade --user pip
     # Upgrade setuptools, we need at least 19.6 to prevent issues with Cython patched 'build_ext' command.
     pip install --upgrade --user 'setuptools>=19.6'
     # Manually install Cython if not already to speedup hidapi build.
@@ -56,8 +121,8 @@ install: true
 
 script:
   - git fetch --unshallow
-  - ./setup.py patch_version
-  - ./setup.py test
+  - $PYTHON setup.py patch_version
+  - $PYTHON setup.py test
 
 before_deploy:
   - |
@@ -65,10 +130,13 @@ before_deploy:
     set -e
     case "$TRAVIS_OS_NAME" in
     osx)
-      make -C osx
+      if [ $PYTHON = python2 ]
+      then
+        make -C osx
+      fi
       ;;
     linux)
-      ./setup.py bdist_{egg,wheel}
+      $PYTHON setup.py bdist_{egg,wheel}
       ;;
     esac
     # Not all builds will produce artifacts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,9 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
 
 cache:
   # Keep cache of downloaded pip packages.
@@ -64,7 +67,7 @@ build_script:
   - "ECHO PATH=%PATH%"
 
 after_build:
-  - "python windows\\helper.py dist"
+  - ps: "if ($Env:PYTHON_VERSION -eq \"2.7\") { python windows\\helper.py dist }"
 
 test_script:
   - "python setup.py test"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2010 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
+import contextlib
 import os
 import re
 import shutil
@@ -24,12 +25,6 @@ from plover import (
 )
 
 from utils.metadata import copy_metadata
-
-
-def reload_module(mod):
-    # Python 2/3 compatibility.
-    from six.moves import reload_module as _reload
-    _reload(mod)
 
 
 def get_version():
@@ -63,7 +58,33 @@ def pyinstaller(*args):
     return main(py_args) or 0
 
 
-class PyInstallerDist(setuptools.Command):
+class Command(setuptools.Command):
+
+    def build_in_place(self):
+        self.run_command('build_py')
+        self.reinitialize_command('build_ext', inplace=1)
+        self.run_command('build_ext')
+
+    @contextlib.contextmanager
+    def project_on_sys_path(self):
+        self.build_in_place()
+        ei_cmd = self.get_finalized_command("egg_info")
+        old_path = sys.path[:]
+        old_modules = sys.modules.copy()
+        try:
+            sys.path.insert(0, pkg_resources.normalize_path(ei_cmd.egg_base))
+            pkg_resources.working_set.__init__()
+            pkg_resources.add_activation_listener(lambda dist: dist.activate())
+            pkg_resources.require('%s==%s' % (ei_cmd.egg_name, ei_cmd.egg_version))
+            yield
+        finally:
+            sys.path[:] = old_path
+            sys.modules.clear()
+            sys.modules.update(old_modules)
+            pkg_resources.working_set.__init__()
+
+
+class PyInstallerDist(Command):
 
     user_options = []
     extra_args = []
@@ -75,8 +96,7 @@ class PyInstallerDist(setuptools.Command):
         pass
 
     def run(self):
-        # Make sure metadata are up-to-date first.
-        self.run_command("egg_info")
+        self.build_in_place()
         code = pyinstaller(*self.extra_args)
         if code != 0:
             sys.exit(code)
@@ -89,7 +109,7 @@ class BinaryDistWin(PyInstallerDist):
     ]
 
 
-class Launch(setuptools.Command):
+class Launch(Command):
 
     description = 'run %s from source' % __software_name__.capitalize()
     command_consumes_arguments = True
@@ -102,15 +122,13 @@ class Launch(setuptools.Command):
         pass
 
     def run(self):
-        # Make sure metadata are up-to-date first.
-        self.run_command('egg_info')
-        reload_module(pkg_resources)
-        from plover.main import main
-        sys.argv = [' '.join(sys.argv[0:2]) + ' --'] + self.args
-        sys.exit(main())
+        with self.project_on_sys_path():
+            from plover.main import main
+            sys.argv = [' '.join(sys.argv[0:2]) + ' --'] + self.args
+            sys.exit(main())
 
 
-class PatchVersion(setuptools.Command):
+class PatchVersion(Command):
 
     description = 'patch package version from VCS'
     user_options = []
@@ -135,7 +153,7 @@ class PatchVersion(setuptools.Command):
             fp.write('\n'.join(contents))
 
 
-class TagWeekly(setuptools.Command):
+class TagWeekly(Command):
 
     description = 'tag weekly version'
     user_options = []
@@ -155,7 +173,7 @@ class TagWeekly(setuptools.Command):
         subprocess.check_call('git tag -f'.split() + [weekly_version])
 
 
-class Test(setuptools.Command):
+class Test(Command):
 
     description = 'run unit tests after in-place build'
     command_consumes_arguments = True
@@ -168,9 +186,10 @@ class Test(setuptools.Command):
         pass
 
     def run(self):
-        # Make sure metadata are up-to-date first.
-        self.run_command('egg_info')
-        reload_module(pkg_resources)
+        with self.project_on_sys_path():
+            self.run_tests()
+
+    def run_tests(self):
         test_dir = os.path.join(os.path.dirname(__file__), 'test')
         # Remove __pycache__ directory so pytest does not freak out
         # when switching between the Linux/Windows versions.
@@ -239,7 +258,7 @@ cmdclass = {
     'tag_weekly': TagWeekly,
     'test': Test,
 }
-setup_requires = ['six']
+setup_requires = []
 options = {}
 kwargs = {}
 

--- a/setup.py
+++ b/setup.py
@@ -271,6 +271,7 @@ setup_requires.append('pytest')
 dependency_links = [
    'git+https://github.com/benoit-pierre/pyobjc.git@pyobjc-3.1.1+plover#egg=pyobjc-core&subdirectory=pyobjc-core',
 ]
+
 install_requires = [
     'six',
     'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -339,6 +339,7 @@ if __name__ == '__main__':
         author_email='joshua.harlan.lifton@gmail.com',
         maintainer='Ted Morin',
         maintainer_email='morinted@gmail.com',
+        include_package_data=True,
         zip_safe=True,
         options=options,
         cmdclass=cmdclass,
@@ -356,9 +357,6 @@ if __name__ == '__main__':
             'plover.oslayer', 'plover.dictionary',
             'plover.system',
         ],
-        package_data={
-            'plover': ['assets/*'],
-        },
         data_files=[
             ('share/applications', ['application/Plover.desktop']),
             ('share/pixmaps', ['plover/assets/plover.png']),

--- a/setup.py
+++ b/setup.py
@@ -302,17 +302,14 @@ install_requires = [
 extras_require = {
     ':"win32" in sys_platform': [
         'pywin32>=219',
-        # Can't reliably require wxPython
     ],
     ':"linux" in sys_platform': [
         'python-xlib>=0.16',
-        'wxPython>=3.0',
     ],
     ':"darwin" in sys_platform': [
         'pyobjc-core==3.1.1+plover',
         'pyobjc-framework-Cocoa>=3.0.3',
         'pyobjc-framework-Quartz>=3.0.3',
-        'wxPython>=3.0',
         'appnope>=0.1.0',
     ],
 }

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -134,6 +134,8 @@ class WineEnvironment(Environment):
             info('intializing Wine prefix')
             for cmd in (
                 'env DISPLAY= wineboot --init',
+                # Wait for previous command to finish.
+                'wineserver -w',
                 'winetricks --no-isolate --unattended corefonts vcrun2008',
             ):
                 self.run(cmd.split())

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -400,7 +400,9 @@ class Helper(object):
         if not self.unattended and filename.endswith('.exe'):
             cmd = [filename]
         else:
-            cmd = ['easy_install.exe']
+            # Don't use easy_install.exe so setuptools
+            # can update itself if needed.
+            cmd = ['python.exe', '-m', 'easy_install']
             if not self.verbose:
                 cmd.append('--quiet')
             cmd.extend(options)
@@ -408,7 +410,8 @@ class Helper(object):
         self._env.run(cmd)
 
     def _pip_install(self, *args):
-        cmd = ['pip.exe',
+        # Don't use pip.exe so pip can update itself if needed.
+        cmd = ['python.exe', '-m', 'pip',
                '--timeout=5',
                '--retries=2',
                '--disable-pip-version-check']


### PR DESCRIPTION
Note: I removed the wxPython requirements in `setup.py` since it's not possible to require it on Windows, and we need to install it manually anyway on all platforms (because it's not installable through pip).