### PR TITLE
Add Circle CI for Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,6 @@ matrix:
         - CACHE_NAME=linux_py3
       dist: trusty
       sudo: required
-    # OSX / Python 3
-    - os: osx
-      osx_image: xcode8
-      env:
-        - PYTHON=python3
-        - CACHE_NAME=osx_py3
 
 cache:
   directories:
@@ -35,15 +29,6 @@ before_install:
     ./bootstrap.sh "$PYTHON"
     # List installed packages versions.
     $PYTHON -m pip list --format=columns
-    if [ $TRAVIS_OS_NAME = osx ]
-    then
-      # The directory containing pyrcc5/pyuic55 is not in $PATH,
-      # so just use the right Python modules directly.
-      sed -i '' \
-        -e 's/"pyrcc5"/"'$PYTHON' -m PyQt5.pyrcc_main"/' \
-        -e 's/"pyuic5"/"'$PYTHON' -m PyQt5.uic.pyuic"/' \
-        pyuic.json
-    fi
     )
 
 install: true
@@ -64,12 +49,6 @@ script:
       exit 0
     fi
     case "$TRAVIS_OS_NAME" in
-    osx)
-      if [ $PYTHON = python3 ]
-      then
-        $PYTHON setup.py bdist_dmg
-      fi
-      ;;
     linux)
       if [ $PYTHON = python3 ]
       then
@@ -111,7 +90,6 @@ deploy:
   file_glob: true
   file:
     - "dist/*.AppImage"
-    - "dist/*.dmg"
     - "dist/*.egg"
     - "dist/*.tar.gz"
     - "dist/*.whl"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Bringing stenography to everyone.
 
-[![Windows build status](https://ci.appveyor.com/api/projects/status/9edrnjpukrag17h7?svg=true)](https://ci.appveyor.com/project/morinted/plover) [![Linux and Mac build Status](https://travis-ci.org/openstenoproject/plover.svg?branch=master)](https://travis-ci.org/openstenoproject/plover)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/9edrnjpukrag17h7?svg=true)](https://ci.appveyor.com/project/morinted/plover) [![Linux build status](https://travis-ci.org/openstenoproject/plover.svg?branch=master)](https://travis-ci.org/openstenoproject/plover) [![Mac build status](https://circleci.com/gh/openstenoproject/plover.svg?style=svg)](https://circleci.com/gh/openstenoproject/plover)
 
 | [Homepage] | [Releases] | [Wiki] | [Blog] | [Google Group] | [Discord Chat][discord] |
 |------------|------------|--------|--------|----------------|-------------------------|

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,52 @@
+# https://discuss.circleci.com/t/python-pip-dependencies-are-not-cached-reinstalled-every-time/6965
+machine:
+  pre:
+    - sudo -H pip install --upgrade virtualenv
+  environment:
+    PYTHON: python3
+
+dependencies:
+  override:
+    - ./bootstrap.sh "$PYTHON"
+  cache_directories:
+    - .cache
+
+compile:
+  pre:
+    - |
+      (
+      set -ex
+      # The directory containing pyrcc5/pyuic55 is not in $PATH,
+      # so just use the right Python modules directly.
+      sed -i '' \
+        -e 's/"pyrcc5"/"'$PYTHON' -m PyQt5.pyrcc_main"/' \
+        -e 's/"pyuic5"/"'$PYTHON' -m PyQt5.uic.pyuic"/' \
+        pyuic.json
+      )
+    - $PYTHON -m pip list --format=columns # List installed packages versions.
+    - git fetch --unshallow --quiet
+    - $PYTHON setup.py patch_version
+  override:
+    - $PYTHON setup.py bdist_dmg
+  post:
+    - mv dist/*.dmg $CIRCLE_ARTIFACTS
+
+test:
+  override:
+    - $PYTHON setup.py test
+
+deployment:
+  release:
+    tag: /.+/
+    owner: openstenoproject
+    commands:
+      - |
+        (
+        set -ex
+        github_release="$(python3 -m utils.download 'https://github.com/aktau/github-release/releases/download/v0.7.2/darwin-amd64-github-release.tar.bz2' '16d40bcb4de7e29055789453f0d5fdbf1bfd3b49')"
+        tar xvjf "$github_release"
+        ./bin/darwin/amd64/github-release release --user openstenoproject --repo plover --tag "$(git describe --tags)" --draft
+        ./bin/darwin/amd64/github-release upload --user openstenoproject --repo plover --tag "$(git describe --tags)" --file "$(find $CIRCLE_ARTIFACTS/*.dmg)" --name "$(basename $(find $CIRCLE_ARTIFACTS/*.dmg))"
+        )
+
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,5 @@
 # https://discuss.circleci.com/t/python-pip-dependencies-are-not-cached-reinstalled-every-time/6965
 machine:
-  pre:
-    - sudo -H pip install --upgrade virtualenv
   environment:
     PYTHON: python3
 
@@ -46,7 +44,7 @@ deployment:
         github_release="$(python3 -m utils.download 'https://github.com/aktau/github-release/releases/download/v0.7.2/darwin-amd64-github-release.tar.bz2' '16d40bcb4de7e29055789453f0d5fdbf1bfd3b49')"
         tar xvjf "$github_release"
         ./bin/darwin/amd64/github-release release --user openstenoproject --repo plover --tag "$(git describe --tags)" --draft
-        ./bin/darwin/amd64/github-release upload --user openstenoproject --repo plover --tag "$(git describe --tags)" --file "$(find $CIRCLE_ARTIFACTS/*.dmg)" --name "$(basename $(find $CIRCLE_ARTIFACTS/*.dmg))"
+        ./bin/darwin/amd64/github-release upload --user openstenoproject --repo plover --tag "$(git describe --tags)" --file $CIRCLE_ARTIFACTS/*.dmg --name "$(basename $CIRCLE_ARTIFACTS/*.dmg)"
         )
 
 


### PR DESCRIPTION
### About

Use circle CI for Mac builds.

### Reason

- Artifacts are available
- No Travis queue
