### PR TITLE
machine/txbolt: improve timeout handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -321,11 +321,12 @@ dependency_links = [
 ]
 
 install_requires = [
-    'six',
-    'setuptools',
-    'pyserial>=2.7',
     'appdirs>=1.3.0',
     'hidapi',
+    'monotonic',
+    'pyserial>=2.7',
+    'setuptools',
+    'six',
 ]
 
 extras_require = {


### PR DESCRIPTION
Rewrite handling so the code really wait at most 50ms (taking into account the time spent processing a stroke), and at least 25ms (to avoid splitting a stroke when using some machines).

Test release available [here](https://github.com/benoit-pierre/plover/releases/tag/txbolt_timeout_test).