### PR TITLE
PRIORITY_DICT

### DIFF
--- a/plover/dictionary/prioritize_dictionaries.py
+++ b/plover/dictionary/prioritize_dictionaries.py
@@ -1,0 +1,27 @@
+from plover import log
+
+def prioritize_dictionaries(selections, old_file_names):
+    def match_partial_path(file_names, selection):
+        matches = []
+        for file_name in file_names:
+            if file_name.endswith(selection):
+                matches.append(file_name)
+
+        if matches:
+            matches.sort(key=len)
+            return(matches[0])
+
+    selections = [x.strip() for x in selections.split(";")]
+    selections.reverse()
+    new_file_names = old_file_names[:]
+    for selection in selections:
+        matching_file = match_partial_path(old_file_names, selection)
+        if matching_file:
+            ix = new_file_names.index(matching_file)
+            t = new_file_names.pop(ix)
+            new_file_names.append(t)
+        else:
+            log.error('No dictionary file matching "%s" found.' % selection, exc_info=True)
+        
+    return new_file_names     
+

--- a/test/test_priority_dict.py
+++ b/test/test_priority_dict.py
@@ -1,0 +1,42 @@
+import unittest
+
+from plover.dictionary.prioritize_dictionaries import prioritize_dictionaries
+
+class PriorityDictTest(unittest.TestCase):
+    def setUp(self):
+        self.starting_dict_order = \
+                [u'~/.local/share/plover/spanish/main.json',
+                u'~/.local/share/plover/main.json',
+                u'~/.local/share/plover/commands.json',
+                u'~/.local/share/plover/user.json']
+
+    def test_shortest_path_dictionary_is_default(self):
+        new_order_bare_main = prioritize_dictionaries("main.json",
+                self.starting_dict_order)
+        self.assertEqual(new_order_bare_main,
+                [u'~/.local/share/plover/spanish/main.json',
+                u'~/.local/share/plover/commands.json',
+                u'~/.local/share/plover/user.json',
+                u'~/.local/share/plover/main.json'])
+        
+        #vs
+
+        new_order_spanish_main = prioritize_dictionaries("spanish/main.json",
+                new_order_bare_main)
+        self.assertEqual(new_order_spanish_main,
+                [u'~/.local/share/plover/commands.json',
+                u'~/.local/share/plover/user.json',
+                u'~/.local/share/plover/main.json',
+                u'~/.local/share/plover/spanish/main.json'])
+
+    def test_order_multiple_dictionaries(self):
+        #new_order = prioritize_dictionaries("commands.json;spanish/main.json; user.json;",
+        new_order = prioritize_dictionaries("commands.json;spanish/main.json; user.json;",
+                self.starting_dict_order)
+
+        self.assertEqual(new_order,
+                [u'~/.local/share/plover/main.json',
+                u'~/.local/share/plover/user.json',
+                u'~/.local/share/plover/spanish/main.json',
+                u'~/.local/share/plover/commands.json'])
+


### PR DESCRIPTION
### Reason

Feature described in "Any update on Spanish input in Plover?" on the Google group.

### Release Notes

Uses the PLOVER:PRIORITY_DICT command to prioritize a dictionary or comma separated list of dictionaries, the first one being the highest priority.
e.g.
{
  "SP-RB": "{PLOVER:PRIORITY_DICT:spanish/main.json; commands.json, briefs.json}",
  "HR-RB": "{PLOVER:PRIORITY_DICT:main.json; commands.json, briefs.json}"
}
### Tested Platforms

Tested on Ubuntu 15.10

I'm getting less GitHub-illiterate by the hour, but this is my first time trying a pull request. Let me know if something's off.