### PR TITLE
show reload icon for outdated dictionaries

### DIFF
--- a/plover/dictionary/loading_manager.py
+++ b/plover/dictionary/loading_manager.py
@@ -17,6 +17,15 @@ class DictionaryLoadingManager(object):
     def __init__(self):
         self.dictionaries = {}
 
+    def __len__(self):
+        return len(self.dictionaries)
+
+    def __getitem__(self, filename):
+        return self.dictionaries[filename].get()
+
+    def __contains__(self, filename):
+        return filename in self.dictionaries
+
     def start_loading(self, filename):
         op = self.dictionaries.get(filename)
         if op is not None and not op.needs_reloading():
@@ -25,6 +34,11 @@ class DictionaryLoadingManager(object):
         op = DictionaryLoadingOperation(filename)
         self.dictionaries[filename] = op
         return op
+
+    def unload_outdated(self):
+        for filename, op in list(self.dictionaries.items()):
+            if op.needs_reloading():
+                del self.dictionaries[filename]
 
     def load(self, filenames):
         start_time = time.time()

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -183,11 +183,12 @@ class StenoDictionary(object):
 
 class StenoDictionaryCollection(object):
 
-    def __init__(self):
+    def __init__(self, dicts=[]):
         self.dicts = []
         self.filters = []
         self.longest_key = 0
         self.longest_key_callbacks = set()
+        self.set_dicts(dicts)
 
     def set_dicts(self, dicts):
         for d in self.dicts:

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -44,6 +44,9 @@ class StenoDictionary(object):
     def __str__(self):
         return '%s(%r)' % (self.__class__.__name__, self.path)
 
+    def __repr__(self):
+        return str(self)
+
     @classmethod
     def create(cls, resource):
         assert not resource.startswith(ASSET_SCHEME)
@@ -211,6 +214,12 @@ class StenoDictionaryCollection(object):
                     if f(key, value):
                         return None
                 return value
+
+    def __str__(self):
+        return 'StenoDictionaryCollection' + repr(tuple(self.dicts))
+
+    def __repr__(self):
+        return str(self)
 
     def lookup(self, key):
         return self._lookup(key, filters=self.filters)

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -55,7 +55,6 @@ class StenoDictionaryTestCase(unittest.TestCase):
         self.assertEqual(notifications, [1, 4, 2, 0])
 
     def test_dictionary_collection(self):
-        dc = StenoDictionaryCollection()
         d1 = StenoDictionary()
         d1[('S',)] = 'a'
         d1[('T',)] = 'b'
@@ -64,7 +63,7 @@ class StenoDictionaryTestCase(unittest.TestCase):
         d2[('S',)] = 'c'
         d2[('W',)] = 'd'
         d2.path = 'd2'
-        dc.set_dicts([d2, d1])
+        dc = StenoDictionaryCollection([d2, d1])
         self.assertEqual(dc.lookup(('S',)), 'c')
         self.assertEqual(dc.lookup(('W',)), 'd')
         self.assertEqual(dc.lookup(('T',)), 'b')
@@ -104,7 +103,6 @@ class StenoDictionaryTestCase(unittest.TestCase):
             dc['invalid']
 
     def test_dictionary_collection_writeable(self):
-        dc = StenoDictionaryCollection()
         d1 = StenoDictionary()
         d1[('S',)] = 'a'
         d1[('T',)] = 'b'
@@ -112,7 +110,7 @@ class StenoDictionaryTestCase(unittest.TestCase):
         d2[('S',)] = 'c'
         d2[('W',)] = 'd'
         d2.readonly = True
-        dc.set_dicts([d2, d1])
+        dc = StenoDictionaryCollection([d2, d1])
         self.assertEqual(dc.first_writable(), d1)
         dc.set(('S',), 'A')
         self.assertEqual(d1[('S',)], 'A')

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -75,8 +75,7 @@ class TranslatorStateSizeTestCase(unittest.TestCase):
         self.s = type(self).FakeState()
         self.t._state = self.s
         self.d = StenoDictionary()
-        self.dc = StenoDictionaryCollection()
-        self.dc.set_dicts([self.d])
+        self.dc = StenoDictionaryCollection([self.d])
         self.t.set_dictionary(self.dc)
 
     def test_dictionary_update_grows_size1(self):
@@ -170,8 +169,7 @@ class TranslatorTestCase(unittest.TestCase):
 
         d = StenoDictionary()
         d[('S', 'P')] = 'hi'
-        dc = StenoDictionaryCollection()
-        dc.set_dicts([d])
+        dc = StenoDictionaryCollection([d])
         t = Translator()
         t.set_dictionary(dc)
         t.translate(stroke('T'))
@@ -230,11 +228,10 @@ class TranslatorTestCase(unittest.TestCase):
             def clear(self):
                 del self._output[:]
                 
-        d = StenoDictionary()        
-        out = Output()        
+        d = StenoDictionary()
+        out = Output()
         t = Translator()
-        dc = StenoDictionaryCollection()
-        dc.set_dicts([d])
+        dc = StenoDictionaryCollection([d])
         t.set_dictionary(dc)
         t.add_listener(out.write)
         
@@ -457,8 +454,7 @@ class TranslateStrokeTestCase(unittest.TestCase):
 
     def setUp(self):
         self.d = StenoDictionary()
-        self.dc = StenoDictionaryCollection()
-        self.dc.set_dicts([self.d])
+        self.dc = StenoDictionaryCollection([self.d])
         self.s = _State()
         self.o = self.CaptureOutput()
         self.tlor = Translator()

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,12 +4,17 @@ import tempfile
 
 
 @contextmanager
-def make_dict(contents):
-    tf = tempfile.NamedTemporaryFile(delete=False)
+def make_dict(contents, extension=None, name=None):
+    kwargs = { 'delete': False }
+    if name is not None:
+        kwargs['prefix'] = name + '_'
+    if extension is not None:
+        kwargs['suffix'] = '.' + extension
+    tf = tempfile.NamedTemporaryFile(**kwargs)
     try:
         tf.write(contents)
         tf.close()
-        yield tf.name
+        yield os.path.realpath(tf.name)
     finally:
         os.unlink(tf.name)
 


### PR DESCRIPTION
The `dictionaries_loaded` hook will be now potentially triggered 2 times during an update:
- after unloading outdated dictionaries
- after (re)loading new/updated dictionaries

This way the GUI can show a `reloading` icon for dictionaries being reloaded because they were externally modified.