### PR TITLE
Tests don't fail if CONFIG_DIR is a symlink

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -38,7 +38,7 @@ class MiscTestCase(unittest.TestCase):
              os.path.abspath('/foo/bar')),
             # Relative path, resolve relative to configuration directory.
             (os.path.normpath('foo/bar'),
-             os.path.join(conf.CONFIG_DIR, 'foo', 'bar')),
+             os.path.join(os.path.realpath(conf.CONFIG_DIR), 'foo', 'bar')),
             # Path below the user home directory.
             (os.path.normpath('~/foo/bar'),
              os.path.expanduser(os.path.normpath('~/foo/bar'))),


### PR DESCRIPTION
MiscTestCase.test_dictionary_path() passes conf.CONFIG_DIR
through os.path.realpath() before using it, since the
functions it's testing do the same.

Fixes #661.