### PR TITLE
Freeze Homebrew for Python 3.5

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -81,13 +81,15 @@ pip_install_requirements()
 
 osx_bootstrap()
 {
+  run brew update
   if [ "$python" == 'python2' ]
   then
     python_package='python'
   else
     python_package="$python"
+    run export HOMEBREW_NO_AUTO_UPDATE=1
+    run git -C "$(brew --repo)/Library/Taps/homebrew/homebrew-core" checkout '5596439c4ca5a9963a7fec0146d3ce2b27e07a17^' Formula/python3.rb
   fi
-  run brew update
   osx_packages_install $python_package
   run brew link --overwrite $python_package
 }

--- a/osx/README.md
+++ b/osx/README.md
@@ -4,6 +4,8 @@
 
 With Homebrew installed, you should be able to have everything setup automatically by using: `./bootstrap.sh`.
 
+At the moment, we need to overwrite the Python formula to get Python 3.5, as 3.6 [breaks the build process](https://github.com/pyinstaller/pyinstaller/issues/2331).
+
 Note: you can use `./bootstrap.sh -n` to get a list of the commands that would be run.
 
 ## Manual development environment setup


### PR DESCRIPTION
PyInstaller doesn't work with Python 3.6 yet, attempt to checkout Python 3.5's formula until https://github.com/pyinstaller/pyinstaller/issues/2331 is fixed.