### PR TITLE
Sort stroke keys when logging

### DIFF
--- a/plover/log.py
+++ b/plover/log.py
@@ -12,7 +12,7 @@ from logging.handlers import RotatingFileHandler
 from logging import DEBUG, INFO, WARNING, ERROR
 
 from plover.oslayer.config import CONFIG_DIR
-
+from plover import system
 
 LOG_FORMAT = '%(asctime)s [%(threadName)s] %(levelname)s: %(message)s'
 LOG_FILENAME = os.path.realpath(os.path.join(CONFIG_DIR, 'plover.log'))
@@ -113,6 +113,7 @@ class Logger(object):
     def log_stroke(self, steno_keys):
         if not self._log_strokes or self._stroke_handler is None:
             return
+        steno_keys.sort(key=lambda x: system.KEY_ORDER.get(x, -1))
         self._stroke_logger.info('Stroke(%s)', ' '.join(steno_keys))
 
     def log_translation(self, undo, do, prev):


### PR DESCRIPTION
### About

Sort stroke keys in log file.

### Issues

Fixes #187

### Reason

Before:

```
2016-09-08 16:05:53,350 Stroke(A- -T P-)
2016-09-08 16:05:53,351 Translation(('PAT',) : "pat")
```

After:

```
2016-09-08 16:14:50,772 Stroke(P- A- -T)
2016-09-08 16:14:50,776 Translation(('PAT',) : "pat")
2016-09-08 16:14:59,539 Stroke(S- T- P- H- -F -R -P -B -L -G -T -S)
2016-09-08 16:14:59,553 Translation(('STPH-FRPBLGTS',) : None)
```
