### PR TITLE
travis: workaround brew's pkg-config script not working on 10.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,7 @@ before_install:
         )
         ;;
       esac
-      brew update
-      brew install $python_package --framework
+      (cd /usr/local/Homebrew && git fetch --depth=2000 && git checkout b1746de260 && HOMEBREW_NO_AUTO_UPDATE=1 brew install $python_package --framework)
       brew link --overwrite $python_package
       [ -n "$packages" ] && brew install "${packages[@]}"
       ;;


### PR DESCRIPTION
Python fails installation because the Python installer depends on
Python 2.5+, which 10.9 doesn't have. We can revert this change
once we update macOS versions.

Brew will auto-update after Python is installed.