### PR TITLE
A few Python tidies

### DIFF
--- a/plover/dictionary/loading_manager.py
+++ b/plover/dictionary/loading_manager.py
@@ -3,12 +3,8 @@
 
 """Centralized place for dictionary loading operation."""
 
-import sys
 import threading
 import time
-
-# Python 2/3 compatibility.
-from six import reraise
 
 from plover.dictionary.base import load_dictionary
 from plover.exception import DictionaryLoaderException

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -57,7 +57,7 @@ def copy_default_dictionaries(dictionaries_files):
             continue
         # Check it's actually a default dictionary.
         basename = os.path.basename(dictionary)
-        if not basename in system.DEFAULT_DICTIONARIES:
+        if basename not in system.DEFAULT_DICTIONARIES:
             continue
         default_dictionary = os.path.join(system.DICTIONARIES_ROOT, basename)
         log.info('recreating %s from %s', dictionary, default_dictionary)
@@ -221,9 +221,9 @@ class StenoEngine(object):
             self._machine.start_capture()
         # Update running extensions.
         enabled_extensions = config['enabled_extensions']
-        running_extensons = set(self._running_extensions)
-        self._stop_extensions(running_extensons - enabled_extensions)
-        self._start_extensions(enabled_extensions - running_extensons)
+        running_extensions = set(self._running_extensions)
+        self._stop_extensions(running_extensions - enabled_extensions)
+        self._start_extensions(enabled_extensions - running_extensions)
         # Trigger `config_changed` hook.
         if config_update:
             self._trigger_hook('config_changed', config_update)
@@ -258,7 +258,7 @@ class StenoEngine(object):
 
     def _start_extensions(self, extension_list):
         for extension_name in extension_list:
-            log.info('starting `%s` extension' % extension_name)
+            log.info('starting `%s` extension', extension_name)
             try:
                 extension = registry.get_plugin('extension', extension_name).obj(self)
                 extension.start()
@@ -269,7 +269,7 @@ class StenoEngine(object):
 
     def _stop_extensions(self, extension_list):
         for extension_name in list(extension_list):
-            log.info('stopping `%s` extension' % extension_name)
+            log.info('stopping `%s` extension', extension_name)
             extension = self._running_extensions.pop(extension_name)
             extension.stop()
             del extension

--- a/plover/gui_qt/add_translation.py
+++ b/plover/gui_qt/add_translation.py
@@ -3,9 +3,9 @@ from collections import namedtuple
 
 from PyQt5.QtCore import QEvent
 
-from plover.misc import expand_path, shorten_path
+from plover.misc import shorten_path
 from plover.steno import normalize_steno
-from plover.engine import ErroredDictionary, StartingStrokeState
+from plover.engine import StartingStrokeState
 from plover.translation import escape_translation, unescape_translation
 
 from plover.gui_qt.add_translation_ui import Ui_AddTranslation

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -17,7 +17,6 @@ from PyQt5.QtWidgets import (
 
 from plover.config import DictionaryConfig
 from plover.engine import ErroredDictionary
-from plover.misc import shorten_path
 from plover.registry import registry
 
 from plover.gui_qt.dictionaries_widget_ui import Ui_DictionariesWidget

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1158,7 +1158,7 @@ class KeyboardEmulation(object):
             for keysym_index, keysym in enumerate(mapping):
                 if keysym == self.PLOVER_MAPPING_KEYSYM:
                     continue
-                if not keysym_index in (0, 1, 4, 5):
+                if keysym_index not in (0, 1, 4, 5):
                     continue
                 modifiers = 0
                 if 1 == (keysym_index % 2):


### PR DESCRIPTION
### About

Some minor Python tidies:

* Remove unused imports and an unused variable
* Fix two places where `log` was being with `%`-formatting instead of comma-formatting.
* Fix a typo in a variable name.

### Reason

It doesn’t fix an issue, this is just general code hygiene.

### Tested Platforms

Just running a Python linter on OS X.