### PR TITLE
Update license to GPLv2+

### DIFF
--- a/plover/__init__.py
+++ b/plover/__init__.py
@@ -14,7 +14,7 @@ __credits__ = ['Founded by stenographer Mirabai Knight.\n\nDevelopers:'
                'Benoit Pierre',
                '\nand many more on GitHub: \n<https://github.com/openstenoproject/plover>'
                ]
-__license__ = 'GNU General Public License v2 (GPLv2)'
+__license__ = 'GNU General Public License v2 or later (GPLv2+)'
 __description__ = 'Open Source Stenography Software'
 __long_description__ = """\
 Plover is a free open source program intended to bring realtime

--- a/setup.py
+++ b/setup.py
@@ -364,7 +364,7 @@ if __name__ == '__main__':
         ],
         classifiers=[
             'Programming Language :: Python :: 2.7',
-            'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+            'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
             'Development Status :: 5 - Production/Stable',
             'Environment :: X11 Applications',
             'Environment :: MacOS X',


### PR DESCRIPTION
### About

Update the license to explicitly state GPLv2+, instead of only GPLv2. This is an attempt to resolve our license conflicts; some of our libraries are GPLv3. For this change, we've received permission from all copyright holders in issue #336 

The wording was grabbed from https://pypi.python.org/pypi?%3Aaction=list_classifiers

### Issues

Closes #336
