### PR TITLE
oslayer/xkeyboardcontrol: fix support for some NKRO keyboards

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -172,8 +172,11 @@ class KeyboardCapture(threading.Thread):
         # Find all keyboard devices.
         keyboard_devices = []
         for devinfo in self.display.xinput_query_device(xinput.AllDevices).devices:
-            # Only keep slave keyboard devices.
-            if devinfo.use != xinput.SlaveKeyboard:
+            # Only keep slave devices.
+            # Note: we look at pointer devices too, as some keyboards (like the
+            # VicTop mechanical gaming keyboard) register 2 devices, including
+            # a pointer device with a key class (to fully support NKRO).
+            if devinfo.use not in (xinput.SlaveKeyboard, xinput.SlavePointer):
                 continue
             # Ignore XTest keyboard device.
             if 'Virtual core XTEST keyboard' == devinfo.name:
@@ -181,7 +184,11 @@ class KeyboardCapture(threading.Thread):
             # Ignore disabled devices.
             if not devinfo.enabled:
                 continue
-            keyboard_devices.append(devinfo.deviceid)
+            # Check for the presence of a key class.
+            for c in devinfo.classes:
+                if c.type == xinput.KeyClass:
+                    keyboard_devices.append(devinfo.deviceid)
+                    break
         if XINPUT_DEVICE_ID == xinput.AllDevices:
             self.devices = keyboard_devices
         else:


### PR DESCRIPTION
Look at Xinput pointer devices too, as some keyboards (like the VicTop mechanical gaming keyboard) register 2 devices, including a pointer device with a key class (to fully support NKRO).

Fix #644.

@GuiltyDolphin: can you make sure the (slightly refactored) code still work?