### PR TITLE
gui_qt/dictionaries_widget: workaround PyQt5 5.2.1 bug

### DIFF
--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -323,7 +323,7 @@
   </connection>
   <connection>
    <sender>table</sender>
-   <signal>itemChanged(QTableWidgetItem*)</signal>
+   <signal>itemChanged()</signal>
    <receiver>DictionariesWidget</receiver>
    <slot>on_dictionary_changed(QTableWidgetItem*)</slot>
    <hints>


### PR DESCRIPTION
On Ubuntu Trusty, with PyQt5 version 5.2.1, connecting the signal for `on_dictionary_changed` fails:
```python
Unexpected error: Traceback (most recent call last):
  File "/home/bpierre/progs/src/plover/plover/main.py", line 73, in main
    code = gui.main(config)
  File "/home/bpierre/progs/src/plover/plover/gui_qt/main.py", line 93, in main
    app = Application(config, use_qt_notifications)
  File "/home/bpierre/progs/src/plover/plover/gui_qt/main.py", line 64, in __init__
    self._win = MainWindow(self._engine, use_qt_notifications)
  File "/home/bpierre/progs/src/plover/plover/gui_qt/main_window.py", line 44, in __init__
    self.dictionaries = DictionariesWidget(engine)
  File "/home/bpierre/progs/src/plover/plover/gui_qt/dictionaries_widget.py", line 38, in __init__
    self.setupUi(self)
  File "/home/bpierre/progs/src/plover/plover/gui_qt/dictionaries_widget_ui.py", line 87, in setupUi
    self.table.itemChanged['QTableWidgetItem*'].connect(DictionariesWidget.on_dictionary_changed)
KeyError: 'there is no matching overloaded signal'
```
Manually patching the signal prototype fix the issue by changing the generated code to:
```python
self.table.itemChanged.connect(DictionariesWidget.on_dictionary_changed)
```