### PR TITLE
gui_qt: fix initial machine type display

### DIFF
--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -143,6 +143,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             self.on_configure()
         # Apply configuration settings.
         config = self._engine.config
+        self.machine_type.setCurrentText(config['machine_type'])
         self._configured = False
         self.dictionaries.on_config_changed(config)
         self.set_visible(not config['start_minimized'])


### PR DESCRIPTION
Otherwise the combo box will be display the first item (`Gemini PR`) until dictionaries are loaded and the machine is setup.