### PR TITLE
Reset case action

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -384,6 +384,7 @@ META_CAPITALIZE = '-|'
 META_CARRY_CAPITALIZATION = '~|'
 META_LOWER = '>'
 META_UPPER = '<'
+META_RESET_CASE_ACTION = '-!'
 META_RETRO_CAPITALIZE = '*-|'
 META_RETRO_LOWER = '*>'
 META_RETRO_UPPER = '*<'
@@ -501,6 +502,11 @@ def _atom_to_action_spaces_before(atom, last_action):
             action = last_action.copy_state()
             action.lower = False
             action.upper = True
+            action.capitalize = False
+        elif meta == META_RESET_CASE_ACTION:
+            action = last_action.copy_state()
+            action.lower = False
+            action.upper = False
             action.capitalize = False
         elif meta == META_RETRO_CAPITALIZE:
             action = last_action.copy_state()
@@ -678,6 +684,11 @@ def _atom_to_action_spaces_after(atom, last_action):
             action = last_action.copy_state()
             action.lower = False
             action.upper = True
+            action.capitalize = False
+        elif meta == META_RESET_CASE_ACTION:
+            action = last_action.copy_state()
+            action.lower = False
+            action.upper = False
             action.capitalize = False
         elif (meta.startswith(META_CARRY_CAPITALIZATION) or
               meta.startswith(META_ATTACH_FLAG + META_CARRY_CAPITALIZATION)):

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -490,11 +490,18 @@ class FormatterTestCase(unittest.TestCase):
           action(text=' ', attach=True)
          ]),
          
-         (('{-|} equip {^s}', action(), True),
-          [action(capitalize=True),
-           action(text='Equip ', word='Equip'),
-           action(text='s ', word='Equips', replace=' '),
-          ]),
+        (('{-|} equip {^s}', action(), True),
+         [action(capitalize=True),
+          action(text='Equip ', word='Equip'),
+          action(text='s ', word='Equips', replace=' '),
+         ]),
+
+        (('{-|}{-!} equip {^s}', action(), True),
+         [action(capitalize=True),
+          action(capitalize=False),
+          action(text='equip ', word='equip'),
+          action(text='s ', word='equips', replace=' '),
+         ]),
 
         (('{-|} equip {^ed}', action(), True),
          [action(capitalize=True),
@@ -507,6 +514,12 @@ class FormatterTestCase(unittest.TestCase):
           action(text='equip ', word='equip')
          ]),
 
+        (('{>}{-!} Equip', action(), True),
+         [action(lower=True),
+          action(lower=False),
+          action(text='Equip ', word='Equip')
+         ]),
+
         (('{>} equip', action(), True),
          [action(lower=True),
           action(text='equip ', word='equip')
@@ -515,6 +528,12 @@ class FormatterTestCase(unittest.TestCase):
         (('{<} equip', action(), True),
          [action(upper=True),
           action(text='EQUIP ', word='EQUIP', upper_carry=True)
+         ]),
+
+        (('{<}{-!} equip', action(), True),
+         [action(upper=True),
+          action(upper=False),
+          action(text='equip ', word='equip', upper_carry=False)
          ]),
 
         (('{<} EQUIP', action(), True),
@@ -526,6 +545,13 @@ class FormatterTestCase(unittest.TestCase):
          [action(upper=True),
           action(text='EQUIP ', word='EQUIP', upper_carry=True),
           action(text='PED ', word='EQUIPPED', replace=' ', upper_carry=True)
+         ]),
+
+        (('{<}{-!} equip {^ed}', action(), True),
+         [action(upper=True),
+          action(upper=False),
+          action(text='equip ', word='equip', upper_carry=False),
+          action(text='ped ', word='equipped', replace=' ', upper_carry=False)
          ]),
 
         (('equip {*-|}', action(), True),


### PR DESCRIPTION
### About

The code adds a new command {-!}, which cancels capitalize-next-word-command {-|}, and uppercasing {>} and lowercasing {<} commands. It also cancels capitalization action after stops such as the period {.}.

### Reason

Canceling case changing actions for the next word is very useful together with commands that for example result to cursor movement, such as {#Left}. This way moving cursor to different location to edit text will not result Plover capitalizing words in the middle of a sentence. Using {<} to achieve this, does not work as then a proper name, such as "Plover" will be decapitalized to "plover".

### Tested Platforms

The code has been tested with Ubuntu 16.04.
