### PR TITLE
Sort stroke keys when logging

### DIFF
--- a/plover/log.py
+++ b/plover/log.py
@@ -12,7 +12,7 @@ from logging.handlers import RotatingFileHandler
 from logging import DEBUG, INFO, WARNING, ERROR
 
 from plover.oslayer.config import CONFIG_DIR
-
+from plover.steno import Stroke
 
 LOG_FORMAT = '%(asctime)s [%(threadName)s] %(levelname)s: %(message)s'
 LOG_FILENAME = os.path.realpath(os.path.join(CONFIG_DIR, 'plover.log'))
@@ -113,7 +113,7 @@ class Logger(object):
     def log_stroke(self, steno_keys):
         if not self._log_strokes or self._stroke_handler is None:
             return
-        self._stroke_logger.info('Stroke(%s)', ' '.join(steno_keys))
+        self._stroke_logger.info('%s', Stroke(steno_keys))
 
     def log_translation(self, undo, do, prev):
         if not self._log_translations or self._stroke_handler is None:

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -46,21 +46,30 @@ class LoggerTestCase(unittest.TestCase):
         stroke_filename1 = self._stroke_filename('/fn1')
         self.logger.set_stroke_filename('/fn1')
         self.logger.enable_stroke_logging(True)
-        self.logger.stroke(('S',))
+        self.logger.stroke(('S-',))
         stroke_filename2 = self._stroke_filename('/fn2')
         self.logger.set_stroke_filename('/fn2')
-        self.logger.stroke(('T',))
+        self.logger.stroke(('-T',))
         self.logger.set_stroke_filename(None)
-        self.logger.stroke(('P',))
-        self.assertEqual(FakeHandler.get_output(), {stroke_filename1: ['Stroke(S)'], 
-                                                    stroke_filename2: ['Stroke(T)']})
+        self.logger.stroke(('P-',))
+        self.assertEqual(FakeHandler.get_output(),
+                         {stroke_filename1: ["Stroke(S : ['S-'])"],
+                          stroke_filename2: ["Stroke(-T : ['-T'])"]
+                          }
+                         )
 
     def test_stroke(self):
         stroke_filename = self._stroke_filename('/fn')
         self.logger.set_stroke_filename(stroke_filename)
         self.logger.enable_stroke_logging(True)
-        self.logger.stroke(('ST', 'T'))
-        self.assertEqual(FakeHandler.get_output(), {stroke_filename: ['Stroke(ST T)']})
+        self.logger.stroke(('S-', '-T', 'T-'))
+        self.logger.stroke(('#', 'S-', '-T'))
+        self.assertEqual(FakeHandler.get_output(),
+                         {stroke_filename: ["Stroke(ST-T : ['S-', 'T-', '-T'])",
+                                            "Stroke(1-9 : ['1-', '-9'])"
+                                            ]
+                          }
+                         )
 
     def test_log_translation(self):
         stroke_filename = self._stroke_filename('/fn')
@@ -73,12 +82,14 @@ class LoggerTestCase(unittest.TestCase):
     def test_enable_stroke_logging(self):
         stroke_filename = self._stroke_filename('/fn')
         self.logger.set_stroke_filename(stroke_filename)
-        self.logger.stroke(('a',))
+        self.logger.stroke(('S-',))
         self.logger.enable_stroke_logging(True)
-        self.logger.stroke(('b',))
+        self.logger.stroke(('T-',))
         self.logger.enable_stroke_logging(False)
-        self.logger.stroke(('c',))
-        self.assertEqual(FakeHandler.get_output(), {stroke_filename: ['Stroke(b)']})
+        self.logger.stroke(('K-',))
+        self.assertEqual(FakeHandler.get_output(),
+                         {stroke_filename: ["Stroke(T : ['T-'])"]}
+                         )
 
     def test_enable_translation_logging(self):
         stroke_filename = self._stroke_filename('/fn')


### PR DESCRIPTION
### About

Sort stroke keys in log file.

### Issues

Fixes #187

### Reason

Before

```
2016-09-08 16:05:53,350 Stroke(A- -T P-)
2016-09-08 16:05:53,351 Translation(('PAT',) : "pat")
```

After

```
2016-09-08 22:15:33,197 Stroke(TAP : ['T-', 'A-', '-P'])
2016-09-08 22:15:33,198 Translation(('TAP',) : "tap")
```