### PR TITLE
Plugins support: command

### DIFF
--- a/plover/engine.py
+++ b/plover/engine.py
@@ -266,6 +266,10 @@ class StenoEngine(object):
             self._trigger_hook('add_translation')
         elif command == 'LOOKUP':
             self._trigger_hook('lookup')
+        else:
+            command_args = command.split(':', 2)
+            command_fn = registry.get_plugin('command', command_args[0]).resolve()
+            command_fn(self, command_args[1] if len(command_args) == 2 else '')
         return False
 
     def _on_stroked(self, steno_keys):

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -13,6 +13,7 @@ PLUGINS_DIR = os.path.join(CONFIG_DIR, 'plugins')
 class Registry(object):
 
     PLUGIN_TYPES = (
+        'command',
         'dictionary',
         'gui',
         'machine',


### PR DESCRIPTION
Add support for custom commands to the plugin system. Note that those are only supported when output is enabled. See [here](https://github.com/benoit-pierre/plover/compare/plugins_support...benoit-pierre:priority_dict) for an example re-implementing #605.