### PR TITLE
get rid of the dependency on pywin32

### DIFF
--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -23,8 +23,6 @@ from ctypes import windll, wintypes
 # Python 2/3 compatibility.
 from six.moves import winreg
 
-import win32api
-
 from plover.key_combo import parse_key_combo
 from plover.oslayer.winkeyboardlayout import KeyboardLayout
 from plover import log
@@ -249,7 +247,7 @@ class KeyboardCaptureProcess(multiprocessing.Process):
         # Ignore KeyboardInterrupt when attached to a console...
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        self._tid = win32api.GetCurrentThreadId()
+        self._tid = windll.kernel32.GetCurrentThreadId()
         self._queue.put(self._tid)
 
         down_keys = set()

--- a/plover/oslayer/winkeyboardlayout.py
+++ b/plover/oslayer/winkeyboardlayout.py
@@ -9,10 +9,9 @@ import ctypes
 from ctypes import windll, wintypes
 from collections import defaultdict, namedtuple
 
-import win32gui
-
 from plover.key_combo import CHAR_TO_KEYNAME, add_modifiers_aliases
 from plover.misc import popcount_8
+
 
 GetKeyboardLayout = windll.user32.GetKeyboardLayout
 GetWindowThreadProcessId = windll.user32.GetWindowThreadProcessId
@@ -443,7 +442,7 @@ class KeyboardLayout(object): # {{{
 
     @staticmethod
     def current_layout_id():
-        pid = GetWindowThreadProcessId(win32gui.GetForegroundWindow(), 0)
+        pid = GetWindowThreadProcessId(windll.user32.GetForegroundWindow(), 0)
         return GetKeyboardLayout(pid)
 
 # }}}

--- a/plover/oslayer/wmctrl.py
+++ b/plover/oslayer/wmctrl.py
@@ -4,10 +4,10 @@ import sys
 
 if sys.platform.startswith('win32'):
 
-    import win32gui
+    from ctypes import windll
 
-    GetForegroundWindow = win32gui.GetForegroundWindow
-    SetForegroundWindow = win32gui.SetForegroundWindow
+    GetForegroundWindow = windll.user32.GetForegroundWindow
+    SetForegroundWindow = windll.user32.SetForegroundWindow
 
 
 elif sys.platform.startswith('darwin'):

--- a/setup.py
+++ b/setup.py
@@ -359,7 +359,6 @@ install_requires = [
 
 extras_require = {
     ':"win32" in sys_platform': [
-        'pywin32>=219',
     ],
     ':"linux" in sys_platform': [
         'python-xlib>=0.16',

--- a/windows/README.md
+++ b/windows/README.md
@@ -15,7 +15,6 @@ It is best to develop using 32 bit tools for Plover.
 ### Externally hosted dependencies
 
 - [Cython](http://cython.org/)
-- [Python for Windows Extensions](http://sourceforge.net/projects/pywin32/)
 - [PyQt5](https://riverbankcomputing.com/software/pyqt/intro)
 
 ### Other dependencies

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -254,13 +254,9 @@ class Helper(object):
              None, None, (), None),
             ('PyQt5', 'pip:PyQt5',
              None, None, (), None),
-            ('pywin32', 'https://downloads.sourceforge.net/project/pywin32/pywin32/Build 220/pywin32-220.win32-py3.5.exe',
-             '5c9bd9643982dbfea4aba500503227dd997931df', 'easy_install', (), None),
         )
     else:
         DEPENDENCIES = (
-            ('pywin32', 'https://downloads.sourceforge.net/project/pywin32/pywin32/Build 219/pywin32-219.win32-py2.7.exe',
-             '8bc39008383c646bed01942584117113ddaefe6b', 'easy_install', (), None),
             ('Cython', 'https://pypi.python.org/packages/2.7/C/Cython/Cython-0.23.4-cp27-none-win32.whl',
              'd7c1978fe2037674b151622158881c700ac2f06a', None, (), None),
             ('VC for Python', 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi',


### PR DESCRIPTION
- it's a pain to install (you can't use pip) and the installation is not contained to Python site-packages (DLLs in one of Windows system folders)
- we can easily change code that uses it to ctypes

Tested with a Windows 10 VM.