### PR TITLE
gui/log: handle exceptions during platform handler init

### DIFF
--- a/plover/gui/log.py
+++ b/plover/gui/log.py
@@ -7,15 +7,20 @@ handler = None
 try:
     if sys.platform.startswith('linux'):
         from plover.oslayer.log_dbus import DbusNotificationHandler
-        handler = DbusNotificationHandler
+        handler_class = DbusNotificationHandler
     elif sys.platform.startswith('darwin'):
         from plover.oslayer.log_osx import OSXNotificationHandler
-        handler = OSXNotificationHandler
-except Exception as e:
-    log.info('could not import platform gui log', exc_info=e)
+        handler_class = OSXNotificationHandler
+except Exception:
+    log.warning('could not import platform gui log', exc_info=True)
+else:
+    try:
+        handler = handler_class()
+    except Exception:
+        log.error('could not initialize platform gui log', exc_info=True)
 
 if handler is None:
     from plover.gui.log_wx import WxNotificationHandler
-    handler = WxNotificationHandler
+    handler = WxNotificationHandler()
 
-log.add_handler(handler())
+log.add_handler(handler)


### PR DESCRIPTION
Example use case: dbus is available, but not the notifications service:
```
DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.Notifications was not provided by any .service files
```