### PR TITLE
switch to official Python installer on macOS + rework artifacts on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,17 @@ script:
   - git fetch --quiet --unshallow
   - $PYTHON setup.py patch_version
   - $PYTHON setup.py test
-
-before_deploy:
   - |
     (
     set -ex
+    # Only generate artifacts if we're actually going to deploy them.
+    # Note: if we moved this to the `before_deploy` phase, we would
+    # not have to check, but we'd also lose caching; since the cache
+    # is stored before the `before_install` phase...
+    if [ -z "$TRAVIS_TAG" ]
+    then
+      exit 0
+    fi
     case "$TRAVIS_OS_NAME" in
     osx)
       if [ $PYTHON = python3 ]
@@ -65,11 +71,30 @@ before_deploy:
       fi
       ;;
     linux)
-      $PYTHON setup.py bdist_egg
       if [ $PYTHON = python3 ]
       then
         $PYTHON setup.py bdist_wheel sdist
-        ./linux/debuild.sh -us -uc
+        sudo apt-get install -qq \
+          libfuse2 \
+          python3-requests \
+          libglib2.0-dev \
+          libx11-dev \
+          libxmu-dev \
+          libbz2-dev \
+          libgdbm-dev \
+          liblzma-dev \
+          libncurses5-dev \
+          libreadline-dev \
+          libsqlite3-dev \
+          libssl-dev \
+          zlib1g-dev \
+          libudev-dev \
+          libusb-1.0-0-dev \
+          libdbus-1-dev \
+          libdbus-glib-1-dev \
+          ;
+        ./linux/appimage.sh -c -j 2 -w dist/*.whl
+        rm -rf .cache/pip
       fi
       ;;
     esac
@@ -85,7 +110,7 @@ deploy:
   draft: true
   file_glob: true
   file:
-    - "dist/*.deb"
+    - "dist/*.AppImage"
     - "dist/*.dmg"
     - "dist/*.egg"
     - "dist/*.tar.gz"

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -30,10 +30,6 @@ url="http://www.openstenoproject.org/plover/"
 source=(https://github.com/openstenoproject/plover/archive/v$pkgver.tar.gz)
 sha1sums=(89ca6af3fe002be218158930d105d25c1e1282be)
 
-prepare() {
-  cd "$pkgname-$pkgver"
-}
-
 check() {
   cd "$pkgname-$pkgver"
   python setup.py test

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 opt_dry_run=0
+opt_timings=0
 
 python='false'
 
@@ -61,8 +62,11 @@ find_dist()
 run()
 {
   info "$@"
-  if [ $opt_dry_run -eq 0 ]
+  [ $opt_dry_run -ne 0 ] && return
+  if [ $opt_timings -ne 0 ]
   then
+    time "$@"
+  else
     "$@"
   fi
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+plover (4.0.0.dev0-1) xenial; urgency=low
+
+  * Switch to Python 3 / PyQt5.
+
+ -- Benoit Pierre <benoit.pierre@gmail.com>  Fri, 30 Sep 2017 17:20:03 +0200
+
 plover (3.0.0-3) xenial; urgency=low
 
   * Drop unnecessary python-hidapi dependency.

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Homepage: http://plover.stenoknight.com/
 Depends:
 	${python3:Depends},
 	python3-appdirs,
+	python3-dbus,
 	python3-hid,
 	python3-pkg-resources,
 	python3-pyqt5,

--- a/linux/appimage.sh
+++ b/linux/appimage.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+set -e
+
+. ./utils/functions.sh
+
+topdir="$PWD"
+distdir="$topdir/dist"
+builddir="$topdir/build/appimage"
+appdir="$builddir/plover.AppDir"
+cachedir="$topdir/.cache/appimage"
+wheel=''
+python='python3'
+make_opts=(-s)
+opt_ccache=0
+opt_optimize=0
+
+parse_opts args "$@"
+set -- "${args[@]}"
+
+while [ $# -ne 0 ]
+do
+  case "$1" in
+    -O)
+      opt_optimize=1
+      ;;
+    -c|--ccache)
+      opt_ccache=1
+      ;;
+    -j|--jobs)
+      make_opts+=("-j$2")
+      shift
+      ;;
+    -p|--python)
+      python="$2"
+      shift
+      ;;
+    -w|--wheel)
+      wheel="$2"
+      shift
+      ;;
+    -*)
+      err "invalid option: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+version="$("$python" -c 'from plover import __version__; print(__version__)')"
+appimage="$distdir/plover-$version-x86_64.AppImage"
+
+run rm -rf "$builddir"
+run mkdir -p "$appdir" "$cachedir" "$distdir"
+
+# Download dependencies.
+run "$python" -m utils.download 'https://github.com/probonopd/AppImages/raw/6ca06be6d68606a18a90ebec5aebfd74e8a973c5/functions.sh' '3155bde5f40fd4aa08b3a76331936bd5b2e6b781' "$cachedir/functions.sh"
+run "$python" -m utils.download 'https://github.com/probonopd/AppImageKit/releases/download/8/appimagetool-x86_64.AppImage' 'e756ecac69f393c72333f8bd9cd3a5f87dc175bf' "$cachedir/appimagetool"
+run "$python" -m utils.download 'https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz' '127121fdca11e735b3686e300d66f73aba663e93'
+run "$python" -m utils.download 'http://ftp.debian.org/debian/pool/main/w/wmctrl/wmctrl_1.07.orig.tar.gz' 'a123019a7fd5adc3e393fc1108cb706268a34e4d'
+run "$python" -m utils.download 'http://ftp.debian.org/debian/pool/main/w/wmctrl/wmctrl_1.07-7.debian.tar.gz' 'e8ac68f7600907be5489c0fd9ffcf2047daaf8cb'
+run "$python" -m utils.download 'https://bootstrap.pypa.io/get-pip.py' '3d45cef22b043b2b333baa63abaa99544e9c031d'
+
+# Generate Plover wheel.
+if [ -z "$wheel" ]
+then
+  run "$python" setup.py bdist_wheel
+  wheel="$distdir/plover-$version-py2.py3-none-any.whl"
+fi
+
+if [ $opt_ccache -ne 0 ]
+then
+   run export CCACHE_DIR="$topdir/.cache/ccache" CCACHE_BASEDIR="$buildir" CC='ccache gcc'
+ fi
+
+# Build Python.
+run tar xf "$downloads/Python-3.5.3.tar.xz" -C "$builddir"
+info '('
+(
+run cd "$builddir/Python-3.5.3"
+cmd=(
+  ./configure
+  --cache-file="$cachedir/python.config.cache"
+  --prefix="$appdir/usr"
+  --enable-ipv6
+  --enable-loadable-sqlite-extensions
+  --enable-shared
+  --with-threads
+  --without-ensurepip
+)
+if [ $opt_optimize -ne 0 ]
+then
+  cmd+=(--enable-optimizations)
+fi
+run "${cmd[@]}"
+run make "${make_opts[@]}"
+run make "${make_opts[@]}" install >/dev/null
+)
+info ')'
+
+# Build wmctrl.
+run tar xf "$downloads/wmctrl_1.07.orig.tar.gz" -C "$builddir"
+info '('
+(
+run cd "$builddir/wmctrl-1.07"
+run tar xf "$downloads/wmctrl_1.07-7.debian.tar.gz"
+run patch -p1 -i debian/patches/01_64-bit-data.patch
+run ./configure \
+  --cache-file="$cachedir/wmctrl.config.cache" \
+  --prefix="$appdir/usr" \
+  ;
+run make "${make_opts[@]}" install
+)
+info ')'
+
+appdir_python()
+{
+  env LD_LIBRARY_PATH="$appdir/usr/lib" "$appdir/usr/bin/python3.5" -s "$@"
+}
+python='appdir_python'
+
+# Install pip/wheel...
+run "$python" "$downloads/get-pip.py" -f "$wheels"
+# ...and cache them for the next iteration.
+wheels_install --no-install pip wheel
+
+# Install Plover and dependencies.
+# Note: temporarily install Cython so building cython-hidapi's wheel is faster.
+rwt Cython -- wheels_install --ignore-installed "$wheel" PyQt5 dbus-python pip wheel
+
+# List installed Python packages.
+run "$python" -m pip list --format=columns
+
+# Note: those will re-appear in their respective
+# locations when creating the AppImage...
+# ¯\_(ツ)_/¯
+run mv "$appdir/usr/share/applications/Plover.desktop" "$appdir/plover.desktop"
+run mv "$appdir/usr/share/pixmaps/plover.png" "$appdir/plover.png"
+
+# Trim the fat.
+run "$python" -m utils.trim "$appdir" linux/appimage_blacklist.txt
+
+# Make distribution source-less.
+run "$python" -m utils.source_less "$appdir/usr/lib/python3.5" '*/pip/_vendor/distlib/*'
+
+# Add launcher.
+# Note: don't use AppImage's AppRun because
+# it will change the working directory.
+create_apprun()
+{
+  cat >"$appdir/AppRun" <<\EOF
+#!/bin/sh
+set -e
+APPDIR="$(dirname "$(readlink -e "$0")")"
+export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
+export PATH="${APPDIR}/usr/bin:${PATH}"
+exec "${APPDIR}/usr/bin/python3.5" -m plover.main "$@"
+EOF
+  chmod +x "$appdir/AppRun"
+}
+run create_apprun
+
+# Finalize AppDir.
+(
+run . "$cachedir/functions.sh"
+run cd "$appdir"
+# Add desktop integration.
+run get_desktopintegration 'plover'
+# Fix missing system dependencies.
+run copy_deps; run copy_deps; run copy_deps
+run move_lib
+# Move usr/include out of the way to preserve usr/include/python3.5m.
+run mv usr/include usr/include.tmp
+run delete_blacklisted
+run mv usr/include.tmp usr/include
+)
+
+# Strip binaries.
+strip_binaries()
+{
+  chmod u+w -R "$appdir"
+  {
+    printf '%s\0' "$appdir/usr/bin/python3.5"
+    find "$appdir" -type f -regex '.*\.so\(\.[0-9.]+\)?$' -print0
+  } | xargs -0 --no-run-if-empty --verbose -n1 strip
+}
+run strip_binaries
+
+# Remove empty directories.
+remove_emptydirs()
+{
+  find "$appdir" -type d -empty -print0 | xargs -0 --no-run-if-empty rmdir -vp --ignore-fail-on-non-empty
+}
+run remove_emptydirs
+
+# Create the AppImage.
+# Note: extract appimagetool so fuse is not needed.
+info '('
+(
+run cd "$builddir"
+run chmod +x "$cachedir/appimagetool"
+run "$cachedir/appimagetool" --appimage-extract
+run env VERSION="$version" ./squashfs-root/AppRun --no-appstream --verbose "$appdir" "$appimage"
+)
+info ')'

--- a/linux/appimage_blacklist.txt
+++ b/linux/appimage_blacklist.txt
@@ -1,0 +1,109 @@
+# General.
+:usr
+  man
+  share/man
+:usr/lib
+  # **/libcrypto.so*
+  pkgconfig
+
+# Python.
+:usr/bin
+  2to3*
+  easy_install*
+  idle*
+  miniterm.py
+  pip*
+  pydoc*
+  python3
+  python3-config
+  python3.5-config
+  python3.5m
+  python3.5m-config
+  pyvenv*
+  wheel
+:usr/lib/python3.5
+  config-3.5m/libpython3.5m.a
+  ctypes/test
+  distutils/command/*.exe
+  distutils/tests
+  ensurepip
+  idlelib
+  lib-dynload/_tkinter.*
+  lib2to3/tests
+  sqlite3/test
+  test
+  tkinter
+  turtle*
+  unittest/test
+:usr/lib/python3.5/site-packages
+  pip/_vendor/distlib/*.exe
+  setuptools/*.exe
+
+# Plover.
+:usr/lib/python3.5/site-packages/plover
+  gui_qt/*.ui
+  gui_qt/messages/**/*.po
+  gui_qt/messages/plover.pot
+  gui_qt/resources
+
+# PyQt5.
+:usr/bin
+  pylupdate5
+  pyrcc5
+  pyuic5
+:usr/lib/python3.5/site-packages/PyQt5
+  **/*Bluetooth*
+  **/*CLucene*
+  **/*Designer*
+  **/*Help*
+  **/*Location*
+  **/*Multimedia*
+  **/*Network*
+  **/*Nfc*
+  **/*OpenGL*
+  **/*Position*
+  **/*Print*
+  **/*Qml*
+  **/*Quick*
+  **/*Sensors*
+  **/*Serial*
+  **/*Sql*
+  **/*Test*
+  **/*Web*
+  **/*Xml*
+  **/*qtwebengine*
+  Qt/plugins/PyQt5/libpyqt5qmlplugin.so
+  Qt/plugins/audio
+  Qt/plugins/bearer
+  Qt/plugins/egldeviceintegrations
+  Qt/plugins/gamepads
+  Qt/plugins/generic
+  Qt/plugins/geoservices
+  Qt/plugins/mediaservice
+  Qt/plugins/platforms/libqeglfs.so
+  Qt/plugins/platforms/libqlinuxfb.so
+  Qt/plugins/platforms/libqminimal.so
+  Qt/plugins/platforms/libqminimalegl.so
+  Qt/plugins/platforms/libqoffscreen.so
+  Qt/plugins/platforms/libqvnc.so
+  Qt/plugins/playlistformats
+  Qt/plugins/position
+  Qt/plugins/printsupport
+  Qt/plugins/sceneparsers
+  Qt/plugins/sensor*
+  Qt/plugins/sqldrivers
+  Qt/qml
+  Qt/resources
+  Qt/translations/qt_help_*
+  Qt/translations/qtconnectivity_*
+  Qt/translations/qtdeclarative_*
+  Qt/translations/qtlocation_*
+  Qt/translations/qtmultimedia_*
+  Qt/translations/qtquick*
+  Qt/translations/qtserialport_*
+  Qt/translations/qtwebsockets_*
+  pylupdate*
+  pyrcc*
+  uic
+
+# vim: ft=config

--- a/linux/packpack.mk
+++ b/linux/packpack.mk
@@ -1,0 +1,10 @@
+PACKAGE := $(PRODUCT)-$(VERSION)
+
+.PHONY: appimage
+
+appimage:
+	tar xf dist/$(PACKAGE).tar.xz -C /build
+	cd /build/$(PACKAGE) && \
+		ln -s /cache .cache && \
+		env MAKEFLAGS='' ./linux/appimage.sh -w /source/dist/$(PACKAGE)-py2.py3-none-any.whl -c -j 2 && \
+		mv dist/*.AppImage ..

--- a/linux/packpack.mk
+++ b/linux/packpack.mk
@@ -8,3 +8,11 @@ appimage:
 		ln -s /cache .cache && \
 		env MAKEFLAGS='' ./linux/appimage.sh -w /source/dist/$(PACKAGE)-py2.py3-none-any.whl -c -j 2 && \
 		mv dist/*.AppImage ..
+
+.PHONY: makepkg
+
+makepkg:
+	mkdir -p /build/src
+	tar xf dist/$(PACKAGE).tar.xz -C /build/src
+	sed 's,^pkgver=.*,pkgver=$(VERSION),' archlinux/PKGBUILD >/build/PKGBUILD
+	cd /build && makepkg --force --syncdeps --noconfirm --noextract

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -e
+
+. ./utils/functions.sh
+
+BUILD_DIR="build/packpack"
+DIST_DIR="dist"
+
+opt_no_pull=0
+
+parse_opts args "$@"
+set -- "${args[@]}"
+
+while [ $# -ne 0 ]
+do
+  case "$1" in
+    --no-pull)
+      opt_no_pull=1
+      ;;
+    -*)
+      err "invalid option: $1"
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
+[ $# -eq 1 ]
+
+REPO='plover/packpack'
+case "$1" in
+  trusty)
+    OS='ubuntu'
+    DIST='trusty'
+    EXT='deb'
+    TARGET="package"
+    ;;
+  *)
+    err "unsupported target: $1"
+    exit 1
+    ;;
+esac
+shift
+
+NAME='plover'
+VERSION="$(./setup.py --version)"
+SDIST="$DIST_DIR/$NAME-$VERSION.tar.xz"
+
+run rm -rf "$BUILD_DIR"
+run mkdir -p "$BUILD_DIR" "$DIST_DIR" .cache
+run ./setup.py -q sdist --format=xztar
+run cp "$SDIST" "$BUILD_DIR/"
+cmd=(env)
+if [ $opt_no_pull -ne 0 ]
+then
+  cmd+=(NO_PULL=1)
+fi
+cmd+=(
+  BUILDDIR="$PWD/$BUILD_DIR" CACHE_DIR="$PWD/.cache"
+  DOCKER_REPO="$REPO"
+  OS="$OS" DIST="$DIST"
+  PRODUCT="$NAME" VERSION="$VERSION"
+  packpack "$TARGET"
+)
+run "${cmd[@]}"
+run_eval "mv '$BUILD_DIR/'*.$EXT '$DIST_DIR/'"

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -39,6 +39,12 @@ case "$1" in
     EXT='deb'
     TARGET="package"
     ;;
+  xenial)
+    OS='ubuntu'
+    DIST='xenial'
+    EXT='deb'
+    TARGET="package"
+    ;;
   *)
     err "unsupported target: $1"
     exit 1

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -33,6 +33,12 @@ done
 
 REPO='plover/packpack'
 case "$1" in
+  rawhide)
+    OS='fedora'
+    DIST='rawhide'
+    EXT='noarch.rpm'
+    TARGET="package"
+    ;;
   trusty)
     OS='ubuntu'
     DIST='trusty'

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -39,6 +39,12 @@ case "$1" in
     EXT='AppImage'
     TARGET="appimage"
     ;;
+  archlinux)
+    OS='archlinux'
+    DIST='1'
+    EXT='pkg.tar.xz'
+    TARGET='makepkg'
+    ;;
   rawhide)
     OS='fedora'
     DIST='rawhide'

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -33,6 +33,12 @@ done
 
 REPO='plover/packpack'
 case "$1" in
+  appimage)
+    OS='appimage'
+    DIST='2'
+    EXT='AppImage'
+    TARGET="appimage"
+    ;;
   rawhide)
     OS='fedora'
     DIST='rawhide'
@@ -64,7 +70,13 @@ SDIST="$DIST_DIR/$NAME-$VERSION.tar.xz"
 
 run rm -rf "$BUILD_DIR"
 run mkdir -p "$BUILD_DIR" "$DIST_DIR" .cache
-run ./setup.py -q sdist --format=xztar
+
+setup_cmd=(./setup.py -q sdist --format=xztar)
+if [ "$TARGET" = 'appimage' ]
+then
+  setup_cmd+=(bdist_wheel)
+fi
+run "${setup_cmd[@]}"
 run cp "$SDIST" "$BUILD_DIR/"
 cmd=(env)
 if [ $opt_no_pull -ne 0 ]
@@ -76,7 +88,7 @@ cmd+=(
   DOCKER_REPO="$REPO"
   OS="$OS" DIST="$DIST"
   PRODUCT="$NAME" VERSION="$VERSION"
-  packpack "$TARGET"
+  packpack -f /source/linux/packpack.mk "$TARGET"
 )
 run "${cmd[@]}"
 run_eval "mv '$BUILD_DIR/'*.$EXT '$DIST_DIR/'"

--- a/rpm/package.spec
+++ b/rpm/package.spec
@@ -1,0 +1,62 @@
+Name:    plover
+Version: 4.0.0.dev0
+Release: 1%{?dist}
+Summary: Open Source Stenography Software
+URL:     http://www.openstenoproject.org/
+License: GPLv2+
+Source0: https://github.com/openstenoproject/plover/archive/v%{version}.tar.gz
+BuildArch: noarch
+BuildRequires: python-qt5
+BuildRequires: python3 >= 3.5
+BuildRequires: python3-appdirs
+BuildRequires: python3-babel
+BuildRequires: python3-devel
+BuildRequires: python3-docopt
+BuildRequires: python3-hidapi
+BuildRequires: python3-mock
+BuildRequires: python3-pyserial >= 2.7
+BuildRequires: python3-pytest
+BuildRequires: python3-pytz
+BuildRequires: python3-qt5
+BuildRequires: python3-setuptools >= 20.7.0
+BuildRequires: python3-setuptools_scm
+BuildRequires: python3-xlib >= 0.16
+Requires: python3
+Requires: python3-appdirs
+Requires: python3-dbus
+Requires: python3-hidapi
+Requires: python3-pyserial >= 2.7
+Requires: python3-qt5
+Requires: python3-setuptools >= 20.7.0
+Requires: python3-xlib >= 0.16
+Requires: wmctrl
+
+%description
+Plover is a free open source program intended to
+bring realtime stenographic technology not just to stenographers, but also to
+hackers, hobbyists, accessibility mavens, and all-around speed demons.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+mkdir -p .deps
+env PYTHONPATH="$PWD/.deps" %{__python3} -m easy_install -d .deps pyqt-distutils
+env PYTHONPATH="$PWD/.deps" %{__python3} setup.py compile_catalog build_ui build
+
+%install
+env PYTHONPATH="$PWD/.deps" %py3_install
+
+%check
+env PYTHONPATH="$PWD/.deps" %{__python3} setup.py test
+
+%files
+%doc README.md
+%license LICENSE.txt
+%{_bindir}/plover
+%{python3_sitelib}/plover*
+/usr/share/applications/Plover.desktop
+/usr/share/pixmaps/plover.png
+
+%changelog
+

--- a/setup.py
+++ b/setup.py
@@ -414,7 +414,7 @@ entrypoints = {
 }
 
 if sys.platform.startswith('darwin'):
-    setup_requires.append('PyInstaller==3.1.1')
+    setup_requires.append('PyInstaller==3.2.1')
     cmdclass['bdist_app'] = BinaryDistApp
     cmdclass['bdist_dmg'] = BinaryDistDmg
 

--- a/utils/download.py
+++ b/utils/download.py
@@ -51,6 +51,12 @@ def download(url, sha1=None, filename=None, downloads_dir=DOWNLOADS_DIR):
 
 
 if __name__ == '__main__':
-    url = sys.argv[1]
-    sha1 = sys.argv[2] if len(sys.argv) > 2 else None
-    print(download(url, sha1))
+    args = sys.argv[1:]
+    url = args.pop(0)
+    sha1 = None
+    filename = None
+    if args:
+        sha1 = args.pop(0) or None
+    if args:
+        filename = args.pop(0)
+    print(download(url, sha1, filename))

--- a/utils/download.py
+++ b/utils/download.py
@@ -28,7 +28,7 @@ def download(url, sha1=None, filename=None, downloads_dir=DOWNLOADS_DIR):
             try:
                 with contextlib.closing(session.send(prepped, stream=True)) as resp:
                     with open(dst, 'wb') as fp:
-                        for chunk in iter(lambda: resp.raw.read(4 * 1024), b''):
+                        for chunk in resp.iter_content(chunk_size=4 * 1024):
                             fp.write(chunk)
             except Exception as e:
                 print('error', e)

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+opt_dry_run=0
+opt_timings=0
+
+python='false'
+wheels="$PWD/.cache/wheels"
+downloads="$PWD/.cache/downloads"
+
+# Usage: parse_opts args "$@"
+#
+# `$args` will be set to unhandled options and non-option arguments.
+#
+# Consumed options:
+#
+# --dry-run/-n: don't execute run/run_eval commands (print them instead)
+# --debug/-d: enable `set -x` for debugging script
+# --: stop options processing
+#
+# Tip: to update $@ after the call, use:
+# parse_opts args "$@" && set -- "${args[@]}"
+parse_opts()
+{
+  args_varname="$1"
+  shift
+  local _args=()
+  while [ $# -ne 0 ]
+  do
+    case "$1" in
+      --dry-run|-n)
+        opt_dry_run=1
+        ;;
+      --debug|-d)
+        set -x
+        ;;
+      --)
+        shift
+        _args+=("$@")
+        break
+        ;;
+      *)
+        _args+=("$1")
+        ;;
+    esac
+    shift
+  done
+  eval "$args_varname=(${_args[@]@Q})"
+}
+
+info()
+{
+  color=34
+  case "$1" in
+    -c*)
+      color="${1#-c}"
+      shift
+      ;;
+  esac
+  if [ -t 2 ]
+  then
+    echo "[${color}m$@[0m" 1>&2
+  else
+    echo "$@" 1>&2
+  fi
+}
+
+err()
+{
+  info -c31 "$@"
+}
+
+find_dist()
+{
+  if ! [ -r /etc/lsb-release ]
+  then
+    if [ -r /etc/arch-release ]
+    then
+      echo arch
+      return
+    fi
+    err "unsuported distribution: $dist"
+    return 1
+  fi
+  dist="$(lsb_release -i -s | tr A-Z a-z)"
+  case "$dist" in
+    arch)
+      echo 'arch'
+      ;;
+    linuxmint|ubuntu)
+      echo 'ubuntu'
+      ;;
+    *)
+      err "unsuported distribution: $dist"
+      return 1
+      ;;
+  esac
+}
+
+run()
+{
+  info "$@"
+  [ $opt_dry_run -ne 0 ] && return
+  if [ $opt_timings -ne 0 ]
+  then
+    time "$@"
+  else
+    "$@"
+  fi
+}
+
+run_eval()
+{
+  info "$@"
+  [ $opt_dry_run -ne 0 ] && return
+  if [ $opt_timings -ne 0 ]
+  then
+    time eval "$@"
+  else
+    eval "$@"
+  fi
+}
+
+# Crude version of wheels_install, that will work
+# if wheel is not installed and for installing it,
+# but still tries to hit/update the wheels cache.
+pip_install()
+{
+  run mkdir -p "$wheels" || return $?
+  run "$python" -m pip install -d "$wheels" -f "$wheels" "$@" || true
+  run "$python" -m pip install -f "$wheels" "$@"
+}
+
+wheels_install()
+{
+  run "$python" -m utils.install_wheels "$@"
+}

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -134,3 +134,23 @@ wheels_install()
 {
   run "$python" -m utils.install_wheels "$@"
 }
+
+# Crude version of https://github.com/jaraco/rwt
+rwt()
+{(
+  local rwt_args=()
+  while [ $# -ne 0 ]
+  do
+    if [ "x$1" = 'x--' ]
+    then
+      shift
+      break
+    fi
+    rwt_args+=("$1")
+    shift
+  done
+  wheels_install -t "$PWD/.rwt" "${rwt_args[@]}"
+  run export PYTHONPATH="$PWD/.rwt${PYTHONPATH:+:$PYTHONPATH}"
+  "$@"
+  run rm -rf .rwt
+)}

--- a/utils/install_wheels.py
+++ b/utils/install_wheels.py
@@ -98,7 +98,7 @@ def _pip(args, verbose=True, no_progress=True):
     cmd.extend(args)
     return subprocess.call(cmd)
 
-def install_wheels(args, verbose=True, no_progress=True):
+def install_wheels(args, verbose=True, no_install=False, no_progress=True):
     wheels_cache = WHEELS_CACHE
     wheel_args = []
     install_args = []
@@ -116,6 +116,9 @@ def install_wheels(args, verbose=True, no_progress=True):
         opt = a
         if opt == '-w':
             wheels_cache = args.pop(0)
+            continue
+        if opt == '--no-install':
+            no_install = True
             continue
         if opt == '--progress-bar':
             if args[0] == 'off':
@@ -145,14 +148,14 @@ def install_wheels(args, verbose=True, no_progress=True):
         # Since pip will not build and cache wheels for VCS links, we do it ourselves:
         # - first, update the cache (without VCS links), and try to install from it
         code = _pip(wheel_args, no_progress=no_progress)
-        if code == 0:
+        if code == 0 and not no_install:
             code = _pip(install_args, no_progress=no_progress)
     else:
         code = 1
     if code != 0:
       # - if it failed, try to update the cache again, this time with VCS links
       code = _pip(wheel_args + constraint_args, no_progress=no_progress)
-      if code == 0:
+      if code == 0 and not no_install:
           # - and try again
           code = _pip(install_args, no_progress=no_progress)
     if code != 0:

--- a/utils/trim.py
+++ b/utils/trim.py
@@ -7,16 +7,33 @@ import os
 
 
 def trim(directory, patterns_file, verbose=True):
+    # Build list of patterns.
+    pattern_list = []
+    subdir = directory
     with open(patterns_file) as fp:
-        for pattern in fp:
-            pattern = os.path.join(directory, pattern.strip())
-            for path in reversed(glob.glob(pattern, recursive=True)):
-                if verbose:
-                    print('removing', path)
-                if os.path.isdir(path):
-                    shutil.rmtree(path)
-                else:
-                    os.unlink(path)
+        for line in fp:
+            line = line.strip()
+            # Empty line, ignore.
+            if not line:
+                continue
+            # Comment, ignore.
+            if line.startswith('#'):
+                continue
+            # Sub-directory change.
+            if line.startswith(':'):
+                subdir = os.path.join(directory, line[1:])
+                continue
+            # Pattern (relative to current sub-directory).
+            pattern_list.append(os.path.join(subdir, line))
+    # Trim directory tree.
+    for pattern in pattern_list:
+        for path in reversed(glob.glob(pattern, recursive=True)):
+            if verbose:
+                print('removing', path)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.unlink(path)
 
 
 if __name__ == '__main__':

--- a/windows/dist_blacklist.txt
+++ b/windows/dist_blacklist.txt
@@ -1,54 +1,60 @@
-Lib/site-packages/PyQt5/**/*AxContainer*
-Lib/site-packages/PyQt5/**/*Bluetooth*
-Lib/site-packages/PyQt5/**/*CLucene*
-Lib/site-packages/PyQt5/**/*DBus*
-Lib/site-packages/PyQt5/**/*Designer*
-Lib/site-packages/PyQt5/**/*Help*
-Lib/site-packages/PyQt5/**/*Location*
-Lib/site-packages/PyQt5/**/*Multimedia*
-Lib/site-packages/PyQt5/**/*Network*
-Lib/site-packages/PyQt5/**/*Nfc*
-Lib/site-packages/PyQt5/**/*OpenGL*
-Lib/site-packages/PyQt5/**/*Position*
-Lib/site-packages/PyQt5/**/*Print*
-Lib/site-packages/PyQt5/**/*Qml*
-Lib/site-packages/PyQt5/**/*Quick*
-Lib/site-packages/PyQt5/**/*Sensors*
-Lib/site-packages/PyQt5/**/*Serial*
-Lib/site-packages/PyQt5/**/*Sql*
-Lib/site-packages/PyQt5/**/*Test*
-Lib/site-packages/PyQt5/**/*Web*
-Lib/site-packages/PyQt5/**/*WinExtras*
-Lib/site-packages/PyQt5/**/*Xml*
-Lib/site-packages/PyQt5/**/*qtwebengine*
-Lib/site-packages/PyQt5/Qt/bin/libeay32.dll
-Lib/site-packages/PyQt5/Qt/bin/ssleay32.dll
-Lib/site-packages/PyQt5/Qt/plugins/audio
-Lib/site-packages/PyQt5/Qt/plugins/bearer
-Lib/site-packages/PyQt5/Qt/plugins/generic
-Lib/site-packages/PyQt5/Qt/plugins/geoservices
-Lib/site-packages/PyQt5/Qt/plugins/mediaservice
-Lib/site-packages/PyQt5/Qt/plugins/playlistformats
-Lib/site-packages/PyQt5/Qt/plugins/position
-Lib/site-packages/PyQt5/Qt/plugins/printsupport
-Lib/site-packages/PyQt5/Qt/plugins/sceneparsers
-Lib/site-packages/PyQt5/Qt/plugins/sensor*
-Lib/site-packages/PyQt5/Qt/plugins/sqldrivers
-Lib/site-packages/PyQt5/Qt/qml
-Lib/site-packages/PyQt5/Qt/resources
-Lib/site-packages/PyQt5/Qt/translations/qt_help_*
-Lib/site-packages/PyQt5/Qt/translations/qtconnectivity_*
-Lib/site-packages/PyQt5/Qt/translations/qtdeclarative_*
-Lib/site-packages/PyQt5/Qt/translations/qtlocation_*
-Lib/site-packages/PyQt5/Qt/translations/qtmultimedia_*
-Lib/site-packages/PyQt5/Qt/translations/qtquick*
-Lib/site-packages/PyQt5/Qt/translations/qtserialport_*
-Lib/site-packages/PyQt5/Qt/translations/qtwebsockets_*
-Lib/site-packages/PyQt5/pylupdate*
-Lib/site-packages/PyQt5/pyrcc*
-Lib/site-packages/PyQt5/uic
-Lib/site-packages/plover/gui_qt/*.ui
-Lib/site-packages/plover/gui_qt/messages/**/*.po
-Lib/site-packages/plover/gui_qt/messages/plover.pot
-Lib/site-packages/plover/gui_qt/resources
-Scripts
+# Python.
+  Scripts
+# PyQt5.
+:Lib/site-packages/PyQt5
+  **/*AxContainer*
+  **/*Bluetooth*
+  **/*CLucene*
+  **/*DBus*
+  **/*Designer*
+  **/*Help*
+  **/*Location*
+  **/*Multimedia*
+  **/*Network*
+  **/*Nfc*
+  **/*OpenGL*
+  **/*Position*
+  **/*Print*
+  **/*Qml*
+  **/*Quick*
+  **/*Sensors*
+  **/*Serial*
+  **/*Sql*
+  **/*Test*
+  **/*Web*
+  **/*WinExtras*
+  **/*Xml*
+  **/*qtwebengine*
+  Qt/bin/libeay32.dll
+  Qt/bin/ssleay32.dll
+  Qt/plugins/audio
+  Qt/plugins/bearer
+  Qt/plugins/generic
+  Qt/plugins/geoservices
+  Qt/plugins/mediaservice
+  Qt/plugins/playlistformats
+  Qt/plugins/position
+  Qt/plugins/printsupport
+  Qt/plugins/sceneparsers
+  Qt/plugins/sensor*
+  Qt/plugins/sqldrivers
+  Qt/qml
+  Qt/resources
+  Qt/translations/qt_help_*
+  Qt/translations/qtconnectivity_*
+  Qt/translations/qtdeclarative_*
+  Qt/translations/qtlocation_*
+  Qt/translations/qtmultimedia_*
+  Qt/translations/qtquick*
+  Qt/translations/qtserialport_*
+  Qt/translations/qtwebsockets_*
+  pylupdate*
+  pyrcc*
+  uic
+# Plover.
+:Lib/site-packages/plover
+  gui_qt/*.ui
+  gui_qt/*.ui
+  gui_qt/messages/**/*.po
+  gui_qt/messages/plover.pot
+  gui_qt/resources


### PR DESCRIPTION
- no more brew on macOS: the official Python installer for 3.5 is used instead
- drop eggs and deb on Linux: instead generate an [AppImage](http://appimage.org/)
- add [packpack](https://github.com/packpack/packpack) support: this can be used to generate the AppImage, a deb for Ubuntu Trusty/Xenial, an Arch Linux package, or a RPM for Fedora Rawhide