### PR TITLE
utils/install_wheels: fix handling of `--no-deps`

### DIFF
--- a/plover_build_utils/install_wheels.py
+++ b/plover_build_utils/install_wheels.py
@@ -41,6 +41,7 @@ _PIP_OPTS = _split_opts(
     '''
     -c 1 --constraint 1
     -r 1 --requirement 1
+    --no-deps 0
     '''
     # Package Index.
     '''
@@ -60,7 +61,6 @@ _PIP_INSTALL_OPTS = _split_opts(
     --upgrade-strategy 1
     --force-reinstall 0
     -I 0 --ignore-installed 0
-    --no-deps 0
     --user 0
     --root 1
     --prefix 1


### PR DESCRIPTION
The option must be passed to `pip wheel` too, otherwise some unnecessary packages may be cached (e.g. when creating the distribution: PyQt5 5.9, even though 5.8.2 is actually used).