### PR TITLE
log: initialize platform handler earlier

### DIFF
--- a/plover/gui_none/main.py
+++ b/plover/gui_none/main.py
@@ -16,24 +16,6 @@ def show_error(title, message):
 
 def main(config):
 
-    handler_class = None
-    try:
-        if sys.platform.startswith('linux'):
-            from plover.oslayer.log_dbus import DbusNotificationHandler
-            handler_class = DbusNotificationHandler
-        elif sys.platform.startswith('darwin'):
-            from plover.oslayer.log_osx import OSXNotificationHandler
-            handler_class = OSXNotificationHandler
-    except Exception:
-        log.info('could not import platform gui log', exc_info=True)
-    if handler_class is not None:
-        try:
-            handler = handler_class()
-        except Exception:
-            log.info('could not initialize platform gui log', exc_info=True)
-        else:
-            log.add_handler(handler)
-
     engine = Engine(config, KeyboardEmulation())
     if not engine.load_config():
         return 3

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -86,29 +86,10 @@ def show_error(title, message):
 
 def main(config):
 
-    use_qt_notifications = True
-    handler_class = None
-    try:
-        if sys.platform.startswith('linux'):
-            from plover.oslayer.log_dbus import DbusNotificationHandler
-            handler_class = DbusNotificationHandler
-        elif sys.platform.startswith('darwin'):
-            from plover.oslayer.log_osx import OSXNotificationHandler
-            handler_class = OSXNotificationHandler
-    except Exception:
-        log.info('could not import platform gui log', exc_info=True)
-    if handler_class is not None:
-        try:
-            handler = handler_class()
-        except Exception:
-            log.info('could not initialize platform gui log', exc_info=True)
-        else:
-            log.add_handler(handler)
-            use_qt_notifications = False
-
     # Setup internationalization support.
     install_gettext()
 
+    use_qt_notifications = not log.has_platform_handler()
     app = Application(config, use_qt_notifications)
     app.run()
     del app

--- a/plover/log.py
+++ b/plover/log.py
@@ -89,6 +89,9 @@ class Logger(object):
             elif sys.platform.startswith('darwin'):
                 from plover.oslayer.log_osx import OSXNotificationHandler
                 handler_class = OSXNotificationHandler
+            elif sys.platform.startswith('win32'):
+                from plover.oslayer.log_plyer import PlyerNotificationHandler
+                handler_class = PlyerNotificationHandler
         except Exception:
             self.info('could not import platform gui log', exc_info=True)
         if handler_class is None:

--- a/plover/main.py
+++ b/plover/main.py
@@ -51,6 +51,7 @@ def main():
     args = parser.parse_args(args=sys.argv[1:])
     if args.log_level is not None:
         log.set_level(args.log_level.upper())
+    log.setup_platform_handler()
 
     registry.load_plugins()
     registry.update()

--- a/plover/oslayer/log_dbus.py
+++ b/plover/oslayer/log_dbus.py
@@ -1,12 +1,15 @@
 
+import os
 import logging
 
 import dbus
 
 from plover import log, __name__ as __software_name__
+from plover.oslayer.config import ASSETS_DIR
 
 
 APPNAME = __software_name__.capitalize()
+APPICON = os.path.join(ASSETS_DIR, 'plover.png')
 SERVICE = 'org.freedesktop.Notifications'
 INTERFACE = '/org/freedesktop/Notifications'
 
@@ -36,7 +39,7 @@ class DbusNotificationHandler(logging.Handler):
         else:
             timeout = 0
             urgency = 2
-        self._notify.Notify(APPNAME, 0, '',       # replaces_id, app_icon
+        self._notify.Notify(APPNAME, 0, APPICON,  # app_name, replaces_id, app_icon
                             APPNAME, message, '', # actions
                             { 'urgency': dbus.Byte(urgency) },
                             timeout * 1000)

--- a/plover/oslayer/log_plyer.py
+++ b/plover/oslayer/log_plyer.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import logging
+
+from plyer import notification
+
+from plover import log, __name__ as __software_name__
+from plover.oslayer.config import ASSETS_DIR
+
+
+APPNAME = __software_name__.capitalize()
+
+if sys.platform.startswith('win32'):
+    APPICON = os.path.join(ASSETS_DIR, 'plover.ico')
+else:
+    APPICON = os.path.join(ASSETS_DIR, 'plover_32x32.png')
+
+
+class PlyerNotificationHandler(logging.Handler):
+    """ Handler using Plyer's notifications to show messages. """
+
+    def __init__(self):
+        super(PlyerNotificationHandler, self).__init__()
+        self.setLevel(log.WARNING)
+        self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
+
+    def emit(self, record):
+        level = record.levelno
+        message = self.format(record)
+        if message.endswith('\n'):
+            message = message[:-1]
+        if level <= log.INFO:
+            timeout = 10
+        elif level <= log.WARNING:
+            timeout = 15
+        else:
+            timeout = 60
+        notification.notify(
+            app_name=APPNAME,
+            app_icon=APPICON,
+            title=APPNAME,
+            message=message,
+            timeout=timeout,
+        )

--- a/setup.py
+++ b/setup.py
@@ -395,6 +395,7 @@ install_requires = [
 extras_require = {
     ':"win32" in sys_platform': [
         'PyQt5',
+        'plyer', # For notifications.
     ],
     ':"linux" in sys_platform': [
         # Note: do not require PyQt5 on Linux, as official distribution


### PR DESCRIPTION
Do it before loading plugins, so the user get some feedback on errors.

Note: this still leave Windows users without feedback if an error occurs during the initialization (no platform specific log handler).