### PR TITLE
linux/appimage: disable user site-packages

### DIFF
--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -100,6 +100,9 @@ appdir_python()
 "
 python='appdir_python'
 
+# Disable user site-packages.
+run sed -i 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/' "$appdir/usr/lib/python3.5/site.py"
+
 # Install Plover and dependencies.
 bootstrap_dist "$wheel"
 


### PR DESCRIPTION
There's one report of issues on Debian when it is enabled. Since it's always possible to explicitly add it to the Python path, it's better to disable it by default.