### PR TITLE
machine/procat: don't send empty string as key

### DIFF
--- a/plover/machine/keymap.py
+++ b/plover/machine/keymap.py
@@ -85,7 +85,7 @@ class Keymap(object):
     def keys_to_actions(self, key_list):
         action_list = []
         for key in key_list:
-            assert key in self._keys
+            assert key in self._keys, "'%s' not in %s" % (key, self._keys)
             action = self._bindings[key]
             if 'no-op' != action:
                 action_list.append(action)

--- a/plover/machine/procat.py
+++ b/plover/machine/procat.py
@@ -57,7 +57,9 @@ class ProCAT(SerialStenotypeBase):
         for i, b in enumerate(iterbytes(raw[:3])):
             for j in range(0, 8):
                 if b & 0x80 >> j:
-                    steno_keys.append(STENO_KEY_CHART[i * 8 + j])
+                    key = STENO_KEY_CHART[i * 8 + j]
+                    if key:
+                        steno_keys.append(key)
         return steno_keys
 
 


### PR DESCRIPTION
### About

Don't send the empty key as a string to keymap.py from the ProCAT machine.

### Issues

Hopefully fixes #601 

### Testing

Not tested.