### PR TITLE
Fix carry capitalization formatting space deletion

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -852,7 +852,11 @@ def _apply_currency(meta, last_action, spaces_after=False):
 
 def _apply_carry_capitalize(meta, last_action, spaces_after=False):
     # Meta format: ^~|content^ (attach flags are optional)
-    attach_last = meta.startswith(META_ATTACH_FLAG)
+
+    # We don't need to attach to the last action if it is already attached.
+    last_attach = last_action and last_action.attach
+    attach_last = meta.startswith(META_ATTACH_FLAG) and not last_attach
+
     attach_next = meta.endswith(META_ATTACH_FLAG)
 
     content_start = meta.index(META_CARRY_CAPITALIZATION) + len(META_CARRY_CAPITALIZATION)
@@ -863,7 +867,11 @@ def _apply_carry_capitalize(meta, last_action, spaces_after=False):
     action.attach = attach_next
 
     # Spaces after: delete last space if we're attaching.
-    replace_last = last_action.text.endswith(SPACE) and attach_last
+    replace_last = (
+        spaces_after
+        and attach_last
+        and last_action.text.endswith(SPACE)
+    )
     action.replace = SPACE if replace_last else NO_SPACE
 
     if meta_content:

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -246,3 +246,24 @@ class BlackboxTest(unittest.TestCase):
             stroke = steno_to_stroke(steno)
             self.translator.translate(stroke)
         self.assertEqual(self.output.text, u'\n\t')
+
+    def test_carry_capitalization_spacing(self):
+        self.dictionary.set(('R-R',), '{^~|\n^}')
+        self.dictionary.set(('R*R',), '{^\n^}')
+        self.dictionary.set(('S-P',), '{^ ^}')
+
+        def space_then_return(return_stroke):
+            for steno in (
+                'S-P',
+                return_stroke,
+            ):
+                stroke = steno_to_stroke(steno)
+                self.translator.translate(stroke)
+            self.assertEqual(self.output.text, u' \n')
+            self.output.text = ''
+
+        space_then_return('R*R')
+        space_then_return('R-R')
+        self.formatter.set_space_placement('After Output')
+        space_then_return('R*R')
+        space_then_return('R-R')


### PR DESCRIPTION
### About

I had a trick in the carry capitalization meta to erase the previous space in after spaces mode, but the code handled too much. Now it's been drilled down to a more specific case.

### Issues

Fixes #554 

### Reason

The difference between {^~|^} and {^^} affected me surprisingly frequently.

### Tested Platforms

Only Mac
