### PR TITLE
Fix Mac output edge cases

### DIFF
--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -107,7 +107,6 @@ DEADKEY_SYMBOLS = {
     'dead_tilde': '~',
 }
 
-
 def down(seq):
     return [(x, True) for x in seq]
 
@@ -131,6 +130,8 @@ MODIFIER_KEYS_TO_MASKS = {
     55: kCGEventFlagMaskCommand,
     63: kCGEventFlagMaskSecondaryFn,
 }
+
+OUTPUT_SOURCE = CGEventSourceCreate(kCGEventSourceStateHIDSystemState)
 
 # For the purposes of this class, we're only watching these keys.
 # We could calculate the keys, but our default layout would be misleading:
@@ -308,9 +309,9 @@ class KeyboardEmulation(object):
     def send_backspaces(number_of_backspaces):
         for _ in range(number_of_backspaces):
             backspace_down = CGEventCreateKeyboardEvent(
-                None, BACK_SPACE, True)
+                OUTPUT_SOURCE, BACK_SPACE, True)
             backspace_up = CGEventCreateKeyboardEvent(
-                None, BACK_SPACE, False)
+                OUTPUT_SOURCE, BACK_SPACE, False)
             CGEventPost(kCGSessionEventTap, backspace_down)
             CGEventPost(kCGSessionEventTap, backspace_up)
 
@@ -378,10 +379,10 @@ class KeyboardEmulation(object):
 
     @staticmethod
     def _send_string_press(c):
-        event = CGEventCreateKeyboardEvent(None, 0, True)
+        event = CGEventCreateKeyboardEvent(OUTPUT_SOURCE, 0, True)
         KeyboardEmulation._set_event_string(event, c)
         CGEventPost(kCGSessionEventTap, event)
-        event = CGEventCreateKeyboardEvent(None, 0, False)
+        event = CGEventCreateKeyboardEvent(OUTPUT_SOURCE, 0, False)
         KeyboardEmulation._set_event_string(event, c)
         CGEventPost(kCGSessionEventTap, event)
 
@@ -481,7 +482,7 @@ class KeyboardEmulation(object):
                     mods_flags &= ~MODIFIER_KEYS_TO_MASKS[keycode]
 
                 event = CGEventCreateKeyboardEvent(
-                    None, keycode, key_down)
+                    OUTPUT_SOURCE, keycode, key_down)
 
                 if key_down and keycode not in MODIFIER_KEYS_TO_MASKS:
                     event_flags = CGEventGetFlags(event)

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -127,7 +127,7 @@ MODIFIER_KEYS_TO_MASKS = {
     62: kCGEventFlagMaskControl | kCGEventFlagMaskSecondaryFn,
     56: kCGEventFlagMaskShift,
     60: kCGEventFlagMaskShift,
-    55: kCGEventFlagMaskCommand,
+    55: kCGEventFlagMaskCommand | kCGEventFlagMaskSecondaryFn,
     63: kCGEventFlagMaskSecondaryFn,
 }
 


### PR DESCRIPTION
Fix #732 

I've given up trying to understand *why* this works the way it does, but through some cargo culting and testing I've found that:

- Command shortcuts *also* have the SecondaryFn Mask and global shortcuts require it (same as Control)
- The Output source None caused #732 as an issue -- I have no clue why. I reverted the output source, and mission control still works so I guess it was unnecessary in the first place.
