### PR TITLE
Drop native support for Ubuntu Trusty

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Depends:
 	python3-dbus,
 	python3-hid,
 	python3-pkg-resources,
-	python3-pyqt5,
+	python3-pyqt5 (>= 5.5),
 	python3-serial (>= 2.7),
 	python3-xlib (>= 0.16),
 	wmctrl,

--- a/linux/README.md
+++ b/linux/README.md
@@ -2,7 +2,7 @@
 
 ## Automatic development environment setup
 
-On Arch Linux and Ubuntu, you should be able to have everything setup automatically by using: `./bootstrap.sh`.
+On Arch Linux or a recent Ubuntu, you should be able to have everything setup automatically by using: `./bootstrap.sh`.
 
 Note: you can use `./bootstrap.sh -n` to get a list of the commands that would be run.
 
@@ -12,7 +12,7 @@ You need Python 3 installed with pip support.
 
 Some of the other dependencies cannot be installed with pip:
 
-* PyQt5
+* PyQt5 (>= 5.5)
 * wmctrl: for additional window management support
 * system libraries used by python-hidapi (e.g. libusb)
 
@@ -34,7 +34,9 @@ For the development version, most dependencies can be installed with APT:
 
 `sudo apt-get install cython3 debhelper devscripts libudev-dev libusb-1.0-0-dev pyqt5-dev-tools python3-appdirs python3-babel python3-dbus python3-dev python3-hid python3-mock python3-pip python3-pkg-resources python3-pyqt5 python3-pytest python3-serial python3-setuptools python3-setuptools-pyqt python3-setuptools-scm python3-six python3-wheel python3-xlib wmctrl`
 
-Note: some of those packages are not available from the standard repositories. you can install them by using the aforementioned PPA: [ppa:benoit.pierre/plover](https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover), or you can install them manually by following the generic install procedure with pip.
+Note:
+- some of those packages are not available from the standard repositories. you can install them by using the aforementioned PPA: [ppa:benoit.pierre/plover](https://launchpad.net/~benoit.pierre/+archive/ubuntu/plover), or you can install them manually by following the generic install procedure with pip.
+- Ubuntu 16.04 LTS (Xenial Xerus) or more recent is recommended, in particular: Ubuntu 14.04 LTS (Trusty Tahr) is too old and unsupported.
 
 For the missing dependencies, follow the generic procedure.
 
@@ -47,10 +49,6 @@ You can create a pip compatible requirements file with:
 And then using pip, e.g. for a user install:
 
 `pip3 install --user -r requirements.txt -c requirements_constraints.txt`
-
-Notes:
-- if your version of pip is too old, you may get parsing errors on the lines with conditional directives (like `python-xlib>=0.17; "linux" in sys_platform`). You can fix those with the following sed command: `sed -i '/; "/{/; "linux" in sys_platform$/!d;s/; .*//}' requirements.txt`.
-- on Ubuntu 14.04 LTS (Trusty Tahr), the site imports are borked, and the user site-packages directory does not get priority over the standard distribution directories, so you may need to manually add it to your Python path: `export PYTHONPATH="$HOME/.local/lib/python3.4/site-packages/${PYTHONPATH:+:}${PYTHONPATH}"`.
 
 ## Running from source
 

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -51,12 +51,6 @@ case "$1" in
     EXT='noarch.rpm'
     TARGET="package"
     ;;
-  trusty)
-    OS='ubuntu'
-    DIST='trusty'
-    EXT='deb'
-    TARGET="package"
-    ;;
   xenial)
     OS='ubuntu'
     DIST='xenial'


### PR DESCRIPTION
The version of PyQt5 available on Ubuntu Trusty is too old.