### PR TITLE
rework plugins handling

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -169,7 +169,7 @@ class Config(object):
                 return p[1](v)
             except ValueError:
                 return p[0]
-        machine_class = registry.get_plugin('machine', machine_type).resolve()
+        machine_class = registry.get_plugin('machine', machine_type).obj
         info = machine_class.get_option_info()
         defaults = {k: v[0] for k, v in info.items()}
         if self._config.has_section(machine_type):
@@ -194,7 +194,7 @@ class Config(object):
     def get_dictionary_file_names(self):
         system_name = self.get_system_name()
         try:
-            system = registry.get_plugin('system', system_name).resolve()
+            system = registry.get_plugin('system', system_name).obj
         except:
             log.error("invalid system name: %s", system_name, exc_info=True)
             return []
@@ -400,14 +400,14 @@ class Config(object):
         if machine_type is None:
             machine_type = self.get_machine_type()
         try:
-            machine_class = registry.get_plugin('machine', machine_type).resolve()
+            machine_class = registry.get_plugin('machine', machine_type).obj
         except:
             log.error("invalid machine type: %s", machine_type, exc_info=True)
             return None
         if system_name is None:
             system_name = self.get_system_name()
         try:
-            system = registry.get_plugin('system', system_name).resolve()
+            system = registry.get_plugin('system', system_name).obj
         except:
             log.error("invalid system name: %s", system_name, exc_info=True)
             return None

--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -23,12 +23,12 @@ from plover.resource import ASSET_SCHEME
 def _get_dictionary_module(filename):
     extension = splitext(filename)[1].lower()[1:]
     try:
-        entrypoint = registry.get_plugin('dictionary', extension)
+        dict_module = registry.get_plugin('dictionary', extension).obj
     except KeyError:
         raise DictionaryLoaderException(
             'Unsupported extension: %s. Supported extensions: %s' %
             (extension, ', '.join(sorted(registry.list_plugins('dictionary')))))
-    return entrypoint.resolve()
+    return dict_module
 
 def create_dictionary(filename):
     '''Create a new dictionary.

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -182,7 +182,7 @@ class StenoEngine(object):
             machine_type = config['machine_type']
             machine_options = config['machine_specific_options']
             try:
-                machine_class = registry.get_plugin('machine', machine_type).resolve()
+                machine_class = registry.get_plugin('machine', machine_type).obj
             except Exception as e:
                 raise InvalidConfigurationError(str(e))
             log.info('setting machine: %s', machine_type)
@@ -219,7 +219,7 @@ class StenoEngine(object):
         for extension_name in extension_list:
             log.info('starting `%s` extension' % extension_name)
             try:
-                extension = registry.get_plugin('extension', extension_name).resolve()(self)
+                extension = registry.get_plugin('extension', extension_name).obj(self)
                 extension.start()
             except Exception:
                 log.error('initializing extension `%s` failed', extension_name, exc_info=True)
@@ -291,7 +291,7 @@ class StenoEngine(object):
             self._trigger_hook('lookup')
         else:
             command_args = command.split(':', 2)
-            command_fn = registry.get_plugin('command', command_args[0]).resolve()
+            command_fn = registry.get_plugin('command', command_args[0]).obj
             command_fn(self, command_args[1] if len(command_args) == 2 else '')
         return False
 
@@ -377,10 +377,6 @@ class StenoEngine(object):
 
     def quit(self):
         self._same_thread_hook(self._quit)
-
-    @with_lock
-    def list_plugins(self, plugin_type):
-        return sorted(registry.list_plugins(plugin_type))
 
     @with_lock
     def machine_specific_options(self, machine_type):

--- a/plover/gui_qt/add_translation.py
+++ b/plover/gui_qt/add_translation.py
@@ -9,7 +9,11 @@ from plover.engine import StartingStrokeState
 from plover.translation import escape_translation, unescape_translation
 
 from plover.gui_qt.add_translation_ui import Ui_AddTranslation
+from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.tool import Tool
+
+
+_ = get_gettext()
 
 
 class AddTranslation(Tool, Ui_AddTranslation):

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -27,6 +27,7 @@ from serial.tools.list_ports import comports
 
 from plover.config import MINIMUM_OUTPUT_CONFIG_UNDO_LEVELS
 from plover.misc import expand_path, shorten_path
+from plover.registry import registry
 
 from plover.gui_qt.config_window_ui import Ui_ConfigWindow
 from plover.gui_qt.config_file_widget_ui import Ui_FileWidget
@@ -352,8 +353,8 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
             'Treal': NopeOption,
         }
         machines = {
-            machine: _(machine)
-            for machine in engine.list_plugins('machine')
+            plugin.name: _(plugin.name)
+            for plugin in registry.list_plugins('machine')
         }
         mappings = (
             (_('Interface'), (
@@ -418,16 +419,16 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
             (_('Plugins'), (
                 ConfigOption(_('Extension:'), 'enabled_extensions',
                              partial(MultipleChoicesOption, choices={
-                                 name: name
-                                 for name in engine.list_plugins('extension')
+                                 plugin.name: plugin.name
+                                 for plugin in registry.list_plugins('extension')
                              }, labels=(_('Name'), _('Enabled'))),
                              _('Configure enabled plugin extensions.')),
             )),
             (_('System'), (
                 ConfigOption(_('System:'), 'system_name',
                              partial(ChoiceOption, choices={
-                                 name: name
-                                 for name in engine.list_plugins('system')
+                                 plugin.name: plugin.name
+                                 for plugin in registry.list_plugins('system')
                              }),
                              dependents=(
                                  ('system_keymap', lambda v: self._update_keymap(system_name=v)),

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -23,7 +23,7 @@ from plover.gui_qt.utils import ToolBar
 
 
 def _dictionary_formats():
-    return set(registry.list_plugins('dictionary'))
+    return set(plugin.name for plugin in registry.list_plugins('dictionary'))
 
 
 class DictionariesWidget(QWidget, Ui_DictionariesWidget):

--- a/plover/gui_qt/i18n.py
+++ b/plover/gui_qt/i18n.py
@@ -49,7 +49,18 @@ def install_gettext():
     os.environ['LANGUAGE'] = lang
     locale_dir = pkg_resources.resource_filename('plover', 'gui_qt/messages')
     if PY2:
-        kwargs = { 'unicode': 1 }
+        # unicode=True
+        args = [True]
     else:
-        kwargs = {}
-    gettext.install('plover', locale_dir, *kwargs)
+        args = []
+    gettext.install('plover', locale_dir, *args)
+
+def get_gettext(package='plover', resource_dir='gui_qt/messages'):
+    locale_dir = pkg_resources.resource_filename(package, resource_dir)
+    if PY2:
+        # unicode=True
+        args = [True]
+    else:
+        args = []
+    translation = gettext.translation(package, locale_dir, fallback=True)
+    return translation.ugettext if PY2 else translation.gettext

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -5,7 +5,11 @@ from plover.translation import unescape_translation
 
 from plover.gui_qt.lookup_dialog_ui import Ui_LookupDialog
 from plover.gui_qt.suggestions_widget import SuggestionsWidget
+from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.tool import Tool
+
+
+_ = get_gettext()
 
 
 class LookupDialog(Tool, Ui_LookupDialog):

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -12,8 +12,12 @@ from PyQt5.QtWidgets import (
 from plover import system
 
 from plover.gui_qt.paper_tape_ui import Ui_PaperTape
-from plover.gui_qt.tool import Tool
+from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.utils import ToolBar
+from plover.gui_qt.tool import Tool
+
+
+_ = get_gettext()
 
 
 class PaperTape(Tool, Ui_PaperTape):

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -16,8 +16,12 @@ from plover.suggestions import Suggestion
 
 from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
 from plover.gui_qt.suggestions_widget import SuggestionsWidget
-from plover.gui_qt.tool import Tool
+from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.utils import ToolBar
+from plover.gui_qt.tool import Tool
+
+
+_ = get_gettext()
 
 
 class SuggestionsDialog(Tool, Ui_SuggestionsDialog):

--- a/plover/main.py
+++ b/plover/main.py
@@ -55,7 +55,7 @@ def main():
     registry.load_plugins()
     registry.update()
 
-    gui = registry.get_plugin('gui', args.gui).resolve()
+    gui = registry.get_plugin('gui', args.gui).obj
 
     try:
         # Ensure only one instance of Plover is running at a time.

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -52,7 +52,7 @@ _EXPORTS = {
 
 def setup(system_name):
     system_symbols = {}
-    mod = registry.get_plugin('system', system_name).resolve()
+    mod = registry.get_plugin('system', system_name).obj
     for symbol, init in _EXPORTS.items():
         system_symbols[symbol] = init(mod)
     system_symbols['NAME'] = system_name

--- a/setup.py
+++ b/setup.py
@@ -280,6 +280,39 @@ options = {}
 kwargs = {}
 build_dependencies = []
 
+entrypoints = {
+    'console_scripts': [
+        'plover = plover.main:main',
+    ],
+
+    'plover.dictionary': [
+        'json = plover.dictionary.json_dict',
+        'rtf = plover.dictionary.rtfcre_dict',
+    ],
+
+    'plover.gui': [
+        'none = plover.gui_none.main',
+    ],
+
+    'plover.machine': [
+        'Gemini PR = plover.machine.geminipr:GeminiPr',
+        'Keyboard  = plover.machine.keyboard:Keyboard',
+        'Passport  = plover.machine.passport:Passport',
+        'ProCAT    = plover.machine.procat:ProCAT',
+        'Stentura  = plover.machine.stentura:Stentura',
+        'TX Bolt   = plover.machine.txbolt:TxBolt',
+        'Treal     = plover.machine.treal:Treal',
+    ],
+
+    'plover.system': [
+        'English Stenotype = plover.system.english_stenotype',
+    ],
+
+    'setuptools.installation': [
+        'eggsecutable = plover.main:main',
+    ],
+}
+
 if sys.platform.startswith('darwin'):
     setup_requires.append('PyInstaller==3.1.1')
     cmdclass['bdist_app'] = BinaryDistApp
@@ -296,6 +329,13 @@ try:
 except ImportError:
     pass
 else:
+    entrypoints['plover.gui'].append('qt = plover.gui_qt.main')
+    entrypoints['plover.gui.qt.tool'] = [
+        'add_translation = plover.gui_qt.add_translation:AddTranslation',
+        'lookup          = plover.gui_qt.lookup_dialog:LookupDialog',
+        'paper_tape      = plover.gui_qt.paper_tape:PaperTape',
+        'suggestions     = plover.gui_qt.suggestions_dialog:SuggestionsDialog',
+    ]
     setup_requires.append('pyqt-distutils')
     try:
         from pyqt_distutils.build_ui import build_ui
@@ -430,41 +470,10 @@ if __name__ == '__main__':
         extras_require=extras_require,
         tests_require=tests_require,
         dependency_links=dependency_links,
-        entry_points='''
-
-        [console_scripts]
-        plover = plover.main:main
-
-        [plover.dictionary]
-        json = plover.dictionary.json_dict
-        rtf = plover.dictionary.rtfcre_dict
-
-        [plover.gui]
-        none = plover.gui_none.main
-        qt   = plover.gui_qt.main
-
-        [plover.gui.qt.tool]
-        add_translation = plover.gui_qt.add_translation:AddTranslation
-        lookup = plover.gui_qt.lookup_dialog:LookupDialog
-        paper_tape = plover.gui_qt.paper_tape:PaperTape
-        suggestions = plover.gui_qt.suggestions_dialog:SuggestionsDialog
-
-        [plover.machine]
-        Gemini PR = plover.machine.geminipr:GeminiPr
-        Keyboard  = plover.machine.keyboard:Keyboard
-        Passport  = plover.machine.passport:Passport
-        ProCAT    = plover.machine.procat:ProCAT
-        Stentura  = plover.machine.stentura:Stentura
-        TX Bolt   = plover.machine.txbolt:TxBolt
-        Treal     = plover.machine.treal:Treal
-
-        [plover.system]
-        English Stenotype = plover.system.english_stenotype
-
-        [setuptools.installation]
-        eggsecutable = plover.main:main
-
-        ''',
+        entry_points='\n'.join('[' + section + ']\n' + '\n'.join(
+            entrypoint for entrypoint in entrypoint_list)
+            for section, entrypoint_list in entrypoints.items()
+        ),
         packages=[
             'plover',
             'plover.dictionary',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -13,8 +13,6 @@ from six import BytesIO
 
 from mock import patch
 
-from pkg_resources import EntryPoint
-
 from plover import config, system
 from plover.machine.keymap import Keymap
 from plover.registry import Registry
@@ -120,7 +118,7 @@ class ConfigTestCase(unittest.TestCase):
 
         machine_name = 'machine foo'
         registry = Registry()
-        registry.register_plugin('machine', EntryPoint.parse('%s = test.test_config:FakeMachine' % machine_name))
+        registry.register_plugin('machine', machine_name, FakeMachine)
         with patch('plover.config.registry', registry):
             c = config.Config()
             

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -6,8 +6,6 @@ from functools import partial
 
 import mock
 
-from pkg_resources import EntryPoint
-
 from plover import system
 from plover.config import DEFAULT_SYSTEM_NAME
 from plover.engine import StenoEngine
@@ -104,7 +102,7 @@ class EngineTestCase(unittest.TestCase):
     def _setup(self, **kwargs):
         FakeMachine.instance = None
         self.reg = Registry()
-        self.reg.register_plugin('machine', EntryPoint.parse('Fake = test.test_engine:FakeMachine'))
+        self.reg.register_plugin('machine', 'Fake', FakeMachine)
         self.kbd = FakeKeyboardEmulation()
         self.cfg = FakeConfig(**kwargs)
         self.events = []


### PR DESCRIPTION
Load all plugins at startup, instead of dynamically as needed:
- I think it's safe to assume that if a plugin is installed, it means the user is going to want to use it, so it's better to fail early if there's a missing dependency rather than suddenly, e.g. when the user tries to use a command
- this make it possible to export metadata for each plugin (help/doc) to provide a more user-friendly UI