### PR TITLE
gui_qt/add_translation: pre-populate with last word or stroke

### DIFF
--- a/plover/gui_qt/add_translation.py
+++ b/plover/gui_qt/add_translation.py
@@ -37,6 +37,28 @@ class AddTranslation(QDialog, Ui_AddTranslation, WindowState):
         self.installEventFilter(self)
         self.strokes.installEventFilter(self)
         self.translation.installEventFilter(self)
+
+        # Pre-populate the strokes or translations with last stroke/word.
+        last_translation = None
+        for t in reversed(engine.translator_state.translations):
+            # Find the last undoable stroke.
+            if t.has_undo():
+                last_translation = t
+                break
+        if last_translation:
+            # Grab the last-formatted word
+            last_word = last_translation.formatting[-1].word
+            if last_word:
+                # If the last translation was created with the dictionary...
+                if last_translation.english:
+                    self.translation.setText(last_word.strip())
+                    self.on_translation_edited()
+                # Otherwise, it's just raw steno
+                else:
+                    self.strokes.setText(last_word.strip())
+                    self.on_strokes_edited()
+                    self.strokes.selectAll()
+
         with engine:
             self._original_state = self.EngineState(None,
                                                     engine.translator_state,


### PR DESCRIPTION
### About

I sort of decided to do this on a whim; we've had similar requests before but there's always some complexity involved that I didn't want to deal with. Namely, the "number of previous strokes/words to look at" option. Instead of dealing with that, I decided to just optimistically try and grab the last word or stroke if there was one. It's dead simple and seems to get the job done, and it doesn't get in the way of the previous flow; if you have the translation window set to invisible, the pre-populated fields won't get in the way due to selection.
