### PR TITLE
Fix GUI tools' settings' persistence

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -49,16 +49,10 @@ DEFAULT_START_MINIMIZED = False
 STROKE_DISPLAY_SECTION = 'Stroke Display'
 STROKE_DISPLAY_SHOW_OPTION = 'show'
 DEFAULT_STROKE_DISPLAY_SHOW = False
-STROKE_DISPLAY_ON_TOP_OPTION = 'on_top'
-DEFAULT_STROKE_DISPLAY_ON_TOP = True
-STROKE_DISPLAY_STYLE_OPTION = 'style'
-DEFAULT_STROKE_DISPLAY_STYLE = 'Paper'
 
 SUGGESTIONS_DISPLAY_SECTION = 'Suggestions Display'
 SUGGESTIONS_DISPLAY_SHOW_OPTION = 'show'
 DEFAULT_SUGGESTIONS_DISPLAY_SHOW = False
-SUGGESTIONS_DISPLAY_ON_TOP_OPTION = 'on_top'
-DEFAULT_SUGGESTIONS_DISPLAY_ON_TOP = True
 
 OUTPUT_CONFIG_SECTION = 'Output Configuration'
 OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION = 'space_placement'
@@ -326,27 +320,6 @@ class Config(object):
     def set_start_attached(self, b):
         self._set(OUTPUT_CONFIG_SECTION, OUTPUT_CONFIG_START_ATTACHED, b)
 
-    def set_stroke_display_on_top(self, b):
-        self._set(STROKE_DISPLAY_SECTION, STROKE_DISPLAY_ON_TOP_OPTION, b)
-
-    def get_stroke_display_on_top(self):
-        return self._get_bool(STROKE_DISPLAY_SECTION,
-            STROKE_DISPLAY_ON_TOP_OPTION, DEFAULT_STROKE_DISPLAY_ON_TOP)
-
-    def set_suggestions_display_on_top(self, b):
-        self._set(SUGGESTIONS_DISPLAY_SECTION, SUGGESTIONS_DISPLAY_ON_TOP_OPTION, b)
-
-    def get_suggestions_display_on_top(self):
-        return self._get_bool(SUGGESTIONS_DISPLAY_SECTION,
-            SUGGESTIONS_DISPLAY_ON_TOP_OPTION, DEFAULT_SUGGESTIONS_DISPLAY_ON_TOP)
-
-    def set_stroke_display_style(self, s):
-        self._set(STROKE_DISPLAY_SECTION, STROKE_DISPLAY_STYLE_OPTION, s)
-
-    def get_stroke_display_style(self):
-        return self._get(STROKE_DISPLAY_SECTION, STROKE_DISPLAY_STYLE_OPTION,
-                         DEFAULT_STROKE_DISPLAY_STYLE)
-
     def set_translation_frame_opacity(self, opacity):
         raise_if_invalid_opacity(opacity)
         self._set(TRANSLATION_FRAME_SECTION,
@@ -519,9 +492,6 @@ class Config(object):
 
     show_stroke_display
     show_suggestions_display
-    stroke_display_on_top
-    stroke_display_style
-    suggestions_display_on_top
     translation_frame_opacity
 
     system_name

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -61,14 +61,12 @@ class PaperTape(Tool, Ui_PaperTape):
         if style is not None:
             self.styles.setCurrentText(self.STYLES[style])
             self.on_style_changed(self.STYLES[style])
-
         font_string = settings.value('font')
         if font_string is not None:
             font = QFont()
             if font.fromString(font_string):
                 self.header.setFont(font)
                 self.tape.setFont(font)
-
         ontop = settings.value('ontop', None, bool)
         if ontop is not None:
             self.action_ToggleOnTop.setChecked(ontop)
@@ -77,7 +75,6 @@ class PaperTape(Tool, Ui_PaperTape):
     def _save_state(self, settings):
         settings.setValue('style', self.STYLES.index(self._style))
         settings.setValue('font', self.header.font().toString())
-
         ontop = bool(self.windowFlags() & Qt.WindowStaysOnTopHint)
         settings.setValue('ontop', ontop)
 

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -57,9 +57,11 @@ class PaperTape(Tool, Ui_PaperTape):
         self.finished.connect(self.save_state)
 
     def _restore_state(self, settings):
-        style = settings.value('style')
+        style = settings.value('style', None, int)
         if style is not None:
-            self.styles.setCurrentText(self.STYLES[int(style)])
+            self.styles.setCurrentText(self.STYLES[style])
+            self.on_style_changed(self.STYLES[style])
+
         font_string = settings.value('font')
         if font_string is not None:
             font = QFont()
@@ -67,15 +69,19 @@ class PaperTape(Tool, Ui_PaperTape):
                 self.header.setFont(font)
                 self.tape.setFont(font)
 
+        ontop = settings.value('ontop', None, bool)
+        if ontop is not None:
+            self.action_ToggleOnTop.setChecked(ontop)
+            self.on_toggle_ontop(ontop)
+
     def _save_state(self, settings):
         settings.setValue('style', self.STYLES.index(self._style))
         settings.setValue('font', self.header.font().toString())
 
+        ontop = bool(self.windowFlags() & Qt.WindowStaysOnTopHint)
+        settings.setValue('ontop', ontop)
+
     def on_config_changed(self, config):
-        if 'stroke_display_on_top' in config:
-            ontop = config['stroke_display_on_top']
-            self.action_ToggleOnTop.setChecked(ontop)
-            self.on_toggle_ontop(ontop)
         if 'system_name' in config:
             self._strokes = []
             self._all_keys = ''.join(key.strip('-') for key in system.KEYS)

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -86,7 +86,6 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             if not font.fromString(font_string):
                 continue
             self._set_font(name, font)
-
         ontop = settings.value('ontop', None, bool)
         if ontop is not None:
             self.action_ToggleOnTop.setChecked(ontop)
@@ -100,7 +99,6 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             font = self._get_font(name)
             font_string = font.toString()
             settings.setValue(name, font_string)
-
         ontop = bool(self.windowFlags() & Qt.WindowStaysOnTopHint)
         settings.setValue('ontop', ontop)
 

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -87,6 +87,11 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
                 continue
             self._set_font(name, font)
 
+        ontop = settings.value('ontop', None, bool)
+        if ontop is not None:
+            self.action_ToggleOnTop.setChecked(ontop)
+            self.on_toggle_ontop(ontop)
+
     def _save_state(self, settings):
         for name in (
             'text_font',
@@ -95,6 +100,9 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             font = self._get_font(name)
             font_string = font.toString()
             settings.setValue(name, font_string)
+
+        ontop = bool(self.windowFlags() & Qt.WindowStaysOnTopHint)
+        settings.setValue('ontop', ontop)
 
     def _show_suggestions(self, suggestion_list):
         self.suggestions.append(suggestion_list)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -66,12 +66,6 @@ class ConfigTestCase(unittest.TestCase):
         ('space_placement', config.OUTPUT_CONFIG_SECTION, 
          config.OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION, config.DEFAULT_OUTPUT_CONFIG_SPACE_PLACEMENT, 
          'Before Output', 'After Output', 'None'),
-        ('stroke_display_on_top', config.STROKE_DISPLAY_SECTION, 
-         config.STROKE_DISPLAY_ON_TOP_OPTION, 
-         config.DEFAULT_STROKE_DISPLAY_ON_TOP, False, True, False),
-        ('stroke_display_style', config.STROKE_DISPLAY_SECTION, 
-         config.STROKE_DISPLAY_STYLE_OPTION, 
-         config.DEFAULT_STROKE_DISPLAY_STYLE, 'Raw', 'Paper', 'Pseudo'),
         )
 
         for case in cases:
@@ -316,9 +310,6 @@ class ConfigTestCase(unittest.TestCase):
             start_attached
             start_capitalized
             start_minimized
-            stroke_display_on_top
-            stroke_display_style
-            suggestions_display_on_top
             system_keymap
             system_name
             translation_frame_opacity


### PR DESCRIPTION
### About

Add saving and restoring of ontop setting to suggestions dialog and paper tape using QSettings.

Fix restoring of paper tape style setting (was only restoring the text label).

Remove the config options for ontop and paper tape style from the main config.

### Reason

This restores behaviour lost when changing from wxWidgets to Qt.

### Tested Platforms

Linux Mint 17
