### PR TITLE
Add ProCAT machine

### DIFF
--- a/plover/machine/geminipr.py
+++ b/plover/machine/geminipr.py
@@ -6,7 +6,7 @@
 # Python 2/3 compatibility.
 from six import iterbytes
 
-import plover.machine.base
+from plover.machine.base import SerialStenotypeBase
 
 # In the Gemini PR protocol, each packet consists of exactly six bytes
 # and the most significant bit (MSB) of every byte is used exclusively
@@ -25,13 +25,8 @@ STENO_KEY_CHART = ("Fn", "#1", "#2", "#3", "#4", "#5", "#6",
 BYTES_PER_STROKE = 6
 
 
-class GeminiPr(plover.machine.base.SerialStenotypeBase):
+class GeminiPr(SerialStenotypeBase):
     """Standard stenotype interface for a Gemini PR machine.
-
-    This class implements the three methods necessary for a standard
-    stenotype interface: start_capture, stop_capture, and
-    add_callback.
-
     """
 
     KEYS_LAYOUT = '''

--- a/plover/machine/procat.py
+++ b/plover/machine/procat.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2016 Ted Morin
+# See LICENSE.txt for details.
+
+"""Thread-based monitoring of a ProCAT stenotype machine."""
+
+# Python 2/3 compatibility.
+from six import iterbytes
+
+from plover.machine.base import SerialStenotypeBase
+
+"""
+ProCAT machines send 4 bytes per stroke, with the last byte only consisting of
+FF. So we need only look at the first 3 bytes to see our steno. The leading
+bit is 0.
+"""
+STENO_KEY_CHART = ('', '#', 'S-', 'T-', 'K-', 'P-', 'W-', 'H-',
+                   'R-', 'A-', 'O-', '*', '-E', '-U', '-F', '-R',
+                   '-P', '-B', '-L', '-G', '-T', '-S', '-D', '-Z',
+                   )
+
+BYTES_PER_STROKE = 4
+
+
+class ProCAT(SerialStenotypeBase):
+    """Interface for ProCAT machines.
+    """
+
+    KEYS_LAYOUT = '''
+        #  #  #  #  #  #  #  #  #  #
+        S- T- P- H- * -F -P -L -T -D
+        S- K- W- R- * -R -B -G -S -Z
+               A- O- -E -U
+    '''
+
+    def run(self):
+        """Overrides base class run method. Do not call directly."""
+        self._ready()
+        while not self.finished.isSet():
+
+            # Grab data from the serial port.
+            raw = self.serial_port.read(BYTES_PER_STROKE)
+            if not raw:
+                continue
+
+            # Convert the raw to a list of steno keys.
+            steno_keys = self.keymap.keys_to_actions(
+                self.process_steno_packet(raw)
+            )
+            if steno_keys:
+                # Notify all subscribers.
+                self._notify(steno_keys)
+
+    @staticmethod
+    def process_steno_packet(raw):
+        # Raw packet has 4 bytes, we only care about the first 3
+        steno_keys = []
+        for i, b in enumerate(iterbytes(raw[:3])):
+            for j in range(0, 8):
+                if b & 0x80 >> j:
+                    steno_keys.append(STENO_KEY_CHART[i * 8 + j])
+        return steno_keys
+
+

--- a/plover/machine/registry.py
+++ b/plover/machine/registry.py
@@ -8,6 +8,7 @@ from plover.machine.txbolt import TxBolt
 from plover.machine.keyboard import Keyboard
 from plover.machine.stentura import Stentura
 from plover.machine.passport import Passport
+from plover.machine.procat import ProCAT
 from plover.machine.treal import Treal
 
 class NoSuchMachineException(Exception):
@@ -49,6 +50,7 @@ machine_registry.register('Gemini PR', GeminiPr)
 machine_registry.register('TX Bolt', TxBolt)
 machine_registry.register('Stentura', Stentura)
 machine_registry.register('Passport', Passport)
+machine_registry.register('ProCAT', ProCAT)
 machine_registry.register('Treal', Treal)
 
 # Legacy configuration

--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -237,3 +237,5 @@ KEYMAPS = {
     },
 }
 
+KEYMAPS['ProCAT'] = KEYMAPS['TX Bolt']
+


### PR DESCRIPTION
### About

Add the ProCAT machine, thanks to David Graper for sending a handy little diagram from his Blaze: [BlazeKeyouts.pdf](https://github.com/openstenoproject/plover/files/468399/BlazeKeyouts.pdf)

When contacting ProCAT, the representative told me that the Flash, Blaze, Stylus I & II, Impression, and Xpression all use the same protocol. Thankfully that should mean we get support for them all.

### Reason

While some ProCAT writers could emulate TX Bolt, it wasn't true of all of them. I believe the Blaze was the last to emulate another protocol.

### Release Notes

We should add ProCAT machines to the list of supported writers.

### Tested Platforms

Glen and I tested on Windows, but I'll leave further testing for the weekly -- I imagine it will work since we're just using the serial base class.

