### PR TITLE
Ignore only KeyPress when a modifier is set

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -213,16 +213,15 @@ class KeyboardCapture(threading.Thread):
             assert event.data.sourceid in self.devices
             keycode = event.data.detail
             modifiers = event.data.mods.effective_mods & ~0b10000 & 0xFF
-            # Ignore event if a modifier is set.
-            if modifiers != 0:
-                continue
             key = KEYCODE_TO_KEY.get(keycode)
             if key is None:
                 # Not a supported key, ignore...
                 continue
             # ...or pass it on to a callback method.
             if event.evtype == xinput.KeyPress:
-                self.key_down(key)
+                # Ignore event if a modifier is set.
+                if modifiers == 0:
+                    self.key_down(key)
             elif event.evtype == xinput.KeyRelease:
                 self.key_up(key)
 


### PR DESCRIPTION
Previously, both KeyPress and KeyRelease were ignored if there were any modifiers. This runs into the issue of a key "sticking" in a perpetually pressed state if the key is pressed without modifiers but released with modifiers.

This wouldn't be an issue in steno, but it creates problems when switching in and out of steno with `{PLOVER:TOGGLE}` and typing rapidly with a conventional keyboard layout. (See the GitHub issue referenced for further details.)

Fixes #597.