### PR TITLE
Rework plugins

### DIFF
--- a/plover/main.py
+++ b/plover/main.py
@@ -12,13 +12,15 @@ import sys
 import traceback
 import argparse
 
+# This need to be imported before pkg_resources.
+from plover.oslayer.config import CONFIG_DIR
+
 import pkg_resources
 
 if sys.platform.startswith('darwin'):
     import appnope
 
 import plover.oslayer.processlock
-from plover.oslayer.config import CONFIG_DIR
 from plover.config import CONFIG_FILE, Config
 from plover.registry import registry
 from plover import log
@@ -59,7 +61,6 @@ def main():
         log.set_level(args.log_level.upper())
     log.setup_platform_handler()
 
-    registry.load_plugins()
     registry.update()
 
     gui = registry.get_plugin('gui', args.gui).obj

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -3,29 +3,49 @@
 
 """Platform dependent configuration."""
 
+from distutils.dist import Distribution
 import os
-from os.path import realpath, join, dirname, abspath, isfile, pardir
 import sys
 
 import appdirs
-import pkg_resources
 
 
 # If plover is run from a pyinstaller binary.
 if hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
-    PROGRAM_DIR = dirname(sys.executable)
+    PROGRAM_DIR = os.path.dirname(sys.executable)
 # If plover is run from an app bundle on Mac.
-elif sys.platform.startswith('darwin') and '.app' in realpath(__file__):
-    PROGRAM_DIR = abspath(join(dirname(sys.executable), *[pardir] * 3))
+elif sys.platform.startswith('darwin') and '.app' in os.path.realpath(__file__):
+    PROGRAM_DIR = os.path.abspath(os.path.join(os.path.dirname(sys.executable), *[os.path.pardir] * 3))
 else:
     PROGRAM_DIR = os.getcwd()
-
-ASSETS_DIR = pkg_resources.resource_filename('plover', 'assets')
 
 # If the program's directory has a plover.cfg file then run in "portable mode",
 # i.e. store all data in the same directory. This allows keeping all Plover
 # files in a portable drive.
-if isfile(join(PROGRAM_DIR, 'plover.cfg')):
+if os.path.isfile(os.path.join(PROGRAM_DIR, 'plover.cfg')):
     CONFIG_DIR = PROGRAM_DIR
 else:
     CONFIG_DIR = appdirs.user_data_dir('plover', 'plover')
+
+# Setup plugins directory.
+if sys.platform.startswith('darwin'):
+    PLUGINS_PLATFORM = 'mac'
+elif sys.platform.startswith('linux'):
+    PLUGINS_PLATFORM = 'linux'
+elif sys.platform.startswith('win'):
+    PLUGINS_PLATFORM = 'win'
+else:
+    PLUGINS_PLATFORM = None
+if PLUGINS_PLATFORM is None:
+    PLUGINS_DIR = None
+else:
+    dist = Distribution().get_command_obj('install', create=True)
+    dist.prefix = os.path.join(CONFIG_DIR, 'plugins', PLUGINS_PLATFORM)
+    dist.finalize_options()
+    PLUGINS_DIR = dist.install_lib
+    sys.path.insert(0, PLUGINS_DIR)
+
+# This need to be imported after patching sys.path.
+import pkg_resources
+
+ASSETS_DIR = pkg_resources.resource_filename('plover', 'assets')

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -28,6 +28,9 @@ class Plugin(object):
         self.obj = obj
         self.__doc__ = obj.__doc__ or ''
 
+    def __str__(self):
+        return '%s:%s' % (self.plugin_type, self.name)
+
 
 class Registry(object):
 

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -1,4 +1,5 @@
 
+from collections import namedtuple
 import sys
 import os
 
@@ -32,6 +33,9 @@ class Plugin(object):
         return '%s:%s' % (self.plugin_type, self.name)
 
 
+PluginDistribution = namedtuple('PluginDistribution', 'dist plugins')
+
+
 class Registry(object):
 
     PLUGIN_TYPES = (
@@ -46,23 +50,32 @@ class Registry(object):
 
     def __init__(self):
         self._plugins = {}
+        self._distributions = {}
         for plugin_type in self.PLUGIN_TYPES:
             self._plugins[plugin_type] = {}
 
     def register_plugin(self, plugin_type, name, obj):
         plugin = Plugin(plugin_type, name, obj)
         self._plugins[plugin_type][name.lower()] = plugin
+        return plugin
 
     def register_plugin_from_entrypoint(self, plugin_type, entrypoint):
         log.info('%s: %s (from %s)', plugin_type,
-                 entrypoint.name, entrypoint.module_name)
+                 entrypoint.name, entrypoint.dist)
         try:
             obj = entrypoint.resolve()
         except:
             log.error('error loading %s plugin: %s (from %s)', plugin_type,
                       entrypoint.name, entrypoint.module_name, exc_info=True)
         else:
-            self.register_plugin(plugin_type, entrypoint.name, obj)
+            plugin = self.register_plugin(plugin_type, entrypoint.name, obj)
+            # Keep track of distributions providing plugins.
+            dist_id = str(entrypoint.dist)
+            dist = self._distributions.get(dist_id)
+            if dist is None:
+                dist = PluginDistribution(entrypoint.dist, set())
+                self._distributions[dist_id] = dist
+            dist.plugins.add(plugin)
 
     def get_plugin(self, plugin_type, plugin_name):
         return self._plugins[plugin_type][plugin_name.lower()]
@@ -79,6 +92,9 @@ class Registry(object):
         if errors:
             log.error("error(s) while loading plugins: %s", errors)
         list(map(working_set.add, distributions))
+
+    def list_distributions(self):
+        return [dist for dist_id, dist in sorted(self._distributions.items())]
 
     def update(self):
         for plugin_type in self.PLUGIN_TYPES:

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -1,24 +1,10 @@
 
 from collections import namedtuple
-import sys
-import os
 
 import pkg_resources
 
-from plover.oslayer.config import CONFIG_DIR
+from plover.oslayer.config import PLUGINS_PLATFORM
 from plover import log
-
-
-PLUGINS_DIR = os.path.join(CONFIG_DIR, 'plugins')
-
-if sys.platform.startswith('darwin'):
-    PLUGINS_PLATFORM = 'mac'
-elif sys.platform.startswith('linux'):
-    PLUGINS_PLATFORM = 'linux'
-elif sys.platform.startswith('win'):
-    PLUGINS_PLATFORM = 'win'
-else:
-    PLUGINS_PLATFORM = None
 
 
 class Plugin(object):
@@ -83,15 +69,6 @@ class Registry(object):
     def list_plugins(self, plugin_type):
         return sorted(self._plugins[plugin_type].values(),
                       key=lambda p: p.name)
-
-    def load_plugins(self, plugins_dir=PLUGINS_DIR):
-        log.info('loading plugins from %s', plugins_dir)
-        working_set = pkg_resources.working_set
-        environment = pkg_resources.Environment([plugins_dir])
-        distributions, errors = working_set.find_plugins(environment)
-        if errors:
-            log.error("error(s) while loading plugins: %s", errors)
-        list(map(working_set.add, distributions))
 
     def list_distributions(self):
         return [dist for dist_id, dist in sorted(self._distributions.items())]

--- a/setup.py
+++ b/setup.py
@@ -211,9 +211,7 @@ class Launch(Command):
 
     def run(self):
         with self.project_on_sys_path():
-            from plover.main import main
-            sys.argv = [' '.join(sys.argv[0:2]) + ' --'] + self.args
-            sys.exit(main())
+            os.execv(sys.executable, 'plover -m plover.main'.split() + self.args)
 
 
 class PatchVersion(Command):


### PR DESCRIPTION
Stop using pkg_resources' find_plugins, and switch to simply prepending a new entry to the Python path, as it will make managing plugins easier:

- now that plugins' entrypoints are resolved on startup, we don't need `find_plugins` to detect broken (due to missing dependencies) plugins
- broken plugins sill need their distributions to be added to the path; so they are visible by pip and can be uninstalled/updated

