### PR TITLE
Fix suggestions handling of empty text actions

### DIFF
--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -112,7 +112,8 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
     def on_translation(self, old, new):
         for action in old:
             remove = len(action.text)
-            self._words = self._words[:-remove]
+            if remove > 0:
+                self._words = self._words[:-remove]
             self._words = self._words + action.replace
 
         for action in new:


### PR DESCRIPTION
### About

Fix empty text actions erasing entire suggestions word string when being removed. There's a similar check in the loop a few lines down, so this was probably just missed whenever that change was made.

### Issues

Fixes #618