### PR TITLE
Fix inconsistent ordering of automatic suffix keys

### DIFF
--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -2,6 +2,7 @@
 from io import open
 import os
 import re
+import collections
 
 from plover.oslayer.config import CONFIG_DIR, ASSETS_DIR
 from plover.registry import registry
@@ -31,12 +32,16 @@ def _key_order(keys, numbers):
             key_order[number_key] = order
     return key_order
 
+def _suffix_keys(keys):
+    assert isinstance(keys, collections.Sequence)
+    return keys
+
 _EXPORTS = {
     'KEYS'                     : lambda mod: mod.KEYS,
     'KEY_ORDER'                : lambda mod: _key_order(mod.KEYS, mod.NUMBERS),
     'NUMBER_KEY'               : lambda mod: mod.NUMBER_KEY,
     'NUMBERS'                  : lambda mod: dict(mod.NUMBERS),
-    'SUFFIX_KEYS'              : lambda mod: mod.SUFFIX_KEYS,
+    'SUFFIX_KEYS'              : lambda mod: _suffix_keys(mod.SUFFIX_KEYS),
     'UNDO_STROKE_STENO'        : lambda mod: mod.UNDO_STROKE_STENO,
     'IMPLICIT_HYPHEN_KEYS'     : lambda mod: set(mod.IMPLICIT_HYPHEN_KEYS),
     'IMPLICIT_HYPHENS'         : lambda mod: set(l.replace('-', '')

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -36,7 +36,7 @@ _EXPORTS = {
     'KEY_ORDER'                : lambda mod: _key_order(mod.KEYS, mod.NUMBERS),
     'NUMBER_KEY'               : lambda mod: mod.NUMBER_KEY,
     'NUMBERS'                  : lambda mod: dict(mod.NUMBERS),
-    'SUFFIX_KEYS'              : lambda mod: set(mod.SUFFIX_KEYS),
+    'SUFFIX_KEYS'              : lambda mod: mod.SUFFIX_KEYS,
     'UNDO_STROKE_STENO'        : lambda mod: mod.UNDO_STROKE_STENO,
     'IMPLICIT_HYPHEN_KEYS'     : lambda mod: set(mod.IMPLICIT_HYPHEN_KEYS),
     'IMPLICIT_HYPHENS'         : lambda mod: set(l.replace('-', '')

--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -10,7 +10,7 @@ KEYS = (
 
 IMPLICIT_HYPHEN_KEYS = ('A-', 'O-', '5-', '0-', '-E', '-U', '*')
 
-SUFFIX_KEYS = ('-S', '-G', '-Z', '-D')
+SUFFIX_KEYS = ('-Z', '-D', '-S', '-G')
 
 NUMBER_KEY = '#'
 

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -246,3 +246,12 @@ class BlackboxTest(unittest.TestCase):
             stroke = steno_to_stroke(steno)
             self.translator.translate(stroke)
         self.assertEqual(self.output.text, u'\n\t')
+
+    def test_automatic_suffix_keys_1(self):
+        self.dictionary.set(('RAEUS',), 'race')
+        self.dictionary.set(('RAEUZ',), 'raise')
+        self.dictionary.set(('-S',), '{^s}')
+        self.dictionary.set(('-Z',), '{^s}')
+        stroke = Stroke(('R-', 'A-', '-E', '-U', '-S', '-Z'))
+        self.translator.translate(stroke)
+        self.assertEqual(self.output.text, u' races')


### PR DESCRIPTION
### About

Fix system SUFFIX_KEYS getting put into a set, which loses all reliable ordering.

Order english stenotype SUFFIX_KEYS into reverse steno order (automatic suffixes which don't break steno order should be picked before those that do).