### PR TITLE
registry: add platform specific entrypoints

### DIFF
--- a/plover/registry.py
+++ b/plover/registry.py
@@ -1,4 +1,5 @@
 
+import sys
 import os
 
 import pkg_resources
@@ -8,6 +9,15 @@ from plover import log
 
 
 PLUGINS_DIR = os.path.join(CONFIG_DIR, 'plugins')
+
+if sys.platform.startswith('darwin'):
+    PLUGINS_PLATFORM = 'mac'
+elif sys.platform.startswith('linux'):
+    PLUGINS_PLATFORM = 'linux'
+elif sys.platform.startswith('win'):
+    PLUGINS_PLATFORM = 'win'
+else:
+    PLUGINS_PLATFORM = None
 
 
 class Registry(object):
@@ -54,6 +64,10 @@ class Registry(object):
             entrypoint_type = 'plover.%s' % plugin_type
             for entrypoint in pkg_resources.iter_entry_points(entrypoint_type):
                 self.register_plugin(plugin_type, entrypoint)
+            if PLUGINS_PLATFORM is not None:
+                entrypoint_type = 'plover.%s.%s' % (PLUGINS_PLATFORM, plugin_type)
+                for entrypoint in pkg_resources.iter_entry_points(entrypoint_type):
+                    self.register_plugin(plugin_type, entrypoint)
 
 
 registry = Registry()


### PR DESCRIPTION
- to allow for cleaner plugins code when implementations differ for each platform
- so a plugin can declare entrypoints for only supported platforms

Example: `plover.linux.command` instead of `plover.command` for declaring a Linux only command.

