### PR TITLE
Translation with more state

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -660,6 +660,10 @@ def _atom_to_action_spaces_after(atom, last_action):
                 action.replace = NO_SPACE
         elif meta == META_CAPITALIZE:
             action = last_action.copy_state()
+            if was_space:
+                # Persist space state
+                action.replace = SPACE
+                action.text = SPACE
             action.capitalize = True
             action.lower = False
         elif meta == META_LOWER:

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -286,7 +286,7 @@ class Translator(object):
                 do.append(t)
                 undo.extend(t.replaced)
         del self._state.translations[len(self._state.translations) - len(undo):]
-        self._output(undo, do, self._state.last())
+        self._output(undo, do, self._state.prev())
         if add_to_history:
             self._state.translations.extend(do)
 
@@ -404,11 +404,14 @@ class _State(object):
         self.translations = []
         self.tail = None
 
-    def last(self):
-        """Get the most recent translation."""
+    def prev(self):
+        """Get the most recent translations."""
         if self.translations:
-            return self.translations[-1]
-        return self.tail
+            return self.translations
+        if self.tail is not None:
+            return [self.tail]
+        return None
+
 
     def restrict_size(self, n):
         """Reduce the history of translations to n."""

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -105,6 +105,39 @@ class BlackboxTest(unittest.TestCase):
             self.translator.translate(stroke)
         self.assertEqual(self.output.text, u' $1.20')
 
+    def test_bug606(self):
+        for steno, translation in (
+            ('KWEGS', 'question'),
+            ('-S'   , '{^s}'    ),
+            ('TP-PL', '{.}'     ),
+        ):
+            self.dictionary.set(normalize_steno(steno), translation)
+        self.formatter.set_space_placement('After Output')
+        for steno in (
+            'KWEGS',
+            '-S',
+            'TP-PL',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u'questions. ')
+
+    def test_bug535_spaces_after(self):
+        # Currency formatting a number with a decimal fails by not erasing
+        # the previous output.
+        self.formatter.set_space_placement('After Output')
+        self.dictionary.set(('P-P',), '{^.^}')
+        self.dictionary.set(('KR*UR',), '{*($c)}')
+        for steno in (
+            '1',
+            'P-P',
+            '2',
+            'KR*UR',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u'$1.20 ')
+
     def test_bug557(self):
         # Using the asterisk key to delete letters in fingerspelled words
         # occasionally causes problems when the space placement is set to
@@ -129,6 +162,79 @@ class BlackboxTest(unittest.TestCase):
             stroke = steno_to_stroke(steno)
             self.translator.translate(stroke)
         self.assertEqual(self.output.text, u'I like ta ')
+
+    def test_bug557_resumed(self):
+        # Using the asterisk key to delete letters in fingerspelled words
+        # occasionally causes problems when the space placement is set to
+        # "After Output".
+        for steno, translation in (
+            ('EU'      , 'I'      ),
+            ('HRAOEUBG', 'like'   ),
+            ('T*'      , '{>}{&t}'),
+            ('A*'      , '{>}{&a}'),
+            ('KR*'     , '{>}{&c}'),
+            ('O*'      , '{>}{&o}'),
+            ('S*'      , '{>}{&s}'),
+        ):
+            self.dictionary.set(normalize_steno(steno), translation)
+        self.formatter.set_space_placement('After Output')
+        for steno in (
+            'EU',
+            'HRAOEUBG',
+            'T*', 'A*', 'KR*', 'O*', 'S*',
+            '*', '*', '*', '*', '*',
+            'HRAOEUBG',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u'I like like ')
+
+    def test_bug557_capitalized(self):
+        # Using the asterisk key to delete letters in fingerspelled words
+        # occasionally causes problems when the space placement is set to
+        # "After Output".
+        for steno, translation in (
+            ('EU'      , 'I'      ),
+            ('HRAOEUBG', 'like'   ),
+            ('T*'      , '{-|}{&t}'),
+            ('A*'      , '{-|}{&a}'),
+            ('KR*'     , '{-|}{&c}'),
+            ('O*'      , '{-|}{&o}'),
+            ('S*'      , '{-|}{&s}'),
+        ):
+            self.dictionary.set(normalize_steno(steno), translation)
+        self.formatter.set_space_placement('After Output')
+        for steno in (
+            'EU',
+            'HRAOEUBG',
+            'T*', 'A*', 'KR*', 'O*', 'S*',
+                          '*',  '*',  '*',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u'I like TA ')
+
+    def test_capitalized_fingerspelling_spaces_after(self):
+        # Using the asterisk key to delete letters in fingerspelled words
+        # occasionally causes problems when the space placement is set to
+        # "After Output".
+        for steno, translation in (
+            ('HRAOEUBG', 'like'   ),
+            ('T*'      , '{&T}'),
+            ('A*'      , '{&A}'),
+            ('KR*'     , '{&C}'),
+            ('O*'      , '{&O}'),
+            ('S*'      , '{&S}'),
+        ):
+            self.dictionary.set(normalize_steno(steno), translation)
+        self.formatter.set_space_placement('After Output')
+        for steno in (
+            'HRAOEUBG',
+            'T*', 'A*', 'KR*', 'O*', 'S*',
+        ):
+            stroke = steno_to_stroke(steno)
+            self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u'like TACOS ')
 
     def test_special_characters(self):
         self.dictionary.set(('R-R',), '{^}\n{^}')

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -105,7 +105,6 @@ class BlackboxTest(unittest.TestCase):
             self.translator.translate(stroke)
         self.assertEqual(self.output.text, u' $1.20')
 
-    @unittest.expectedFailure
     def test_bug557(self):
         # Using the asterisk key to delete letters in fingerspelled words
         # occasionally causes problems when the space placement is set to

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -109,7 +109,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([], 
           [translation(rtfcre=('S'), english='hello')], 
-          translation(rtfcre=('T'), english='a', formatting=[action(text='f')])
+          [translation(rtfcre=('T'), english='a', formatting=[action(text='f')])]
          ),
          ([action(text=' hello', word='hello')],),
          [('s', ' hello')]
@@ -130,7 +130,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([], 
           [translation(rtfcre=('ST-T',))], 
-          translation(formatting=[action(text='hi')])),
+          [translation(formatting=[action(text='hi')])]),
          ([action(text=' ST-T', word='ST-T')],),
          [('s', ' ST-T')]
         ),
@@ -138,7 +138,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([translation(formatting=[action(text=' test')])],
           [translation(english='rest')],
-          translation(formatting=[action(capitalize=True)])),
+          [translation(formatting=[action(capitalize=True)])]),
          ([action(text=' Rest', word='Rest')],),
          [('b', 4), ('s', 'Rest')]
         ),
@@ -147,7 +147,7 @@ class FormatterTestCase(unittest.TestCase):
          ([translation(formatting=[action(text='dare'), 
                                    action(text='ing', replace='e')])],
          [translation(english='rest')],
-         translation(formatting=[action(capitalize=True)])),
+         [translation(formatting=[action(capitalize=True)])]),
          ([action(text=' Rest', word='Rest')],),
          [('b', 6), ('s', ' Rest')]
         ),
@@ -187,7 +187,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([],
           [translation(rtfcre=('1',))],
-          translation(formatting=[action(text='hi', word='hi')])),
+          [translation(formatting=[action(text='hi', word='hi')])]),
          ([action(text=' 1', word='1', glue=True)],),
          [('s', ' 1')]
         ),
@@ -195,7 +195,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([],
           [translation(rtfcre=('1',))],
-          translation(formatting=[action(text='hi', word='hi', glue=True)])),
+          [translation(formatting=[action(text='hi', word='hi', glue=True)])]),
          ([action(text='1', word='hi1', glue=True)],),
          [('s', '1')]
         ),
@@ -203,7 +203,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([],
           [translation(rtfcre=('1-9',))],
-          translation(formatting=[action(text='hi', word='hi', glue=True)])),
+          [translation(formatting=[action(text='hi', word='hi', glue=True)])]),
          ([action(text='19', word='hi19', glue=True)],),
          [('s', '19')]
         ),
@@ -211,7 +211,7 @@ class FormatterTestCase(unittest.TestCase):
         (
          ([],
           [translation(rtfcre=('ST-PL',))],
-          translation(formatting=[action(text='hi', word='hi')])),
+          [translation(formatting=[action(text='hi', word='hi')])]),
          ([action(text=' ST-PL', word='ST-PL')],),
          [('s', ' ST-PL')]
         ),
@@ -1125,10 +1125,10 @@ class FormatterTestCase(unittest.TestCase):
             formatter = formatting.Formatter()
             formatter.set_output(output)
             formatter.set_space_placement('After Output')
-            prev = None
+            prev = []
             for t in translations:
                 formatter.format([], [t], prev)
-                prev = t
+                prev.append(t)
             self.assertEqual(output.instructions, expected_instructions)
 
     def test_undo_replace(self):
@@ -1137,8 +1137,8 @@ class FormatterTestCase(unittest.TestCase):
             formatter = formatting.Formatter()
             formatter.set_output(output)
             formatter.set_space_placement('After Output')
-            prev = translation(english='test')
-            formatter.format([], [prev], None)
+            prev = [translation(english='test')]
+            formatter.format([], prev, None)
             undo = translation(english='{^,}')
             formatter.format([], [undo], prev)
             # Undo.

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -838,7 +838,7 @@ class FormatterTestCase(unittest.TestCase):
          action(text='! ', replace=' ', capitalize=True)),
 
         (('{-|}', action(word='test', text='test ')),
-         action(capitalize=True, word='test')),
+         action(capitalize=True, word='test', text=' ', replace=' ')),
 
         (('{>}', action(word='test', text='test ')),
          action(lower=True, word='test', replace=' ', text=' ')),


### PR DESCRIPTION
Pass more state from the translator to the formatter so the output code can be simplified (by only taking into account an action text and replace fields). Supersede #666.
