### PR TITLE
add plugins manager to the standard plugins

### DIFF
--- a/ci/circle.sh
+++ b/ci/circle.sh
@@ -8,8 +8,8 @@ setup()
 {
   # Install Python.
   run mkdir -p "$downloads"
-  installer_url='https://www.python.org/ftp/python/3.5.3/python-3.5.3-macosx10.6.pkg'
-  installer_md5='6f9ee2ad1fceb1a7c66c9ec565e57102'
+  installer_url='https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg'
+  installer_md5='96bf5d47777e8352209f743c06bed555'
   installer_pkg="$downloads/python35.pkg"
   for retry in $(seq 3)
   do

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -40,7 +40,6 @@ setup()
       # Python:
       libbz2-dev
       libgdbm-dev
-      libglib2.0-dev
       liblzma-dev
       libncurses5-dev
       libreadline-dev
@@ -48,7 +47,17 @@ setup()
       libssl-dev
       zlib1g-dev
       # PyQt5:
+      libasound2
+      libegl1-mesa
+      libfontconfig1
       libgl1-mesa-glx
+      libnss3
+      libxcomposite1
+      libxcursor1
+      libxi6
+      libxrandr2
+      libxss1
+      libxtst6
     )
   fi
   run sudo apt-get install -qq "${builddeps[@]}"

--- a/linux/appimage/blacklist.txt
+++ b/linux/appimage/blacklist.txt
@@ -52,56 +52,20 @@
   pyrcc5
   pyuic5
 :usr/lib/python3.5/site-packages/PyQt5
-  **/*Bluetooth*
-  **/*CLucene*
   **/*Designer*
   **/*Help*
-  **/*Location*
-  **/*Multimedia*
-  **/*Network*
-  **/*Nfc*
-  **/*OpenGL*
-  **/*Position*
-  **/*Print*
-  **/*Qml*
-  **/*Quick*
-  **/*Sensors*
-  **/*Serial*
-  **/*Sql*
   **/*Test*
-  **/*Web*
-  **/*Xml*
-  **/*qtwebengine*
   Qt/plugins/PyQt5/libpyqt5qmlplugin.so
-  Qt/plugins/audio
-  Qt/plugins/bearer
   Qt/plugins/egldeviceintegrations
-  Qt/plugins/gamepads
-  Qt/plugins/generic
-  Qt/plugins/geoservices
-  Qt/plugins/mediaservice
   Qt/plugins/platforms/libqeglfs.so
   Qt/plugins/platforms/libqlinuxfb.so
   Qt/plugins/platforms/libqminimal.so
   Qt/plugins/platforms/libqminimalegl.so
-  Qt/plugins/platforms/libqoffscreen.so
   Qt/plugins/platforms/libqvnc.so
-  Qt/plugins/playlistformats
-  Qt/plugins/position
-  Qt/plugins/printsupport
   Qt/plugins/sceneparsers
-  Qt/plugins/sensor*
-  Qt/plugins/sqldrivers
   Qt/qml
-  Qt/resources
+  Qt/resources/qtwebengine_devtools_resources.pak
   Qt/translations/qt_help_*
-  Qt/translations/qtconnectivity_*
-  Qt/translations/qtdeclarative_*
-  Qt/translations/qtlocation_*
-  Qt/translations/qtmultimedia_*
-  Qt/translations/qtquick*
-  Qt/translations/qtserialport_*
-  Qt/translations/qtwebsockets_*
   pylupdate*
   pyrcc*
   uic

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -12,6 +12,7 @@ cachedir="$topdir/.cache/appimage"
 wheel=''
 python='python3'
 make_opts=(-s)
+configure_opts=(-q)
 opt_ccache=0
 opt_optimize=0
 
@@ -81,6 +82,7 @@ cmd=(
   --enable-shared
   --with-threads
   --without-ensurepip
+  ${configure_opts[@]}
 )
 if [ $opt_optimize -ne 0 ]
 then

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -52,8 +52,8 @@ run rm -rf "$builddir"
 run mkdir -p "$appdir" "$cachedir" "$distdir"
 
 # Download dependencies.
-run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImages/raw/6ca06be6d68606a18a90ebec5aebfd74e8a973c5/functions.sh' '3155bde5f40fd4aa08b3a76331936bd5b2e6b781' "$cachedir/functions.sh"
-run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImageKit/releases/download/8/appimagetool-x86_64.AppImage' 'e756ecac69f393c72333f8bd9cd3a5f87dc175bf' "$cachedir/appimagetool"
+run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImages/raw/f748bb63999e655cfbb70e88ec27e74e2b9bf8fd/functions.sh' 'a99457e22d24a61f42931b2aaafd41f2746af820' "$cachedir/functions.sh"
+run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImageKit/releases/download/9/appimagetool-x86_64.AppImage' 'ba71c5a03398b81eaa678207da1338c83189db89' "$cachedir/appimagetool"
 run "$python" -m plover_build_utils.download 'https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz' '127121fdca11e735b3686e300d66f73aba663e93'
 
 # Generate Plover wheel.

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -54,7 +54,7 @@ run mkdir -p "$appdir" "$cachedir" "$distdir"
 # Download dependencies.
 run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImages/raw/f748bb63999e655cfbb70e88ec27e74e2b9bf8fd/functions.sh' 'a99457e22d24a61f42931b2aaafd41f2746af820' "$cachedir/functions.sh"
 run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImageKit/releases/download/9/appimagetool-x86_64.AppImage' 'ba71c5a03398b81eaa678207da1338c83189db89' "$cachedir/appimagetool"
-run "$python" -m plover_build_utils.download 'https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz' '127121fdca11e735b3686e300d66f73aba663e93'
+run "$python" -m plover_build_utils.download 'https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz' '4aacbd09ca6988255de84a98ab9e4630f584efba'
 
 # Generate Plover wheel.
 if [ -z "$wheel" ]
@@ -69,10 +69,10 @@ then
  fi
 
 # Build Python.
-run tar xf "$downloads/Python-3.5.3.tar.xz" -C "$builddir"
+run tar xf "$downloads/Python-3.5.4.tar.xz" -C "$builddir"
 info '('
 (
-run cd "$builddir/Python-3.5.3"
+run cd "$builddir/Python-3.5.4"
 cmd=(
   ./configure
   --cache-file="$cachedir/python.config.cache"

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -155,7 +155,7 @@ remove_emptydirs()
 run remove_emptydirs
 
 # Check requirements.
-run "$python" -m plover_build_utils.check_requirements
+run "$python" -I -m plover_build_utils.check_requirements
 
 # Create the AppImage.
 # Note: extract appimagetool so fuse is not needed.

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -128,8 +128,12 @@ run cd "$appdir"
 # Add desktop integration.
 run get_desktopintegration 'plover'
 # Fix missing system dependencies.
+# Note: temporarily move PyQt5 out of the way so
+# we don't try to bundle its system dependencies.
+run mv "$appdir/usr/lib/python3.5/site-packages/PyQt5" "$builddir"
 run copy_deps; run copy_deps; run copy_deps
 run move_lib
+run mv "$builddir/PyQt5" "$appdir/usr/lib/python3.5/site-packages"
 # Move usr/include out of the way to preserve usr/include/python3.5m.
 run mv usr/include usr/include.tmp
 run delete_blacklisted

--- a/osx/app_resources/dist_blacklist.txt
+++ b/osx/app_resources/dist_blacklist.txt
@@ -21,21 +21,12 @@
   **/*CLucene*
   **/*DBus*
   **/*Designer*
-  **/*Help*
   **/*Location*
-  **/*Multimedia*
-  **/*Network*
   **/*Nfc*
-  **/*Position*
-  **/*Qml*
-  **/*Quick*
   **/*Sensors*
   **/*Serial*
   **/*Sql*
   **/*Test*
-  **/*Web*
-  **/*Xml*
-  **/*qtwebengine*
   Qt/plugins/audio
   Qt/plugins/bearer
   Qt/plugins/generic
@@ -66,3 +57,5 @@
   gui_qt/messages/**/*.po
   gui_qt/messages/plover.pot
   gui_qt/resources
+
+# vim: ft=config

--- a/osx/make_app.sh
+++ b/osx/make_app.sh
@@ -110,4 +110,4 @@ ditto -v --arch x86_64 "$app_dir" "$app_dist_dir"
 
 # Check requirements.
 python="$PWD/$app_dist_dir/Contents/Frameworks/$target_python"
-run "$python" -m plover_build_utils.check_requirements
+run "$python" -I -m plover_build_utils.check_requirements

--- a/plover_build_utils/functions.sh
+++ b/plover_build_utils/functions.sh
@@ -6,7 +6,6 @@ opt_timings=0
 python='false'
 wheels="$PWD/.cache/wheels"
 downloads="$PWD/.cache/downloads"
-py2venv="$PWD/.cache/py2venv"
 
 # Usage: parse_opts args "$@"
 #

--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -5,7 +5,7 @@ plyer==1.2.4; "win32" in sys_platform
 pyobjc-core==3.1.1+plover2; "darwin" in sys_platform
 pyobjc-framework-Cocoa==3.1.1+plover2; "darwin" in sys_platform
 pyobjc-framework-Quartz==3.1.1; "darwin" in sys_platform
-PyQt5==5.8.2
+PyQt5==5.9
 pyserial==3.3
 python-xlib==0.19; "linux" in sys_platform
 setuptools==35.0.2

--- a/requirements_plugins.txt
+++ b/requirements_plugins.txt
@@ -1,3 +1,9 @@
+# plover-plugins-manager
+docutils==0.13.1
+pip==9.0.1
+plover-plugins-manager==0.5.4
+Pygments==2.2.0
+wheel==0.29.0
 # plover-treal
 hidapi==0.7.99.post20
 plover-treal==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ class BinaryDistWin(Command):
             data_dir, '*/pip/_vendor/distlib/*',
         )
         # Check requirements.
-        run(dist_py, '-m', 'plover_build_utils.check_requirements')
+        run(dist_py, '-I', '-m', 'plover_build_utils.check_requirements')
         # Zip results.
         if self.zipdir:
             from plover_build_utils.zipdir import zipdir

--- a/setup.py
+++ b/setup.py
@@ -123,8 +123,8 @@ class BinaryDistWin(Command):
         # Setup embedded Python distribution.
         # Note: python35.zip is decompressed to prevent errors when 2to3
         # is used (including indirectly by setuptools `build_py` command).
-        py_embedded = download('https://www.python.org/ftp/python/3.5.2/python-3.5.2-embed-win32.zip',
-                               'a62675cd88736688bb87999e8b86d13ef2656312')
+        py_embedded = download('https://www.python.org/ftp/python/3.5.4/python-3.5.4-embed-win32.zip',
+                               '0760db3f93f02a2dacb38e80134b49e16266b84f')
         dist_dir = os.path.join(wheel_cmd.dist_dir, PACKAGE + '-win32')
         data_dir = os.path.join(dist_dir, 'data')
         stdlib = os.path.join(data_dir, 'python35.zip')

--- a/windows/dist_blacklist.txt
+++ b/windows/dist_blacklist.txt
@@ -2,52 +2,16 @@
   Scripts
 # PyQt5.
 :Lib/site-packages/PyQt5
-  **/*AxContainer*
-  **/*Bluetooth*
-  **/*CLucene*
-  **/*DBus*
   **/*Designer*
   **/*Help*
-  **/*Location*
-  **/*Multimedia*
-  **/*Network*
-  **/*Nfc*
-  **/*OpenGL*
-  **/*Position*
-  **/*Print*
-  **/*Qml*
-  **/*Quick*
-  **/*Sensors*
-  **/*Serial*
-  **/*Sql*
   **/*Test*
-  **/*Web*
-  **/*WinExtras*
-  **/*Xml*
-  **/*qtwebengine*
   Qt/bin/libeay32.dll
   Qt/bin/ssleay32.dll
-  Qt/plugins/audio
-  Qt/plugins/bearer
-  Qt/plugins/generic
-  Qt/plugins/geoservices
-  Qt/plugins/mediaservice
-  Qt/plugins/playlistformats
-  Qt/plugins/position
-  Qt/plugins/printsupport
+  Qt/plugins/platforms/qminimal.dll
   Qt/plugins/sceneparsers
-  Qt/plugins/sensor*
-  Qt/plugins/sqldrivers
   Qt/qml
-  Qt/resources
+  Qt/resources/qtwebengine_devtools_resources.pak
   Qt/translations/qt_help_*
-  Qt/translations/qtconnectivity_*
-  Qt/translations/qtdeclarative_*
-  Qt/translations/qtlocation_*
-  Qt/translations/qtmultimedia_*
-  Qt/translations/qtquick*
-  Qt/translations/qtserialport_*
-  Qt/translations/qtwebsockets_*
   pylupdate*
   pyrcc*
   uic
@@ -58,3 +22,5 @@
   gui_qt/messages/**/*.po
   gui_qt/messages/plover.pot
   gui_qt/resources
+
+# vim: ft=config


### PR DESCRIPTION
* update PyQt5 to latest LTS version (5.9)
* add `plover-plugins-manager` to standard plugins: this means bundling-in the Qt web engine
* updated distributions Python version to 3.5.4
* PyQt5 system dependencies are no longer bundled, as this can cause issues on a number of distributions

Tested:
* AppImage on Arch Linux, Ubuntu Trusty/Xenial, and Fedora 22/25/Rawhide: starting the plugins manager on Fedora 25/Rawhide crash (SSL error, the distribution's pip does not work either...)
* Windows setup on Windows 10
