### PR TITLE
Plugins support: improve systems

### DIFF
--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -19,6 +19,7 @@ import plover.dictionary.json_dict as json_dict
 import plover.dictionary.rtfcre_dict as rtfcre_dict
 from plover.config import JSON_EXTENSION, RTF_EXTENSION
 from plover.exception import DictionaryLoaderException
+from plover.resource import ASSET_SCHEME
 
 dictionaries = {
     JSON_EXTENSION.lower(): json_dict,
@@ -43,6 +44,7 @@ def create_dictionary(filename):
     Note: the file is not created! The resulting dictionary save
     method must be called to finalize the creation on disk.
     '''
+    assert not filename.startswith(ASSET_SCHEME)
     dictionary_module = _get_dictionary_module(filename)
     if dictionary_module.create_dictionary is None:
         raise DictionaryLoaderException('%s does not support creation' % dictionary_module.__name__)
@@ -67,7 +69,8 @@ def load_dictionary(filename):
         ne = DictionaryLoaderException('loading \'%s\' failed: %s' % (filename, str(e)))
         reraise(type(ne), ne, sys.exc_info()[2])
     d.set_path(filename)
-    d.save = ThreadedSaver(d, filename, dictionary_module.save_dictionary)
+    if not filename.startswith(ASSET_SCHEME):
+        d.save = ThreadedSaver(d, filename, dictionary_module.save_dictionary)
     return d
 
 def save_dictionary(d, filename, saver):

--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -5,8 +5,6 @@
 
 """
 
-import io
-
 try:
     import simplejson as json
 except ImportError:
@@ -15,8 +13,10 @@ except ImportError:
 # Python 2/3 compatibility.
 from six import iteritems
 
+from plover.resource import resource_stream
 from plover.steno_dictionary import StenoDictionary
 from plover.steno import normalize_steno
+
 
 def create_dictionary():
     return StenoDictionary()
@@ -25,7 +25,7 @@ def load_dictionary(filename):
 
     for encoding in ('utf-8', 'latin-1'):
         try:
-            with io.open(filename, 'r', encoding=encoding) as fp:
+            with resource_stream(filename, encoding=encoding) as fp:
                 d = json.load(fp)
                 break
         except UnicodeDecodeError:

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -20,6 +20,7 @@ import re
 # Python 2/3 compatibility.
 from six import get_function_code
 
+from plover.resource import resource_stream
 from plover.steno import normalize_steno
 from plover.steno_dictionary import StenoDictionary
 # TODO: Move dictionary format somewhere more canonical than formatting.
@@ -288,7 +289,7 @@ def load_stylesheet(s):
 
 def load_dictionary(filename):
     """Load an RTF/CRE dictionary."""
-    with open(filename, 'rb') as fp:
+    with resource_stream(filename) as fp:
         s = fp.read().decode('cp1252')
     styles = load_stylesheet(s)
     d = {}

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -302,7 +302,6 @@ class StenoEngine(object):
         return self._config.as_dict()
 
     @config.setter
-    @with_lock
     def config(self, update):
         self._same_thread_hook(self._update, config_update=update)
 

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -46,6 +46,7 @@ class DictionaryItemDelegate(QStyledItemDelegate):
             dictionary_paths = [
                 shorten_path(dictionary.get_path())
                 for dictionary in self._dictionary_list
+                if not dictionary.readonly
             ]
             combo = QComboBox(parent)
             combo.addItems(dictionary_paths)
@@ -182,7 +183,11 @@ class DictionaryItemModel(QAbstractTableModel):
     def flags(self, index):
         if not index.isValid():
             return Qt.NoItemFlags
-        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+        f = Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        item = self._entries[index.row()]
+        if not item.dictionary.readonly:
+            f |= Qt.ItemIsEditable
+        return f
 
     def filter(self, strokes_filter=None, translation_filter=None):
         self.modelAboutToBeReset.emit()

--- a/plover/misc.py
+++ b/plover/misc.py
@@ -8,6 +8,7 @@ import sys
 from six import PY3
 
 from plover.oslayer.config import CONFIG_DIR
+from plover.resource import ASSET_SCHEME
 
 
 if PY3:
@@ -60,6 +61,8 @@ def expand_path(path):
         - if starting with "~/", it is substituted with the user home directory
         - if relative, it is resolved relative to CONFIG_DIR
     '''
+    if path.startswith(ASSET_SCHEME):
+        return path
     path = os.path.expanduser(path)
     path = os.path.realpath(os.path.join(CONFIG_DIR, path))
     return path
@@ -72,6 +75,8 @@ def shorten_path(path):
 
         Note: relative path are automatically assumed to be relative to CONFIG_DIR.
     '''
+    if path.startswith(ASSET_SCHEME):
+        return path
     path = os.path.realpath(os.path.join(CONFIG_DIR, path))
     config_dir = os.path.realpath(CONFIG_DIR)
     if not config_dir.endswith(os.sep):

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -1,0 +1,34 @@
+
+import io
+import os
+
+import pkg_resources
+
+
+ASSET_SCHEME = 'asset:'
+
+def _asset_split(resource_name):
+    return resource_name[len(ASSET_SCHEME):].split(':', 2)
+
+def resource_exists(resource_name):
+    if resource_name.startswith(ASSET_SCHEME):
+        return pkg_resources.resource_exists(*_asset_split(resource_name))
+    return os.path.exists(resource_name)
+
+def resource_filename(resource_name):
+    if resource_name.startswith(ASSET_SCHEME):
+        return pkg_resources.resource_filename(*_asset_split(resource_name))
+    return resource_name
+
+def resource_stream(resource_name, encoding=None):
+    filename = resource_filename(resource_name)
+    mode = 'rb' if encoding is None else 'r'
+    return io.open(filename, mode, encoding=encoding)
+
+def resource_string(resource_name, encoding=None):
+    if resource_name.startswith(ASSET_SCHEME):
+        s = pkg_resources.resource_string(*_asset_split(resource_name))
+        return s if encoding is None else unicode(s, encoding)
+    mode = 'rb' if encoding is None else 'r'
+    with io.open(resource_name, mode, encoding=encoding) as fp:
+        return fp.read()

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -36,6 +36,10 @@ class StenoDictionary(collections.MutableMapping):
         """The length of the longest key in the dict."""
         return self._longest_key
 
+    @property
+    def readonly(self):
+        return self.save is None
+
     def __len__(self):
         return self._dict.__len__()
         

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -46,6 +46,8 @@ _EXPORTS = {
                                               for pattern, replacement in mod.ORTHOGRAPHY_RULES],
     'ORTHOGRAPHY_RULES_ALIASES': lambda mod: dict(mod.ORTHOGRAPHY_RULES_ALIASES),
     'KEYMAPS'                  : lambda mod: mod.KEYMAPS,
+    'DICTIONARIES_ROOT'        : lambda mod: mod.DICTIONARIES_ROOT,
+    'DEFAULT_DICTIONARIES'     : lambda mod: mod.DEFAULT_DICTIONARIES,
 }
 
 def setup(system_name):

--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -236,3 +236,6 @@ KEYMAPS = {
         'no-op': ('X1-', 'X2-', 'X3'),
     },
 }
+
+DICTIONARIES_ROOT = 'asset:plover:assets'
+DEFAULT_DICTIONARIES = ('main.json', 'commands.json', 'user.json')

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -9,6 +9,7 @@ import unittest
 
 import plover.misc as misc
 import plover.oslayer.config as conf
+from plover.resource import ASSET_SCHEME
 
 
 class MiscTestCase(unittest.TestCase):
@@ -29,6 +30,9 @@ class MiscTestCase(unittest.TestCase):
 
     def test_dictionary_path(self):
         for short_path, full_path in (
+            # Asset, no change.
+            (ASSET_SCHEME + 'foo:bar',
+             ASSET_SCHEME + 'foo:bar'),
             # Absolute path, no change.
             (os.path.abspath('/foo/bar'),
              os.path.abspath('/foo/bar')),


### PR DESCRIPTION
Rework the handling of the dictionaries configuration, so the setting is handled per system, and each system can define a list of default dictionaries to use.

So the configuration now looks like this:

```
[System: English Stenotype]
dictionaries = ["main.json", "commands.json", "user.json"]
```

And the system additional constants are:

``` python
DICTIONARIES_ROOT = 'asset:plover:assets'
DEFAULT_DICTIONARIES = ('main.json', 'commands.json', 'user.json')
```

The `DICTIONARIES_ROOT/DEFAULT_DICTIONARIES` split is in prevision of orthographic systems using a Python dictionary, e.g. with:

``` python
DICTIONARIES_ROOT = 'asset:plover_template_system:dictionaries'
DEFAULT_DICTIONARIES = ('asset:plover_template_system:dictionaries/ortho.py', 'main.json', 'user.json')
```

only `main.json` and `user.json` will be recreated if needed, since a Python dictionary is read-only and cannot be modified.
