### PR TITLE
translation: small code simplifications

### DIFF
--- a/plover/translation.py
+++ b/plover/translation.py
@@ -439,27 +439,18 @@ def _back_string():
     return _back_string.mapping
 
 def _toggle_asterisk(translations, undo, do):
-    replaced = translations[len(translations)-1:]
-    if len(replaced) < 1:
-        return
-    undo.extend(replaced)
-    redo = replaced[0].replaced
-    do.extend(redo)
-    translations.remove(replaced[0])
-    translations.extend(redo)
-    last_stroke = replaced[0].strokes[len(replaced[0].strokes)-1]
-    keys = last_stroke.steno_keys[:]
+    if not translations:
+        return None
+    replaced = translations[-1]
+    undo.append(replaced)
+    keys = set(replaced.strokes[-1].steno_keys)
     if '*' in keys:
         keys.remove('*')
     else:
-        keys.append('*')
+        keys.add('*')
     return Stroke(keys)
 
 def _repeat_last_stroke(translations):
-    replaced = translations[len(translations)-1:]
-    if len(replaced) < 1:
-        return
-    last_stroke = replaced[0].strokes[len(replaced[0].strokes)-1]
-    keys = last_stroke.steno_keys[:]
-    return Stroke(keys)
-
+    if not translations:
+        return None
+    return Stroke(translations[-1].strokes[-1].steno_keys)


### PR DESCRIPTION
Note: I noticed `_toggle_asterisk` was also directly modifying the state translations, which was tripping this patch:

```diff
diff --git a/plover/translation.py b/plover/translation.py
index 4caf3d47..f43d0fe1 100644
--- a/plover/translation.py
+++ b/plover/translation.py
@@ -285,7 +285,9 @@ class Translator(object):
             if t is not None:
                 do.append(t)
                 undo.extend(t.replaced)
-        del self._state.translations[len(self._state.translations) - len(undo):]
+        if undo:
+            assert undo == self._state.translations[-len(undo):], '%s / %s ' % (undo, self._state.translations[-len(undo):])
+            del self._state.translations[-len(undo):]
         self._output(undo, do, self._state.prev())
         if add_to_history:
             self._state.translations.extend(do)
```