### PR TITLE
oslayer/osxkeyboardcontrol: don't ignore key release with modifiers

### DIFF
--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -214,7 +214,7 @@ class KeyboardCapture(threading.Thread):
                                       kCGEventFlagMaskNonCoalesced)
             has_nonsupressible_modifiers = \
                 CGEventGetFlags(event) & ~suppressible_modifiers
-            if has_nonsupressible_modifiers:
+            if has_nonsupressible_modifiers and event_type == kCGEventKeyDown:
                 return PASS_EVENT_THROUGH
 
             keycode = CGEventGetIntegerValueField(


### PR DESCRIPTION
Fix #597 on Mac as well. See #598 and #609.