### PR TITLE
gui_qt: make sure signals are not delivered to closed tools

### DIFF
--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -167,7 +167,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             dialog = self._active_dialogs[name] = dialog_class(self._engine, *args)
             def on_finished():
                 del self._active_dialogs[name]
-                dialog.destroy()
+                dialog.deleteLater()
                 if manage_windows:
                     wmctrl.SetForegroundWindow(previous_window)
             dialog.finished.connect(on_finished)


### PR DESCRIPTION
Just destroying the dialog is not enough: signals are not automatically disconnected, so for example the paper tape will keep on being notified about strokes.