### PR TITLE
registry: sort `list_plugins` result

### DIFF
--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -27,9 +27,8 @@ def _get_dictionary_module(filename):
     except KeyError:
         raise DictionaryLoaderException(
             'Unsupported extension: %s. Supported extensions: %s' %
-            (extension, ', '.join(sorted(
-                plugin.name for plugin in registry.list_plugins('dictionary')
-            ))))
+            (extension, ', '.join(plugin.name for plugin in
+                                  registry.list_plugins('dictionary'))))
     return dict_module
 
 def create_dictionary(filename):

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -90,8 +90,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         self.toolbar.customContextMenuRequested.connect(
             lambda: self.toolbar_menu.popup(QCursor.pos())
         )
-        for tool_plugin in sorted(registry.list_plugins('gui.qt.tool'),
-                                  key=lambda p: p.name):
+        for tool_plugin in registry.list_plugins('gui.qt.tool'):
             tool = tool_plugin.obj
             action_parameters = []
             if tool.ICON is not None:

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -65,7 +65,8 @@ class Registry(object):
         return self._plugins[plugin_type][plugin_name.lower()]
 
     def list_plugins(self, plugin_type):
-        return self._plugins[plugin_type].values()
+        return sorted(self._plugins[plugin_type].values(),
+                      key=lambda p: p.name)
 
     def load_plugins(self, plugins_dir=PLUGINS_DIR):
         log.info('loading plugins from %s', plugins_dir)


### PR DESCRIPTION
So there's no need to do it everywhere `registry.list_plugins` is used. This fixes the display order of machines in the UI.