### PR TITLE
Cherry picks for 3.1.1

### DIFF
--- a/plover/gui/util.py
+++ b/plover/gui/util.py
@@ -6,9 +6,11 @@ import wx
 
 
 if sys.platform.startswith('win32'):
-    import win32gui
-    GetForegroundWindow = win32gui.GetForegroundWindow
-    SetForegroundWindow = win32gui.SetForegroundWindow
+
+    from ctypes import windll
+
+    GetForegroundWindow = windll.user32.GetForegroundWindow
+    SetForegroundWindow = windll.user32.SetForegroundWindow
 
     def SetTopApp(w):
         # Nothing else is necessary for windows.

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -112,6 +112,7 @@ DEADKEY_SYMBOLS = {
     'dead_tilde': '~',
 }
 
+
 def down(seq):
     return [(x, True) for x in seq]
 
@@ -127,15 +128,14 @@ def down_up(seq):
 MODIFIER_KEYS_TO_MASKS = {
     58: kCGEventFlagMaskAlternate,
     61: kCGEventFlagMaskAlternate,
-    59: kCGEventFlagMaskControl,
-    62: kCGEventFlagMaskControl,
+    # As of Sierra we *require* secondary fn to get control to work properly.
+    59: kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn,
+    62: kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn,
     56: kCGEventFlagMaskShift,
     60: kCGEventFlagMaskShift,
     55: kCGEventFlagMaskCommand,
     63: kCGEventFlagMaskSecondaryFn,
 }
-
-OUTPUT_SOURCE = CGEventSourceCreate(kCGEventSourceStateHIDSystemState)
 
 # For the purposes of this class, we're only watching these keys.
 # We could calculate the keys, but our default layout would be misleading:
@@ -313,9 +313,9 @@ class KeyboardEmulation(object):
     def send_backspaces(number_of_backspaces):
         for _ in range(number_of_backspaces):
             backspace_down = CGEventCreateKeyboardEvent(
-                OUTPUT_SOURCE, BACK_SPACE, True)
+                None, BACK_SPACE, True)
             backspace_up = CGEventCreateKeyboardEvent(
-                OUTPUT_SOURCE, BACK_SPACE, False)
+                None, BACK_SPACE, False)
             CGEventPost(kCGSessionEventTap, backspace_down)
             CGEventPost(kCGSessionEventTap, backspace_up)
 
@@ -382,10 +382,10 @@ class KeyboardEmulation(object):
 
     @staticmethod
     def _send_string_press(c):
-        event = CGEventCreateKeyboardEvent(OUTPUT_SOURCE, 0, True)
+        event = CGEventCreateKeyboardEvent(None, 0, True)
         KeyboardEmulation._set_event_string(event, c)
         CGEventPost(kCGSessionEventTap, event)
-        event = CGEventCreateKeyboardEvent(OUTPUT_SOURCE, 0, False)
+        event = CGEventCreateKeyboardEvent(None, 0, False)
         KeyboardEmulation._set_event_string(event, c)
         CGEventPost(kCGSessionEventTap, event)
 
@@ -485,7 +485,7 @@ class KeyboardEmulation(object):
                     mods_flags &= ~MODIFIER_KEYS_TO_MASKS[keycode]
 
                 event = CGEventCreateKeyboardEvent(
-                    OUTPUT_SOURCE, keycode, key_down)
+                    None, keycode, key_down)
 
                 if key_down and keycode not in MODIFIER_KEYS_TO_MASKS:
                     event_flags = CGEventGetFlags(event)

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -368,6 +368,7 @@ class KeyboardEmulation(object):
                     apply_raw.sequence.extend(down_up([keycode]))
                 else:
                     # Flush on type change.
+                    last_modifier = None
                     apply_raw()
                     key_plan.append((self.STRING_PRESS, c))
         # Flush after string is complete.

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -23,8 +23,6 @@ from ctypes import windll, wintypes
 # Python 2/3 compatibility.
 from six.moves import winreg
 
-import win32api
-
 from plover.key_combo import parse_key_combo
 from plover.oslayer.winkeyboardlayout import KeyboardLayout
 from plover import log
@@ -249,7 +247,7 @@ class KeyboardCaptureProcess(multiprocessing.Process):
         # Ignore KeyboardInterrupt when attached to a console...
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        self._tid = win32api.GetCurrentThreadId()
+        self._tid = windll.kernel32.GetCurrentThreadId()
         self._queue.put(self._tid)
 
         down_keys = set()

--- a/plover/oslayer/winkeyboardlayout.py
+++ b/plover/oslayer/winkeyboardlayout.py
@@ -10,10 +10,9 @@ import ctypes
 from ctypes import windll, wintypes
 from collections import defaultdict, namedtuple
 
-import win32gui
-
 from plover.key_combo import CHAR_TO_KEYNAME, add_modifiers_aliases
 from plover.misc import popcount_8
+
 
 GetKeyboardLayout = windll.user32.GetKeyboardLayout
 GetWindowThreadProcessId = windll.user32.GetWindowThreadProcessId
@@ -444,7 +443,7 @@ class KeyboardLayout(object): # {{{
 
     @staticmethod
     def current_layout_id():
-        pid = GetWindowThreadProcessId(win32gui.GetForegroundWindow(), 0)
+        pid = GetWindowThreadProcessId(windll.user32.GetForegroundWindow(), 0)
         return GetKeyboardLayout(pid)
 
 # }}}

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -172,8 +172,11 @@ class KeyboardCapture(threading.Thread):
         # Find all keyboard devices.
         keyboard_devices = []
         for devinfo in self.display.xinput_query_device(xinput.AllDevices).devices:
-            # Only keep slave keyboard devices.
-            if devinfo.use != xinput.SlaveKeyboard:
+            # Only keep slave devices.
+            # Note: we look at pointer devices too, as some keyboards (like the
+            # VicTop mechanical gaming keyboard) register 2 devices, including
+            # a pointer device with a key class (to fully support NKRO).
+            if devinfo.use not in (xinput.SlaveKeyboard, xinput.SlavePointer):
                 continue
             # Ignore XTest keyboard device.
             if 'Virtual core XTEST keyboard' == devinfo.name:
@@ -181,7 +184,11 @@ class KeyboardCapture(threading.Thread):
             # Ignore disabled devices.
             if not devinfo.enabled:
                 continue
-            keyboard_devices.append(devinfo.deviceid)
+            # Check for the presence of a key class.
+            for c in devinfo.classes:
+                if c.type == xinput.KeyClass:
+                    keyboard_devices.append(devinfo.deviceid)
+                    break
         if XINPUT_DEVICE_ID == xinput.AllDevices:
             self.devices = keyboard_devices
         else:

--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,6 @@ install_requires = [
 
 extras_require = {
     ':"win32" in sys_platform': [
-        'pywin32>=219',
     ],
     ':"linux" in sys_platform': [
         'python-xlib>=0.16',

--- a/setup.py
+++ b/setup.py
@@ -338,7 +338,7 @@ extras_require = {
     ':"darwin" in sys_platform': [
         'pyobjc-core==3.1.1+plover2',
         'pyobjc-framework-Cocoa==3.1.1+plover2',
-        'pyobjc-framework-Quartz>=3.0.3',
+        'pyobjc-framework-Quartz==3.1.1',
         'appnope>=0.1.0',
     ],
 }

--- a/windows/README.md
+++ b/windows/README.md
@@ -16,7 +16,6 @@ It is best to develop using 32 bit tools for Plover.
 
 - [Cython](http://cython.org/)
 - [Microsoft Visual C++ Compiler for Python 2.7](https://www.microsoft.com/en-us/download/details.aspx?id=44266)
-- [Python for Windows Extensions](http://sourceforge.net/projects/pywin32/)
 - [wxPython](http://www.wxpython.org/)
 
 ### Other dependencies

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -248,20 +248,16 @@ class Win32Environment(Environment):
 class Helper(object):
 
     if PY3:
-        # Note: update pip so hidapi install from wheel works.
         DEPENDENCIES = (
+            # Note: update pip so hidapi install from wheel works.
             ('pip', 'pip:pip',
              None, None, (), None),
-            ('pywin32', 'https://downloads.sourceforge.net/project/pywin32/pywin32/Build 220/pywin32-220.win32-py3.5.exe',
-             '5c9bd9643982dbfea4aba500503227dd997931df', 'easy_install', (), None),
         )
     else:
         DEPENDENCIES = (
             # Note: we force the installation directory, otherwise the installer gets confused when run under AppVeyor, and installs in the wrong directory...
             ('wxPython', 'https://downloads.sourceforge.net/wxpython/wxPython3.0-win32-3.0.2.0-py27.exe',
              '864d44e418a0859cabff71614a495bea57738c5d', None, ('/SP-', '/VERYSILENT', r'/DIR=C:\Python27\Lib\site-packages'), None),
-            ('pywin32', 'https://downloads.sourceforge.net/project/pywin32/pywin32/Build 219/pywin32-219.win32-py2.7.exe',
-             '8bc39008383c646bed01942584117113ddaefe6b', 'easy_install', (), None),
             ('Cython', 'https://pypi.python.org/packages/2.7/C/Cython/Cython-0.23.4-cp27-none-win32.whl',
              'd7c1978fe2037674b151622158881c700ac2f06a', None, (), None),
             ('VC for Python', 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi',


### PR DESCRIPTION
* lock down PyObjc version
* NKRO fix for Linux
* control key fix for macOS Sierra
* fix for missing modifiers in combos on macOS

Note: for some reason the Python 3 build on AppVeyor fails because of a permission error when installing pywin32... ¯\\_(ツ)_/¯