### PR TITLE
gui: fix spurious warning at startup on Windows

### DIFF
--- a/plover/gui/log.py
+++ b/plover/gui/log.py
@@ -2,7 +2,7 @@ import sys
 from plover import log
 
 
-handler = None
+handler_class = handler = None
 
 try:
     if sys.platform.startswith('linux'):


### PR DESCRIPTION
Warning in question:

```
2016-10-29 23:25:36,812 [MainThread] ERROR: could not initialize platform gui log
Traceback (most recent call last):
  File "plover\gui\log.py", line 18, in <module>
NameError: name 'handler_class' is not defined
```
