### PR TITLE
drop Python 2 support on Windows / OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,6 @@ before_install:
     set -ex
     # Bootstrap dev environment.
     bootstrap_cmd=(./bootstrap.sh)
-    if ! [ "$PYTHON" = 'python3' -a -n "$TRAVIS_TAG" ]
-    then
-      bootstrap_cmd+=('--tests-only')
-    fi
     bootstrap_cmd+=("$PYTHON")
     "${bootstrap_cmd[@]}"
     # List installed packages versions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,6 @@ matrix:
           - $HOME/.cache/wheels
       before_cache:
         - rm -rf $HOME/.cache/pip/log
-    # OSX / Python 2
-    - os: osx
-      osx_image: xcode8
-      env:
-        - PYTHON=python2
-        - CACHE_NAME=osx_py2
-      cache:
-        directories:
-          - $HOME/Library/Caches/pip
-          - $HOME/Library/Caches/wheels
-      before_cache:
-        - rm -rf $HOME/Library/Caches/pip/log
     # OSX / Python 3
     - os: osx
       osx_image: xcode8

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,15 @@ before_install:
     "${bootstrap_cmd[@]}"
     # List installed packages versions.
     $PYTHON -m pip list
+    if [ $TRAVIS_OS_NAME = osx ]
+    then
+      # For some reason, pyrcc5/pyuic55 are not found,
+      # so just use the right Python modules directly.
+      sed -i '' \
+        -e 's/"pyrcc5"/"'$PYTHON' -m PyQt5.pyrcc_main"/' \
+        -e 's/"pyuic5"/"'$PYTHON' -m PyQt5.uic.pyuic"/' \
+        pyuic.json
+    fi
     )
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
     bootstrap_cmd+=("$PYTHON")
     "${bootstrap_cmd[@]}"
     # List installed packages versions.
-    $PYTHON -m pip list
+    $PYTHON -m pip list --format=columns
     if [ $TRAVIS_OS_NAME = osx ]
     then
       # For some reason, pyrcc5/pyuic55 are not found,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,6 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
@@ -67,7 +64,7 @@ build_script:
   - "python setup.py build"
 
 after_build:
-  - ps: "if ($Env:PYTHON_VERSION -eq \"3.5\") { python windows\\helper.py dist }"
+  - ps: "python windows\\helper.py dist"
 
 test_script:
   - "python setup.py test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ install:
   # Setup the rest of the environment.
   - "python windows\\helper.py setup"
 
-  - "pip --disable-pip-version-check list"
+  - "pip --disable-pip-version-check list --format=columns"
 
 build:
   verbosity: minimal

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -82,16 +82,10 @@ pip_install_requirements()
 osx_bootstrap()
 {
   run brew update
-  if [ "$python" == 'python2' ]
-  then
-    python_package='python'
-  else
-    python_package="$python"
-    run export HOMEBREW_NO_AUTO_UPDATE=1
-    run git -C "$(brew --repo)/Library/Taps/homebrew/homebrew-core" checkout '5596439c4ca5a9963a7fec0146d3ce2b27e07a17^' Formula/python3.rb
-  fi
-  osx_packages_install $python_package
-  run brew link --overwrite $python_package
+  run export HOMEBREW_NO_AUTO_UPDATE=1
+  run git -C "$(brew --repo)/Library/Taps/homebrew/homebrew-core" checkout '5596439c4ca5a9963a7fec0146d3ce2b27e07a17^' Formula/python3.rb
+  osx_packages_install $python
+  run brew link --overwrite $python
 }
 
 osx_packages_install()
@@ -103,11 +97,6 @@ osx_packages_install()
     run brew upgrade $package
   done
 }
-
-osx_python2_base_packages=(
-)
-osx_python2_extra_packages=(
-)
 
 osx_python3_base_packages=(
 )
@@ -290,6 +279,12 @@ case "$OSTYPE" in
     exit 1
     ;;
 esac
+
+if [ "$python" == 'python2' -a "$OSTYPE" != 'linux-gnu' ]
+then
+  err "Python 2 is only supported on Linux"
+  exit 1
+fi
 
 var="${dist}_${python}_base_packages[@]"
 packages=("${!var}")

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -98,7 +98,6 @@ osx_packages_install()
 }
 
 osx_python3_packages=(
-pyqt5
 )
 
 # }}}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-opt_tests_only=0
 opt_dry_run=0
 
 python='false'
@@ -98,9 +97,7 @@ osx_packages_install()
   done
 }
 
-osx_python3_base_packages=(
-)
-osx_python3_extra_packages=(
+osx_python3_packages=(
 pyqt5
 )
 
@@ -118,7 +115,8 @@ arch_packages_install()
   run sudo pacman --sync --needed "$@"
 }
 
-arch_python2_base_packages=(
+arch_python2_packages=(
+base-devel
 cython2
 libusb
 python2-appdirs
@@ -127,6 +125,7 @@ python2-dbus
 python2-hidapi
 python2-mock
 python2-pip
+python2-pyqt5
 python2-pyserial
 python2-pytest
 python2-setuptools
@@ -134,14 +133,10 @@ python2-setuptools-scm
 python2-six
 python2-wheel
 python2-xlib
-)
-arch_python2_extra_packages=(
-base-devel
-python2-pyqt5
 wmctrl
 )
 
-arch_python3_base_packages=(
+arch_python3_packages=(
 cython
 libusb
 python-appdirs
@@ -149,6 +144,7 @@ python-babel
 python-dbus
 python-mock
 python-pip
+python-pyqt5
 python-pyserial
 python-pytest
 python-setuptools
@@ -156,9 +152,6 @@ python-setuptools-scm
 python-six
 python-wheel
 python-xlib
-)
-arch_python3_extra_packages=(
-python-pyqt5
 wmctrl
 )
 
@@ -177,10 +170,11 @@ ubuntu_packages_install()
   run sudo apt-get install -y "$@"
 }
 
-ubuntu_python2_base_packages=(
+ubuntu_python2_packages=(
 cython
 libudev-dev
 libusb-1.0-0-dev
+pyqt5-dev-tools
 python-appdirs
 python-babel
 python-dbus
@@ -189,25 +183,25 @@ python-hid
 python-mock
 python-pip
 python-pkg-resources
+python-pyqt5
 python-pytest
 python-serial
 python-setuptools
+python-setuptools-pyqt
 python-setuptools-scm
 python-six
 python-wheel
 python-xlib
-)
-ubuntu_python2_extra_packages=(
-pyqt5-dev-tools
-python-pyqt5
-python-setuptools-pyqt
 wmctrl
 )
 
-ubuntu_python3_base_packages=(
+ubuntu_python3_packages=(
 cython3
+debhelper
+devscripts
 libudev-dev
 libusb-1.0-0-dev
+pyqt5-dev-tools
 python3-appdirs
 python3-babel
 python3-dbus
@@ -216,20 +210,15 @@ python3-hid
 python3-mock
 python3-pip
 python3-pkg-resources
+python3-pyqt5
 python3-pytest
 python3-serial
 python3-setuptools
+python3-setuptools-pyqt
 python3-setuptools-scm
 python3-six
 python3-wheel
 python3-xlib
-)
-ubuntu_python3_extra_packages=(
-debhelper
-devscripts
-pyqt5-dev-tools
-python3-pyqt5
-python3-setuptools-pyqt
 wmctrl
 )
 
@@ -240,9 +229,6 @@ set -e
 while [ $# -ne 0 ]
 do
   case "$1" in
-    --tests-only|-t)
-      opt_tests_only=1
-      ;;
     --dry-run|-n)
       opt_dry_run=1
       ;;
@@ -286,13 +272,8 @@ then
   exit 1
 fi
 
-var="${dist}_${python}_base_packages[@]"
+var="${dist}_${python}_packages[@]"
 packages=("${!var}")
-if [ $opt_tests_only -eq 0 ]
-then
-  var="${dist}_${python}_extra_packages[@]"
-  packages+=("${!var}")
-fi
 
 "${dist}_bootstrap"
 if [ -n "$packages" ]

--- a/osx/README.md
+++ b/osx/README.md
@@ -12,7 +12,6 @@ Note: you can use `./bootstrap.sh -n` to get a list of the commands that would b
 
 - install [Homebrew](http://brew.sh/)
 - install Python3.5: `brew install python3`
-- install PyQt5: `brew install pyqt5`
 - install other dependencies:
 ```
 ./setup.py write_requirements

--- a/plover/gui_qt/i18n.py
+++ b/plover/gui_qt/i18n.py
@@ -57,10 +57,5 @@ def install_gettext():
 
 def get_gettext(package='plover', resource_dir='gui_qt/messages'):
     locale_dir = pkg_resources.resource_filename(package, resource_dir)
-    if PY2:
-        # unicode=True
-        args = [True]
-    else:
-        args = []
     translation = gettext.translation(package, locale_dir, fallback=True)
     return translation.ugettext if PY2 else translation.gettext

--- a/setup.py
+++ b/setup.py
@@ -394,6 +394,7 @@ install_requires = [
 
 extras_require = {
     ':"win32" in sys_platform': [
+        'PyQt5',
     ],
     ':"linux" in sys_platform': [
         # Note: do not require PyQt5 on Linux, as official distribution

--- a/setup.py
+++ b/setup.py
@@ -396,6 +396,9 @@ extras_require = {
     ':"win32" in sys_platform': [
     ],
     ':"linux" in sys_platform': [
+        # Note: do not require PyQt5 on Linux, as official distribution
+        # packages are missing the required Python distribution info.
+        # 'PyQt5',
         'python-xlib>=0.16',
     ],
     ':"darwin" in sys_platform': [

--- a/setup.py
+++ b/setup.py
@@ -403,6 +403,7 @@ extras_require = {
         'python-xlib>=0.16',
     ],
     ':"darwin" in sys_platform': [
+        'PyQt5',
         'pyobjc-core==3.1.1+plover2',
         'pyobjc-framework-Cocoa==3.1.1+plover2',
         'pyobjc-framework-Quartz==3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -324,33 +324,28 @@ if sys.platform.startswith('win32'):
 
 setup_requires.append('pytest')
 
+entrypoints['plover.gui'].append('qt = plover.gui_qt.main')
+entrypoints['plover.gui.qt.tool'] = [
+    'add_translation = plover.gui_qt.add_translation:AddTranslation',
+    'lookup          = plover.gui_qt.lookup_dialog:LookupDialog',
+    'paper_tape      = plover.gui_qt.paper_tape:PaperTape',
+    'suggestions     = plover.gui_qt.suggestions_dialog:SuggestionsDialog',
+]
+setup_requires.append('pyqt-distutils')
 try:
-    import PyQt5
+    from pyqt_distutils.build_ui import build_ui
 except ImportError:
     pass
 else:
-    entrypoints['plover.gui'].append('qt = plover.gui_qt.main')
-    entrypoints['plover.gui.qt.tool'] = [
-        'add_translation = plover.gui_qt.add_translation:AddTranslation',
-        'lookup          = plover.gui_qt.lookup_dialog:LookupDialog',
-        'paper_tape      = plover.gui_qt.paper_tape:PaperTape',
-        'suggestions     = plover.gui_qt.suggestions_dialog:SuggestionsDialog',
-    ]
-    setup_requires.append('pyqt-distutils')
-    try:
-        from pyqt_distutils.build_ui import build_ui
-    except ImportError:
-        pass
-    else:
-        class BuildUi(build_ui):
+    class BuildUi(build_ui):
 
-            def run(self):
-                from utils.pyqt import fix_icons
-                self._hooks['fix_icons'] = fix_icons
-                build_ui.run(self)
+        def run(self):
+            from utils.pyqt import fix_icons
+            self._hooks['fix_icons'] = fix_icons
+            build_ui.run(self)
 
-        cmdclass['build_ui'] = BuildUi
-        build_dependencies.append('build_ui')
+    cmdclass['build_ui'] = BuildUi
+    build_dependencies.append('build_ui')
 
 setup_requires.append('Babel')
 try:

--- a/windows/README.md
+++ b/windows/README.md
@@ -15,7 +15,6 @@ It is best to develop using 32 bit tools for Plover.
 ### Externally hosted dependencies
 
 - [Cython](http://cython.org/)
-- [PyQt5](https://riverbankcomputing.com/software/pyqt/intro)
 
 ### Other dependencies
 

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -207,7 +207,7 @@ class WineEnvironment(Environment):
         ):
             if var in env:
                 del env[var]
-            return env
+        return env
 
 
 class Win32Environment(Environment):

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -13,7 +13,6 @@ import sys
 import traceback
 
 
-PY3 = sys.version_info[0] >= 3
 WIN_DIR = os.path.dirname(os.path.abspath(__file__))
 TOP_DIR = os.path.dirname(WIN_DIR)
 NULL = open(os.devnull, 'r+b')
@@ -247,21 +246,13 @@ class Win32Environment(Environment):
 
 class Helper(object):
 
-    if PY3:
-        # Note: update pip so hidapi install from wheel works.
-        DEPENDENCIES = (
-            ('pip', 'pip:pip',
-             None, None, (), None),
-            ('PyQt5', 'pip:PyQt5',
-             None, None, (), None),
-        )
-    else:
-        DEPENDENCIES = (
-            ('Cython', 'https://pypi.python.org/packages/2.7/C/Cython/Cython-0.23.4-cp27-none-win32.whl',
-             'd7c1978fe2037674b151622158881c700ac2f06a', None, (), None),
-            ('VC for Python', 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi',
-             '7800d037ba962f288f9b952001106d35ef57befe', None, (), None),
-        )
+    # Note: update pip so hidapi install from wheel works.
+    DEPENDENCIES = (
+        ('pip', 'pip:pip',
+         None, None, (), None),
+        ('PyQt5', 'pip:PyQt5',
+         None, None, (), None),
+    )
 
     def __init__(self):
         self.dry_run = False
@@ -556,16 +547,10 @@ class Helper(object):
 
 class WineHelper(Helper):
 
-    if PY3:
-        DEPENDENCIES = (
-            ('Python', 'https://www.python.org/ftp/python/3.5.2/python-3.5.2.exe',
-             '3873deb137833a724be8932e3ce659f93741c20b', None, ('PrependPath=1', '/S'), None),
-        ) + Helper.DEPENDENCIES
-    else:
-        DEPENDENCIES = (
-            ('Python', 'https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi',
-             '662142691e0beba07a0bacee48e5e93a02537ff7', None, (), None),
-        ) + Helper.DEPENDENCIES
+    DEPENDENCIES = (
+        ('Python', 'https://www.python.org/ftp/python/3.5.2/python-3.5.2.exe',
+         '3873deb137833a724be8932e3ce659f93741c20b', None, ('PrependPath=1', '/S'), None),
+    ) + Helper.DEPENDENCIES
 
     def __init__(self):
         super(WineHelper, self).__init__()

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -250,8 +250,6 @@ class Helper(object):
     DEPENDENCIES = (
         ('pip', 'pip:pip',
          None, None, (), None),
-        ('PyQt5', 'pip:PyQt5',
-         None, None, (), None),
     )
 
     def __init__(self):

--- a/windows/hook-plover.py
+++ b/windows/hook-plover.py
@@ -27,16 +27,11 @@ for group in distribution.get_entry_map().values():
     for entrypoint in group.values():
         hiddenimports.append(entrypoint.module_name)
 
-try:
-    import PyQt5
-except ImportError:
-    pass
-else:
-    # Qt GUI localization.
-    from PyQt5.QtCore import QLibraryInfo
+# Qt GUI localization.
+from PyQt5.QtCore import QLibraryInfo
 
-    for catalog in glob('plover/gui_qt/messages/*/*/*.mo'):
-        datas.append((catalog, os.path.dirname(catalog)))
-    translations_dir = QLibraryInfo.location(QLibraryInfo.TranslationsPath)
-    for filename in glob(os.path.join(translations_dir, 'qtbase_*.qm')):
-        datas.append((filename, 'PyQt5/Qt/translations'))
+for catalog in glob('plover/gui_qt/messages/*/*/*.mo'):
+    datas.append((catalog, os.path.dirname(catalog)))
+translations_dir = QLibraryInfo.location(QLibraryInfo.TranslationsPath)
+for filename in glob(os.path.join(translations_dir, 'qtbase_*.qm')):
+    datas.append((filename, 'PyQt5/Qt/translations'))


### PR DESCRIPTION
Rational:
- Python 2 builds on those platform are narrow Unicode builds
- PyQt5 wheels are only available for Python 3
- those Python 2 builds are not really useful from a test standpoint, since the testsuite does not really test our platform specific code