### PR TITLE
add extension support to the registry

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -83,6 +83,9 @@ SYSTEM_CONFIG_SECTION = 'System: %s'
 SYSTEM_KEYMAP_OPTION = 'keymap[%s]'
 SYSTEM_DICTIONARIES_OPTION = 'dictionaries'
 
+PLUGINS_CONFIG_SECTION = 'Plugins'
+ENABLED_EXTENSIONS_OPTION = 'enabled_extensions'
+
 # Logging constants.
 LOG_EXTENSION = '.log'
 
@@ -435,6 +438,29 @@ class Config(object):
         keymap.set_mappings(mappings)
         return keymap
 
+    def set_enabled_extensions(self, extensions):
+        if extensions is None:
+            self._config.remove_option(PLUGINS_CONFIG_SECTION,
+                                       ENABLED_EXTENSIONS_OPTION)
+        else:
+            self._set(PLUGINS_CONFIG_SECTION,
+                      ENABLED_EXTENSIONS_OPTION,
+                      json.dumps(sorted(list(set(extensions)))))
+
+    def get_enabled_extensions(self):
+        extensions = ()
+        value = self._get(PLUGINS_CONFIG_SECTION,
+                          ENABLED_EXTENSIONS_OPTION,
+                          None)
+        if value is not None:
+            try:
+                extensions = set(json.loads(value))
+            except ValueError:
+                log.error("invalid enabled extensions set, resetting to default",
+                          exc_info=True)
+                self.set_enabled_extensions(None)
+        return set(extensions)
+
     def _set(self, section, option, value):
         if not self._config.has_section(section):
             self._config.add_section(section)
@@ -484,6 +510,8 @@ class Config(object):
     undo_levels
 
     dictionary_file_names
+
+    enabled_extensions
 
     enable_stroke_logging
     enable_translation_logging

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -15,6 +15,7 @@ class Registry(object):
     PLUGIN_TYPES = (
         'command',
         'dictionary',
+        'extension',
         'gui',
         'gui.qt.tool',
         'machine',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -308,6 +308,7 @@ class ConfigTestCase(unittest.TestCase):
             dictionary_file_names
             enable_stroke_logging
             enable_translation_logging
+            enabled_extensions
             log_file_name
             machine_specific_options
             machine_type

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -31,6 +31,7 @@ class FakeConfig(object):
         'undo_levels'               : 10,
         'start_capitalized'         : True,
         'start_attached'            : False,
+        'enabled_extensions'        : set(),
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Add support for extension plugins.

Minimal code for an extension:

```python
class Extension(object):

    def __init__(self, engine):
        pass

    def start(self):
        pass

    def stop(self):
        pass
```

An extension must be explicitly enabled by the user. It will be automatically initialized  and started/stopped when (re-)configuring the engine.

Use cases:
- monitoring external events (tracking application focus to automatically enable/disable Plover or maintain per application states)
- listening to a control socket for commands
- creating more complex plugins that are not state less (an extension could dynamically register other plugins)...