### PR TITLE
osxkeyboardcontrol: don't suppress keyup events created by Plover

### DIFF
--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -215,7 +215,7 @@ class KeyboardCapture(threading.Thread):
                                       kCGEventFlagMaskNonCoalesced)
             has_nonsupressible_modifiers = \
                 CGEventGetFlags(event) & ~suppressible_modifiers
-            if has_nonsupressible_modifiers and event_type == kCGEventKeyDown:
+            if has_nonsupressible_modifiers:
                 return PASS_EVENT_THROUGH
 
             keycode = CGEventGetIntegerValueField(


### PR DESCRIPTION
### About

Seems at some point I accidentally suppressed key up events generated by Plover causing them never to be released.

### Issues

Fixes #779 

