### PR TITLE
rework formatting code

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -12,7 +12,216 @@ from collections import namedtuple
 import re
 import string
 
-from plover import orthography
+from plover.orthography import add_suffix
+
+
+CASE_CAP_FIRST_WORD = 'cap_first_word'
+CASE_LOWER = 'lower'
+CASE_LOWER_FIRST_CHAR = 'lower_first_char'
+CASE_TITLE = 'title'
+CASE_UPPER = 'upper'
+CASE_UPPER_FIRST_WORD = 'upper_first_word'
+
+SPACE = ' '
+META_ATTACH_FLAG = '^'
+META_CAPITALIZE = '-|'
+META_CARRY_CAPITALIZATION = '~|'
+META_COMMAND = 'PLOVER:'
+META_COMMAS = (',', ':', ';')
+META_GLUE_FLAG = '&'
+META_KEY_COMBINATION = '#'
+META_LOWER = '>'
+META_MODE = 'MODE:'
+META_RETRO_CAPITALIZE = '*-|'
+META_RETRO_FORMAT = '*('
+META_RETRO_LOWER = '*>'
+META_RETRO_UPPER = '*<'
+META_STOPS = ('.', '!', '?')
+META_UPPER = '<'
+MODE_CAMEL = 'CAMEL'
+MODE_CAPS = 'CAPS'
+MODE_LOWER = 'LOWER'
+MODE_RESET = 'RESET'
+MODE_RESET_CASE = 'RESET_CASE'
+MODE_RESET_SPACE = 'RESET_SPACE'
+MODE_SET_SPACE = 'SET_SPACE:'
+MODE_SNAKE = 'SNAKE'
+MODE_TITLE = 'TITLE'
+
+META_ESCAPE = '\\'
+RE_META_ESCAPE = '\\\\'
+META_START = '{'
+META_END = '}'
+META_ESC_START = META_ESCAPE + META_START
+META_ESC_END = META_ESCAPE + META_END
+
+META_RE = re.compile(r"""(?:%s%s|%s%s|[^%s%s])+ # One or more of anything
+                                                # other than unescaped { or }
+                                                #
+                                              | # or
+                                                #
+                     %s(?:%s%s|%s%s|[^%s%s])*%s # Anything of the form {X}
+                                                # where X doesn't contain
+                                                # unescaped { or }
+                      """ % (RE_META_ESCAPE, META_START, RE_META_ESCAPE,
+                             META_END, META_START, META_END,
+                             META_START,
+                             RE_META_ESCAPE, META_START, RE_META_ESCAPE,
+                             META_END, META_START, META_END,
+                             META_END),
+                     re.VERBOSE)
+
+# A more human-readable version of the above RE is:
+#
+# re.compile(r"""(?:\\{|\\}|[^{}])+ # One or more of anything other than
+#                                   # unescaped { or }
+#                                   #
+#                                 | # or
+#                                   #
+#              {(?:\\{|\\}|[^{}])*} # Anything of the form {X} where X
+#                                   # doesn't contain unescaped { or }
+#             """, re.VERBOSE)
+
+
+WORD_RX = re.compile(r'((\d+([.,]\d+)+|\w+[-\w]*|[^\w\s]+)\s*)', re.UNICODE)
+
+
+class RetroFormatter(object):
+    """Helper for iterating over the result of previous translations.
+
+    Support iterating over previous actions, text, fragments of text, or words:
+
+    text     : "Something something, blah! Blah: 45.8... (blah: foo42)   "
+    fragments: "__________-----------______------________-------_________"
+    words    : "__________---------__----__----__----____-____--_____----"
+
+    """
+
+    FRAGMENT_RX = re.compile(r'\s*[^\s]+\s*|^\s*$')
+
+    def __init__(self, previous_translations):
+        self.previous_translations = previous_translations
+
+    def iter_last_actions(self):
+        """Iterate over past actions (last first)."""
+        for translation in reversed(self.previous_translations):
+            for action in reversed(translation.formatting):
+                yield action
+
+    def iter_last_fragments(self):
+        """Iterate over last text fragments (last first).
+
+        A text fragment is a series of non-whitespace characters
+        followed by zero or more trailing whitespace characters.
+        """
+        replace = 0
+        next_action = None
+        current_fragment = ''
+        for action in self.iter_last_actions():
+            part = '' if action.text is None else action.text
+            if next_action is not None and \
+               next_action.text is not None and \
+               not next_action.prev_attach:
+                part += next_action.space_char
+            if replace:
+                # Ignore replaced content.
+                if len(part) > replace:
+                    part = part[:-replace]
+                    replace = 0
+                else:
+                    replace -= len(part)
+                    part = ''
+            if part:
+                # Find out new complete fragments.
+                fragments = self.FRAGMENT_RX.findall(part + current_fragment)
+                for f in reversed(fragments[1:]):
+                    yield f
+                current_fragment = fragments[0]
+            replace += len(action.prev_replace)
+            next_action = action
+        # Don't forget to process the current (first) fragment.
+        if not current_fragment.isspace():
+            yield current_fragment.lstrip()
+
+    def last_fragments(self, count=1):
+        """Return the last <count> text fragments."""
+        fragment_list = []
+        for fragment in self.iter_last_fragments():
+            fragment_list.insert(0, fragment)
+            if len(fragment_list) == count:
+                break
+        return fragment_list
+
+    def iter_last_words(self, strip=False, rx=WORD_RX):
+        """Iterate over last words (last first).
+
+        If <strip> is False, then trailing whitespace is included
+        as part of each word (useful for calculating position).
+
+        For <strip> to be properly supported when a custom regexp is
+        passed as <rx>, then it must include trailing whitespace as
+        part of each word.
+        """
+        for fragment in self.iter_last_fragments():
+            # Split each fragment into words.
+            for match in reversed(rx.findall(fragment)):
+                yield match[0].rstrip() if strip else match[0]
+
+    def last_words(self, count=1, strip=False, rx=WORD_RX):
+        """Return the last <count> words."""
+        word_list = []
+        for w in self.iter_last_words(strip=strip, rx=rx):
+            word_list.insert(0, w)
+            if len(word_list) == count:
+                break
+        return word_list
+
+    def last_text(self, size):
+        """Return the last <size> characters."""
+        text = ''
+        if not size:
+            return text
+        for fragment in self.iter_last_fragments():
+            text = fragment + text
+            if len(text) >= size:
+                break
+        return text[-size:]
+
+
+class _Context(RetroFormatter):
+    """Context for formatting translations to actions.
+
+    Keep tracks of previous actions as well as newly translated actions,
+    offer helpers for creating new actions and convenient access to past
+    actions/text/words.
+    """
+
+    def __init__(self, previous_translations, last_action):
+        super(_Context, self).__init__(previous_translations)
+        assert last_action is not None
+        self.last_action = last_action
+        self.translated_actions = []
+
+    def new_action(self):
+        """Create a new action, only copying global state."""
+        return self.last_action.new_state()
+
+    def copy_last_action(self):
+        """Create a new action, cloning the last action state."""
+        return self.last_action.copy_state()
+
+    def translated(self, action):
+        """Mark an action as translated."""
+        assert action is not None
+        self.translated_actions.append(action)
+        self.last_action = action
+
+    def iter_last_actions(self):
+        """Custom iterator with support for newly translated actions."""
+        for action in reversed(self.translated_actions):
+            yield action
+        for action in super(_Context, self).iter_last_actions():
+            yield action
 
 
 class Formatter(object):
@@ -40,12 +249,13 @@ class Formatter(object):
     output_type = namedtuple(
         'output', ['send_backspaces', 'send_string', 'send_key_combination',
                    'send_engine_command'])
-    start_capitalized = False
-    start_attached = False
 
     def __init__(self):
         self.set_output(None)
         self.spaces_after = False
+        self.last_output_spaces_after = False
+        self.start_capitalized = False
+        self.start_attached = False
         self._listeners = set()
 
     def add_listener(self, callback):
@@ -93,41 +303,129 @@ class Formatter(object):
         rendered translations. If there is no context then this may be None.
 
         """
+        assert undo or do
 
-        last_formatting = prev[-1].formatting if prev else None
-        for t in do:
-            last_action = self._get_last_action(last_formatting)
-            if t.english:
-                t.formatting = _translation_to_actions(t.english, last_action,
-                                                       self.spaces_after)
+        if do:
+            last_action = None
+            if prev:
+                previous_translations = prev
+                if prev[-1].formatting:
+                    last_action = prev[-1].formatting[-1]
             else:
-                t.formatting = _raw_to_actions(t.rtfcre[0], last_action,
-                                               self.spaces_after)
-            last_formatting = t.formatting
-
-        if prev:
-            num_previous = 1
-            if do:
-                # Worst case scenario: replacing fingerspelled content.
-                first_formatting = do[0].formatting
-                num_previous = max(num_previous, len(first_formatting[0].replace))
-            prev_formatting = [a for t in prev[-num_previous:] for a in t.formatting]
+                previous_translations = []
+            if last_action is None:
+                # Initial output.
+                next_attach = self.start_attached or self.spaces_after
+                next_case = CASE_CAP_FIRST_WORD if self.start_capitalized else None
+                last_action = _Action(next_attach=next_attach, next_case=next_case)
+            ctx = _Context(previous_translations, last_action)
+            for t in do:
+                if t.english:
+                    t.formatting = _translation_to_actions(t.english, ctx)
+                else:
+                    t.formatting = _raw_to_actions(t.rtfcre[0], ctx)
+            new = ctx.translated_actions
         else:
-            prev_formatting = []
+            new = []
 
         old = [a for t in undo for a in t.formatting]
-        new = [a for t in do for a in t.formatting]
+
+        # Figure out what really changed.
+
+        min_length = min(len(old), len(new))
+        for i in range(min_length):
+            if old[i] != new[i]:
+                break
+        else:
+            i = min_length
+
+        if i > 0:
+            optimized_away = old[:i]
+            old = old[i:]
+            new = new[i:]
+        else:
+            optimized_away = []
+
+        # Notify listeners.
 
         for callback in self._listeners:
             callback(old, new)
 
-        OutputHelper(self._output, prev_formatting).render(old, new)
+        # Render output.
 
-    def _get_last_action(self, actions):
-        """Return last action in actions if possible or return a default action."""
-        if actions:
-            return actions[-1]
-        return _Action(attach=self.start_attached, capitalize=self.start_capitalized)
+        if optimized_away:
+            last_action = optimized_away[-1]
+        elif prev and prev[-1].formatting:
+            last_action = prev[-1].formatting[-1]
+        else:
+            last_action = None
+
+        OutputHelper(self._output, self.last_output_spaces_after,
+                     self.spaces_after).render(last_action, old, new)
+        self.last_output_spaces_after = self.spaces_after
+
+
+class TextFormatter(object):
+    """Format a series of action into text."""
+
+    def __init__(self, spaces_after):
+        self.spaces_after = spaces_after
+        # Initial replaced text.
+        self.replaced_text = ''
+        # New appended text.
+        self.appended_text = ''
+        self.trailing_space = ''
+
+    def _render_action(self, action, last_action):
+        if self.spaces_after and self.trailing_space:
+            assert self.appended_text.endswith(self.trailing_space)
+            self.appended_text = self.appended_text[:-len(self.trailing_space)]
+        if action.prev_replace:
+            replaced = len(action.prev_replace)
+            appended = len(self.appended_text)
+            if replaced > appended:
+                assert action.prev_replace.endswith(self.appended_text)
+                replaced -= appended
+                if replaced > len(self.replaced_text):
+                    assert action.prev_replace.endswith(self.replaced_text)
+                    self.replaced_text = action.prev_replace[:replaced]
+                else:
+                    assert self.replaced_text.endswith(action.prev_replace)
+                    self.replaced_text = self.replaced_text[:-replaced]
+                    self.replaced_text += action.prev_replace[:replaced]
+                self.appended_text = ''
+            else:
+                assert self.appended_text.endswith(action.prev_replace)
+                self.appended_text = self.appended_text[:-replaced]
+        if not action.prev_attach:
+            self.appended_text += action.space_char
+        self.appended_text += action.text
+        if self.spaces_after and not action.next_attach:
+            self.appended_text += action.space_char
+            self.trailing_space = action.space_char
+        else:
+            self.trailing_space = ''
+
+    def render(self, action_list, last_action):
+        """Render a series of action.
+
+        Note: the function is a generator that yields non-text
+        actions (commands, combos, ...) for special processing.
+        """
+        if self.spaces_after and last_action is not None:
+            self.trailing_space = last_action.trailing_space
+            self.appended_text = last_action.trailing_space
+        for action in action_list:
+            if action.text is None:
+                yield action
+            else:
+                self._render_action(action, last_action)
+            last_action = action
+
+    def reset(self):
+        """Reset current state (rendered text)."""
+        self.replaced_text = ''
+        self.appended_text = self.trailing_space
 
 
 class OutputHelper(object):
@@ -137,16 +435,12 @@ class OutputHelper(object):
     optimizes away extra backspaces and typing.
 
     """
-    def __init__(self, output, initial_formatting=None):
-        if initial_formatting is None:
-            self.initial_formatting = []
-        else:
-            self.initial_formatting = initial_formatting
-        self.before = None
-        self.after = None
+    def __init__(self, output, before_spaces_after, after_spaces_after):
         self.output = output
+        self.before = TextFormatter(before_spaces_after)
+        self.after = TextFormatter(after_spaces_after)
 
-    def commit(self):
+    def flush(self):
         # FIXME:
         # - what about things like emoji zwj sequences?
         # - normalize strings to better handle combining characters?
@@ -157,57 +451,32 @@ class OutputHelper(object):
         # 2
         # >>> len(unicodedata.normalize('NFC', u"C\u0327"))
         # 1
-        offset = len(commonprefix([self.before, self.after]))
-        delete = self.before[offset:]
-        if delete:
-            self.output.send_backspaces(len(delete))
-        append = self.after[offset:]
-        if append:
-            self.output.send_string(append)
-        self.before = ''
-        self.after = ''
+        after = self.after.appended_text
+        before = self.after.replaced_text + self.before.appended_text
+        common_length = len(commonprefix([before, after]))
+        erased = len(before) - common_length
+        if erased:
+            self.output.send_backspaces(erased)
+        appended = after[common_length:]
+        if appended:
+            self.output.send_string(appended)
+        self.before.reset()
+        self.after.reset()
 
-    @staticmethod
-    def _actions_to_text(action_list, text=u''):
-        for a in action_list:
-            if a.replace and text.endswith(a.replace):
-                text = text[:-len(a.replace)]
-            if a.text:
-                text += a.text
-        return text
-
-    def render(self, undo, do):
-
-        initial_text = self._actions_to_text(self.initial_formatting)
-
-        min_length = min(len(undo), len(do))
-        for i in range(min_length):
-            if undo[i] != do[i]:
-                break
-        else:
-            i = min_length
-
-        if i > 0:
-            initial_text = self._actions_to_text(undo[:i], initial_text)
-            undo = undo[i:]
-            do = do[i:]
-
-        self.before = initial_text
-        self.after = initial_text[:]
-
-        self.before = self._actions_to_text(undo, self.before)
-
-        for a in do:
-            if a.replace and self.after.endswith(a.replace):
-                self.after = self.after[:-len(a.replace)]
-            self.after += a.text
-            if a.combo:
-                self.commit()
-                self.output.send_key_combination(a.combo)
-            if a.command:
-                self.commit()
-                self.output.send_engine_command(a.command)
-        self.commit()
+    def render(self, last_action, undo, do):
+        # Render undone actions, ignoring non-text actions.
+        for action in self.before.render(undo, last_action):
+            pass
+        # Render new actions.
+        if self.before.replaced_text:
+            self.after.appended_text = self.before.replaced_text
+        for action in self.after.render(do, last_action):
+            self.flush()
+            if action.combo:
+                self.output.send_key_combination(action.combo)
+            elif action.command:
+                self.output.send_engine_command(action.command)
+        self.flush()
 
 
 class _Action(object):
@@ -219,36 +488,36 @@ class _Action(object):
 
     """
 
-    CASE_NONE, CASE_UPPER, CASE_LOWER, CASE_TITLE = range(4)
-
-    def __init__(self, attach=False, glue=False, word='', capitalize=False,
-                 lower=False, orthography=True, space_char=' ',
-                 upper=False, upper_carry=False,
-                 case=CASE_NONE, text='', replace='', combo='',
-                 command=''):
+    def __init__(self,
+                 # Previous.
+                 prev_attach=False, prev_replace='',
+                 # Current.
+                 glue=False, word=None, orthography=True, space_char=' ',
+                 upper_carry=False, case=None, text=None, trailing_space='',
+                 combo=None, command=None,
+                 # Next.
+                 next_attach=False, next_case=None
+                ):
         """Initialize a new action.
 
         Arguments:
 
-        attach -- True if there should be no space between this and the next
-        action.
+        prev_attach -- True if there should be no space between this and the
+                       previous action.
+
+        prev_replace -- Text that should be deleted for this action.
 
         glue -- True if there be no space between this and the next action if
-        the next action also has glue set to True.
+                the next action also has glue set to True.
 
-        word -- The current word. This is context for future actions whose
-        behavior depends on the previous word such as suffixes.
-
-        capitalize -- True if the next action should be capitalized.
-
-        lower -- True if the next action should be lower cased.
-
-        upper -- True if the entire next action should be uppercase.
+        word -- The current root word (sans prefix, and un-cased). This is
+                context for future actions whose behavior depends on it such as
+                suffixes.
 
         upper_carry -- True if we are uppercasing the current word.
 
         othography -- True if orthography rules should be applies when adding
-        a suffix to this action.
+                      a suffix to this action.
 
         space_char -- this character will replace spaces after all other
         formatting has been applied
@@ -257,48 +526,61 @@ class _Action(object):
 
         text -- The text that should be rendered for this action.
 
-        replace -- Text that should be deleted for this action.
+        trailing_space -- This the space that would be added when rendering
+                          up to this action with space placement set to
+                          'after output'.
 
         combo -- The key combo, in plover's key combo language, that should be
-        executed for this action.
+                 executed for this action.
 
         command -- The command that should be executed for this action.
 
+        next_attach -- True if there should be no space between this and the next
+                       action.
+
+        next_case -- Case to apply to next action: capitalize/lower/upper...
+
         """
         # State variables
-        self.attach = attach
+        self.prev_attach = prev_attach
         self.glue = glue
         self.word = word
-        self.capitalize = capitalize
-        self.lower = lower
-        self.upper = upper
         self.upper_carry = upper_carry
         self.orthography = orthography
-
+        self.next_attach = next_attach
+        self.next_case = next_case
         # Persistent state variables
         self.space_char = space_char
         self.case = case
-
+        self.trailing_space = trailing_space
         # Instruction variables
+        self.prev_replace = prev_replace
         self.text = text
-        self.replace = replace
         self.combo = combo
         self.command = command
 
     def copy_state(self):
         """Clone this action but only clone the state variables."""
-        a = _Action()
-        a.attach = self.attach
-        a.glue = self.glue
-        a.word = self.word
-        a.capitalize = self.capitalize
-        a.lower = self.lower
-        a.upper = self.upper
-        a.upper_carry = self.upper_carry
-        a.orthography = self.orthography
-        a.case = self.case
-        a.space_char = self.space_char
-        return a
+        return _Action(
+            # Previous.
+            prev_attach=self.next_attach,
+            # Current.
+            case=self.case, glue=self.glue, orthography=self.orthography,
+            space_char=self.space_char, upper_carry=self.upper_carry,
+            word=self.word, trailing_space=self.trailing_space,
+            # Next.
+            next_attach=self.next_attach, next_case=self.next_case,
+        )
+
+    def new_state(self):
+        return _Action(
+            # Previous.
+            prev_attach=self.next_attach,
+            # Current.
+            space_char=self.space_char, case=self.case,
+            trailing_space=self.trailing_space,
+            # Next.
+        )
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -320,42 +602,7 @@ class _Action(object):
 _Action.DEFAULT = _Action()
 
 
-META_ESCAPE = '\\'
-RE_META_ESCAPE = '\\\\'
-META_START = '{'
-META_END = '}'
-META_ESC_START = META_ESCAPE + META_START
-META_ESC_END = META_ESCAPE + META_END
-
-META_RE = re.compile(r"""(?:%s%s|%s%s|[^%s%s])+ # One or more of anything
-                                                # other than unescaped { or }
-                                                #
-                                              | # or
-                                                #
-                     %s(?:%s%s|%s%s|[^%s%s])*%s # Anything of the form {X}
-                                                # where X doesn't contain
-                                                # unescaped { or }
-                      """ % (RE_META_ESCAPE, META_START, RE_META_ESCAPE,
-                             META_END, META_START, META_END,
-                             META_START,
-                             RE_META_ESCAPE, META_START, RE_META_ESCAPE,
-                             META_END, META_START, META_END,
-                             META_END),
-                     re.VERBOSE)
-
-# A more human-readable version of the above RE is:
-#
-# re.compile(r"""(?:\\{|\\}|[^{}])+ # One or more of anything other than
-#                                   # unescaped { or }
-#                                   #
-#                                 | # or
-#                                   #
-#              {(?:\\{|\\}|[^{}])*} # Anything of the form {X} where X
-#                                   # doesn't contain unescaped { or }
-#             """, re.VERBOSE)
-
-
-def _translation_to_actions(translation, last_action, spaces_after):
+def _translation_to_actions(translation, ctx):
     """Create actions for a translation.
 
     Arguments:
@@ -367,57 +614,29 @@ def _translation_to_actions(translation, last_action, spaces_after):
     Returns: A list of actions.
 
     """
-    actions = []
     # Reduce the translation to atoms. An atom is an irreducible string that is
     # either entirely a single meta command or entirely text containing no meta
     # commands.
     if translation.isdigit():
         # If a translation is only digits then glue it to neighboring digits.
-        atoms = [_apply_glue(translation)]
+        atoms = [_glue_translation(translation)]
     else:
-        atoms = [
-            x.strip(' ') for x in META_RE.findall(translation) if x.strip(' ')
-        ]
-
-    if not atoms:
-        return [last_action.copy_state()]
-
+        atoms = filter(None, (
+            x.strip(' ') for x in META_RE.findall(translation))
+        )
+    action_list = []
     for atom in atoms:
-        action = _atom_to_action(atom, last_action, spaces_after)
-        actions.append(action)
-        last_action = action
-    return actions
+        action = _atom_to_action(atom, ctx)
+        action_list.append(action)
+        ctx.translated(action)
+    if not action_list:
+        action = ctx.copy_last_action()
+        action_list = [action]
+        ctx.translated(action)
+    return action_list
 
 
-SPACE = ' '
-NO_SPACE = ''
-META_STOPS = ('.', '!', '?')
-META_COMMAS = (',', ':', ';')
-META_CAPITALIZE = '-|'
-META_CARRY_CAPITALIZATION = '~|'
-META_LOWER = '>'
-META_UPPER = '<'
-META_RETRO_CAPITALIZE = '*-|'
-META_RETRO_LOWER = '*>'
-META_RETRO_UPPER = '*<'
-META_RETRO_FORMAT = '*('
-META_GLUE_FLAG = '&'
-META_ATTACH_FLAG = '^'
-META_KEY_COMBINATION = '#'
-META_COMMAND = 'PLOVER:'
-META_MODE = 'MODE:'
-MODE_CAPS = 'CAPS'
-MODE_TITLE = 'TITLE'
-MODE_LOWER = 'LOWER'
-MODE_SNAKE = 'SNAKE'
-MODE_SET_SPACE = 'SET_SPACE:'
-MODE_RESET_SPACE = 'RESET_SPACE'
-MODE_RESET_CASE = 'RESET_CASE'
-MODE_CAMEL = 'CAMEL'
-MODE_RESET = 'RESET'
-
-
-def _raw_to_actions(stroke, last_action, spaces_after):
+def _raw_to_actions(stroke, ctx):
     """Turn a raw stroke into actions.
 
     Arguments:
@@ -434,464 +653,228 @@ def _raw_to_actions(stroke, last_action, spaces_after):
     # output the raw stroke as is.
     no_dash = stroke.replace('-', '', 1)
     if no_dash.isdigit():
-        return _translation_to_actions(no_dash, last_action, spaces_after)
-    else:
-        if spaces_after:
-            return [_Action(text=(stroke + SPACE), word=stroke, case=last_action.case,
-                            space_char=last_action.space_char)]
+        return _translation_to_actions(no_dash, ctx)
+    action = _Action(text=stroke, word=stroke,
+                     case=ctx.last_action.case,
+                     prev_attach=ctx.last_action.next_attach,
+                     space_char=ctx.last_action.space_char,
+                     trailing_space=ctx.last_action.space_char)
+    ctx.translated(action)
+    return [action]
+
+
+def _atom_to_action(atom, ctx):
+    """Convert an atom into an action.
+
+    Arguments:
+
+    atom -- A string holding an atom. An atom is an irreducible string that is
+    either entirely a single meta command or entirely text containing no meta
+    commands.
+
+    last_action -- The context in which the new action takes place.
+
+    Returns: An action for the atom.
+
+    """
+    meta = _get_meta(atom)
+    if meta is not None:
+        meta = _unescape_atom(meta)
+        if meta in META_COMMAS:
+            action = _apply_meta_comma(meta, ctx)
+        elif meta in META_STOPS:
+            action = _apply_meta_stop(meta, ctx)
+        elif meta == META_CAPITALIZE:
+            action = _apply_meta_case(CASE_CAP_FIRST_WORD, ctx)
+        elif meta == META_LOWER:
+            action = _apply_meta_case(CASE_LOWER_FIRST_CHAR, ctx)
+        elif meta == META_UPPER:
+            action = _apply_meta_case(CASE_UPPER_FIRST_WORD, ctx)
+        elif meta == META_RETRO_CAPITALIZE:
+            action = _apply_meta_retro_case(CASE_CAP_FIRST_WORD, ctx)
+        elif meta == META_RETRO_LOWER:
+            action = _apply_meta_retro_case(CASE_LOWER_FIRST_CHAR, ctx)
+        elif meta == META_RETRO_UPPER:
+            action = _apply_meta_retro_case(CASE_UPPER_FIRST_WORD, ctx)
+        elif (meta.startswith(META_CARRY_CAPITALIZATION) or
+              meta.startswith(META_ATTACH_FLAG + META_CARRY_CAPITALIZATION)):
+            action = _apply_meta_carry_capitalize(meta, ctx)
+        elif meta.startswith(META_RETRO_FORMAT):
+            action = _apply_meta_currency(meta, ctx)
+        elif meta.startswith(META_COMMAND):
+            action = _apply_meta_command(meta, ctx)
+        elif meta.startswith(META_MODE):
+            action = _apply_meta_mode(meta, ctx)
+        elif meta.startswith(META_GLUE_FLAG):
+            action = _apply_meta_glue(meta, ctx)
+        elif (meta.startswith(META_ATTACH_FLAG) or
+              meta.endswith(META_ATTACH_FLAG)):
+            action = _apply_meta_attach(meta, ctx)
+        elif meta.startswith(META_KEY_COMBINATION):
+            action = _apply_meta_combo(meta, ctx)
         else:
-            return [_Action(text=(SPACE + stroke), word=stroke, case=last_action.case,
-                            space_char=last_action.space_char)]
-
-
-def _atom_to_action(atom, last_action, spaces_after):
-    """Convert an atom into an action.
-
-    Arguments:
-
-    atom -- A string holding an atom. An atom is an irreducible string that is
-    either entirely a single meta command or entirely text containing no meta
-    commands.
-
-    last_action -- The context in which the new action takes place.
-
-    Returns: An action for the atom.
-
-    """
-
-    if spaces_after:
-        return _atom_to_action_spaces_after(atom, last_action)
+            action = ctx.new_action()
     else:
-        return _atom_to_action_spaces_before(atom, last_action)
-
-
-def _atom_to_action_spaces_before(atom, last_action):
-    """Convert an atom into an action.
-
-    Arguments:
-
-    atom -- A string holding an atom. An atom is an irreducible string that is
-    either entirely a single meta command or entirely text containing no meta
-    commands.
-
-    last_action -- The context in which the new action takes place.
-
-    Returns: An action for the atom.
-
-    """
-
-    action = _Action(space_char=last_action.space_char, case=last_action.case)
-    last_word = last_action.word
-    last_glue = last_action.glue
-    last_attach = last_action.attach
-    last_capitalize = last_action.capitalize
-    last_lower = last_action.lower
-    last_upper = last_action.upper
-    last_upper_carry = last_action.upper_carry
-    last_orthography = last_action.orthography
-    begin = False  # for meta attach
-    meta = _get_meta(atom)
-    if meta is not None:
-        meta = _unescape_atom(meta)
-        if meta in META_COMMAS:
-            action.text = meta
-        elif meta in META_STOPS:
-            action.text = meta
-            action.capitalize = True
-            action.lower = False
-            action.upper = False
-        elif meta == META_CAPITALIZE:
-            action = last_action.copy_state()
-            action.capitalize = True
-            action.lower = False
-            action.upper = False
-        elif meta == META_LOWER:
-            action = last_action.copy_state()
-            action.lower = True
-            action.upper = False
-            action.capitalize = False
-        elif meta == META_UPPER:
-            action = last_action.copy_state()
-            action.lower = False
-            action.upper = True
-            action.capitalize = False
-        elif meta == META_RETRO_CAPITALIZE:
-            action = last_action.copy_state()
-            action.word = _capitalize(action.word)
-            if len(last_action.text) < len(last_action.word):
-                action.replace = last_action.word
-                action.text = _capitalize(last_action.word)
-            else:
-                action.replace = last_action.text
-                action.text = _capitalize_nowhitespace(last_action.text)
-        elif meta == META_RETRO_LOWER:
-            action = last_action.copy_state()
-            action.word = _lower(action.word)
-            if len(last_action.text) < len(last_action.word):
-                action.replace = last_action.word
-                action.text = _lower(last_action.word)
-            else:
-                action.replace = last_action.text
-                action.text = _lower_nowhitespace(last_action.text)
-        elif meta == META_RETRO_UPPER:
-            action = last_action.copy_state()
-            action.word = _upper(action.word)
-            action.upper_carry = True
-            if len(last_action.text) < len(last_action.word):
-                action.replace = last_action.word
-                action.text = _upper(last_action.word)
-            else:
-                action.replace = last_action.text
-                action.text = _upper(last_action.text)
-        elif (meta.startswith(META_CARRY_CAPITALIZATION) or
-              meta.startswith(META_ATTACH_FLAG + META_CARRY_CAPITALIZATION)):
-            action = _apply_carry_capitalize(meta, last_action)
-        elif meta.startswith(META_RETRO_FORMAT):
-            if meta.startswith(META_RETRO_FORMAT) and meta.endswith(')'):
-                action = _apply_currency(meta, last_action)
-        elif meta.startswith(META_COMMAND):
-            action = last_action.copy_state()
-            action.command = meta[len(META_COMMAND):]
-        elif meta.startswith(META_MODE):
-            action = last_action.copy_state()
-            action = _change_mode(meta[len(META_MODE):], action)
-        elif meta.startswith(META_GLUE_FLAG):
-            action.glue = True
-            glue = last_glue or last_attach
-            space = NO_SPACE if glue else SPACE
-            text = meta[len(META_GLUE_FLAG):]
-            if last_capitalize:
-                text = _capitalize(text)
-            if last_lower:
-                text = _lower(text)
-            action.text = space + text
-            action.word = _rightmost_word(last_word + action.text)
-        elif (meta.startswith(META_ATTACH_FLAG) or
-              meta.endswith(META_ATTACH_FLAG)):
-            begin = meta.startswith(META_ATTACH_FLAG)
-            end = meta.endswith(META_ATTACH_FLAG)
-            if begin:
-                meta = meta[len(META_ATTACH_FLAG):]
-            if end and len(meta) >= len(META_ATTACH_FLAG):
-                meta = meta[:-len(META_ATTACH_FLAG)]
-            space = NO_SPACE if begin or last_attach else SPACE
-            if end:
-                action.attach = True
-            if begin and end and meta == '':
-                # We use an empty connection to indicate a "break" in the
-                # application of orthography rules. This allows the
-                # stenographer to tell plover not to auto-correct a word.
-                action.orthography = False
-            if (((begin and not end) or (begin and end and ' ' in meta)) and
-                    last_orthography):
-                new = orthography.add_suffix(last_word.lower(), meta)
-                common = commonprefix([last_word.lower(), new])
-                action.replace = last_word[len(common):]
-                meta = new[len(common):]
-            if last_capitalize:
-                meta = _capitalize(meta)
-            if last_lower:
-                meta = _lower(meta)
-            if last_upper_carry:
-                meta = _upper(meta)
-                action.upper_carry = True
-            action.text = space + meta
-            action.word = _rightmost_word(
-                last_word[:len(last_word)-len(action.replace)] + action.text)
-        elif meta.startswith(META_KEY_COMBINATION):
-            action = last_action.copy_state()
-            action.combo = meta[len(META_KEY_COMBINATION):]
-    else:
-        text = _unescape_atom(atom)
-        if last_capitalize:
-            text = _capitalize(text)
-        if last_lower:
-            text = _lower(text)
-        if last_upper:
-            text = _upper(text)
-            action.upper_carry = True
-        space = NO_SPACE if last_attach else SPACE
-        action.text = space + text
-        action.word = _rightmost_word(text)
-
-    action.text = _apply_mode(action.text, action.case, action.space_char,
-                              begin, last_attach, last_glue,
-                              last_capitalize, last_upper, last_lower)
-
+        action = ctx.new_action()
+        action.text = _unescape_atom(atom)
+    # Finalize action's text.
+    text = action.text
+    if text is not None:
+        # Update word.
+        if action.word is None:
+            last_word = None
+            if action.glue and ctx.last_action.glue:
+                last_word = ctx.last_action.word
+            action.word = _rightmost_word((last_word or '') + text)
+        # Apply case.
+        case = ctx.last_action.next_case
+        if case is None and action.prev_attach and ctx.last_action.upper_carry:
+            case = CASE_UPPER_FIRST_WORD
+        text = _apply_case(text, case)
+        if case == CASE_UPPER_FIRST_WORD:
+            action.upper_carry = not ' ' in text
+        # Apply mode.
+        action.text = _apply_mode(text, action.case, action.space_char,
+                                  action.prev_attach, ctx.last_action)
+        # Update trailing space.
+        action.trailing_space = '' if action.next_attach else action.space_char
     return action
 
 
-def _atom_to_action_spaces_after(atom, last_action):
-    """Convert an atom into an action.
-
-    Arguments:
-
-    atom -- A string holding an atom. An atom is an irreducible string that is
-    either entirely a single meta command or entirely text containing no meta
-    commands.
-
-    last_action -- The context in which the new action takes place.
-
-    Returns: An action for the atom.
-
-    """
-
-    action = _Action(space_char=last_action.space_char, case=last_action.case)
-    last_word = last_action.word
-    last_glue = last_action.glue
-    last_attach = last_action.attach
-    last_capitalize = last_action.capitalize
-    last_lower = last_action.lower
-    last_upper = last_action.upper
-    last_upper_carry = last_action.upper_carry
-    last_orthography = last_action.orthography
-    last_space = SPACE if last_action.text.endswith(SPACE) else NO_SPACE
-    was_space = len(last_space) is not 0
-    begin = False  # for meta attach
-    meta = _get_meta(atom)
-    if meta is not None:
-        meta = _unescape_atom(meta)
-        if meta in META_COMMAS:
-            action.text = meta + SPACE
-            if last_action.text != '':
-                if was_space:
-                    action.replace = SPACE
-                else:
-                    action.replace = NO_SPACE
-            if last_attach:
-                action.replace = NO_SPACE
-        elif meta in META_STOPS:
-            action.text = meta + SPACE
-            action.capitalize = True
-            action.lower = False
-            if last_action.text != '':
-                if was_space:
-                    action.replace = SPACE
-                else:
-                    action.replace = NO_SPACE
-            if last_attach:
-                action.replace = NO_SPACE
-        elif meta == META_CAPITALIZE:
-            action = last_action.copy_state()
-            if was_space:
-                # Persist space state
-                action.replace = SPACE
-                action.text = SPACE
-            action.capitalize = True
-            action.lower = False
-        elif meta == META_LOWER:
-            action = last_action.copy_state()
-            if was_space:
-                # Persist space state
-                action.replace = SPACE
-                action.text = SPACE
-            action.lower = True
-            action.capitalize = False
-        elif meta == META_UPPER:
-            action = last_action.copy_state()
-            action.lower = False
-            action.upper = True
-            action.capitalize = False
-        elif (meta.startswith(META_CARRY_CAPITALIZATION) or
-              meta.startswith(META_ATTACH_FLAG + META_CARRY_CAPITALIZATION)):
-            action = _apply_carry_capitalize(meta, last_action, spaces_after=True)
-        elif meta == META_RETRO_CAPITALIZE:
-            action = last_action.copy_state()
-            action.word = _capitalize(action.word)
-            if len(last_action.text) < len(last_action.word):
-                action.replace = last_action.word + SPACE
-                action.text = _capitalize(last_action.word + SPACE)
-            else:
-                action.replace = last_action.text
-                action.text = _capitalize_nowhitespace(last_action.text)
-        elif meta == META_RETRO_LOWER:
-            action = last_action.copy_state()
-            action.word = _lower(action.word)
-            if len(last_action.text) < len(last_action.word):
-                action.replace = last_action.word + SPACE
-                action.text = _lower(last_action.word + SPACE)
-            else:
-                action.replace = last_action.text
-                action.text = _lower_nowhitespace(last_action.text)
-        elif meta == META_RETRO_UPPER:
-            action = last_action.copy_state()
-            action.word = _upper(action.word)
-            action.upper_carry = True
-            if len(last_action.text) < len(last_action.word):
-                action.replace = last_action.word + SPACE
-                action.text = _upper(last_action.word + SPACE)
-            else:
-                action.replace = last_action.text
-                action.text = _upper(last_action.text)
-        elif meta.startswith(META_RETRO_FORMAT):
-            if meta.startswith(META_RETRO_FORMAT) and meta.endswith(')'):
-                action = _apply_currency(meta, last_action, spaces_after=True)
-        elif meta.startswith(META_COMMAND):
-            action = last_action.copy_state()
-            action.command = meta[len(META_COMMAND):]
-        elif meta.startswith(META_MODE):
-            action = last_action.copy_state()
-            action = _change_mode(meta[len(META_MODE):], action)
-        elif meta.startswith(META_GLUE_FLAG):
-            action.glue = True
-            text = meta[len(META_GLUE_FLAG):]
-            if last_capitalize:
-                text = _capitalize(text)
-            if last_lower:
-                text = _lower(text)
-            action.text = text + SPACE
-            action.word = _rightmost_word(text)
-            if last_glue:
-                if was_space:
-                    action.replace = SPACE
-                else:
-                    action.replace = NO_SPACE
-                action.word = _rightmost_word(last_word + text)
-            if last_attach:
-                action.replace = NO_SPACE
-                action.word = _rightmost_word(last_word + text)
-        elif (meta.startswith(META_ATTACH_FLAG) or
-              meta.endswith(META_ATTACH_FLAG)):
-            begin = meta.startswith(META_ATTACH_FLAG)
-            end = meta.endswith(META_ATTACH_FLAG)
-            if begin:
-                meta = meta[len(META_ATTACH_FLAG):]
-            if end and len(meta) >= len(META_ATTACH_FLAG):
-                meta = meta[:-len(META_ATTACH_FLAG)]
-
-            space = NO_SPACE if end else SPACE
-            replace_space = NO_SPACE if last_attach else SPACE
-
-            if end:
-                action.attach = True
-            if begin and end and meta == '':
-                # We use an empty connection to indicate a "break" in the
-                # application of orthography rules. This allows the
-                # stenographer to tell plover not to auto-correct a word.
-                action.orthography = False
-                if last_action.text != '':
-                    action.replace = replace_space
-            if (((begin and not end) or (begin and end and ' ' in meta)) and
-                    last_orthography):
-                new = orthography.add_suffix(last_word.lower(), meta)
-                common = commonprefix([last_word.lower(), new])
-                if last_action.text == '':
-                    replace_space = NO_SPACE
-                action.replace = last_word[len(common):] + replace_space
-                meta = new[len(common):]
-            if begin and end:
-                if last_action.text != '':
-                    action.replace = replace_space
-            if last_capitalize:
-                meta = _capitalize(meta)
-            if last_lower:
-                meta = _lower(meta)
-            if last_upper_carry:
-                meta = _upper(meta)
-                action.upper_carry = True
-            action.text = meta + space
-            action.word = _rightmost_word(
-                last_word[:len(last_word + last_space)-len(action.replace)]
-                + meta)
-            if end and not begin and last_space == SPACE:
-                action.word = _rightmost_word(meta)
-        elif meta.startswith(META_KEY_COMBINATION):
-            action = last_action.copy_state()
-            action.combo = meta[len(META_KEY_COMBINATION):]
-    else:
-        text = _unescape_atom(atom)
-        if last_capitalize:
-            text = _capitalize(text)
-        if last_lower:
-            text = _lower(text)
-        if last_upper:
-            text = _upper(text)
-            action.upper_carry = True
-
-        action.text = text + SPACE
-        action.word = _rightmost_word(text)
-
-    action.text = _apply_mode(action.text, action.case, action.space_char,
-                              begin, last_attach, last_glue,
-                              last_capitalize, last_upper, last_lower)
+def _apply_meta_attach(meta, ctx):
+    action = ctx.new_action()
+    begin = meta.startswith(META_ATTACH_FLAG)
+    end = meta.endswith(META_ATTACH_FLAG)
+    if begin:
+        meta = meta[len(META_ATTACH_FLAG):]
+        action.prev_attach = True
+    if end:
+        meta = meta[:-len(META_ATTACH_FLAG)]
+        action.next_attach = True
+    last_word = ctx.last_action.word or ''
+    if not meta:
+        # We use an empty connection to indicate a "break" in the
+        # application of orthography rules. This allows the
+        # stenographer to tell Plover not to auto-correct a word.
+        action.orthography = False
+    elif (
+        last_word and
+        not meta.isspace() and
+        ctx.last_action.orthography and
+        begin and (not end or ' ' in meta)
+    ):
+        new_word = add_suffix(last_word, meta)
+        common_len = len(commonprefix([last_word, new_word]))
+        action.prev_replace = last_word[common_len:]
+        last_word = last_word[:common_len]
+        meta = new_word[common_len:]
+    action.text = meta
+    if action.prev_attach:
+        action.word = _rightmost_word(last_word + meta)
     return action
 
 
-def _apply_mode(text, case, space_char, begin, last_attach,
-                last_glue, last_capitalize, last_upper, last_lower):
-    # Should title case be applied to the beginning of the next string?
-    lower_title_case = ((begin or
-                         last_attach or
-                         last_glue) and not
-                        (last_capitalize or
-                         last_upper))
-    # Apply case, then replace space character
-    text = _apply_case(text, case, lower_title_case)
-    text = _apply_space_char(text, space_char)
-
-    # Title case is sensitive to lower flag
-    if last_lower and len(text) > 0:  # Check for text
-        if case is _Action.CASE_TITLE:
-            text = _lower_nowhitespace(text)
-
-    return text
+def _apply_meta_comma(meta, ctx):
+    action = ctx.new_action()
+    action.text = meta
+    action.prev_attach = True
+    return action
 
 
-def _apply_currency(meta, last_action, spaces_after=False):
+def _apply_meta_stop(meta, ctx):
+    action = ctx.new_action()
+    action.prev_attach = True
+    action.text = meta
+    action.next_case = CASE_CAP_FIRST_WORD
+    return action
+
+
+def _apply_meta_case(meta, ctx):
+    action = ctx.copy_last_action()
+    action.next_case = meta
+    return action
+
+
+def _apply_meta_retro_case(meta, ctx):
+    action = ctx.copy_last_action()
+    action.prev_attach = True
+    last_words = ctx.last_words(count=1)
+    if last_words:
+        action.prev_replace = last_words[0]
+        action.text = _apply_case(last_words[0], meta)
+        if meta == CASE_UPPER_FIRST_WORD:
+            action.upper_carry = True
+    else:
+        action.text = ''
+    return action
+
+
+def _apply_meta_combo(meta, ctx):
+    action = ctx.copy_last_action()
+    action.combo = meta[len(META_KEY_COMBINATION):]
+    return action
+
+
+def _apply_meta_command(meta, ctx):
+    action = ctx.copy_last_action()
+    action.command = meta[len(META_COMMAND):]
+    return action
+
+
+def _apply_meta_glue(meta, ctx):
+    action = ctx.new_action()
+    action.glue = True
+    action.text = meta[len(META_GLUE_FLAG):]
+    if ctx.last_action.glue:
+        action.prev_attach = True
+    return action
+
+
+def _apply_meta_currency(meta, ctx):
+    action = ctx.copy_last_action()
+    if not meta.endswith(')'):
+        return action
     dict_format = meta[len(META_RETRO_FORMAT):-len(')')]
-    action = last_action.copy_state()
-    cast_input = None
-    try:
-        cast_input = float(last_action.word)
-    except ValueError:
-        pass
-    else:
-        currency_format = dict_format.replace('c', '{:,.2f}')
-    try:
-        cast_input = int(last_action.word)
-    except ValueError:
-        pass
-    else:
-        currency_format = dict_format.replace('c', '{:,}')
-    if cast_input is not None:
-        action.replace = last_action.word
-        action.word = currency_format.format(cast_input)
-        action.text = action.word
-        if spaces_after:
-            action.replace += SPACE
-            action.text += SPACE
+    last_words = ctx.last_words(count=1)
+    if not last_words:
+        return action
+    for cast, fmt in (
+        (float, '{:,.2f}'),
+        (int,   '{:,}'   ),
+    ):
+        try:
+            cast_input = cast(last_words[0])
+        except ValueError:
+            pass
+        else:
+            currency_format = dict_format.replace('c', fmt)
+            action.prev_attach = True
+            action.prev_replace = last_words[0]
+            action.text = currency_format.format(cast_input)
+            action.word = None
     return action
 
 
-def _apply_carry_capitalize(meta, last_action, spaces_after=False):
+def _apply_meta_carry_capitalize(meta, ctx):
     # Meta format: ^~|content^ (attach flags are optional)
-    attach_last = meta.startswith(META_ATTACH_FLAG)
-    attach_next = meta.endswith(META_ATTACH_FLAG)
-
-    content_start = meta.index(META_CARRY_CAPITALIZATION) + len(META_CARRY_CAPITALIZATION)
-    content_end = -len(META_ATTACH_FLAG) if attach_next else None
-    meta_content = meta[content_start:content_end]
-
-    action = last_action.copy_state()
-    action.attach = attach_next
-
-    # Spaces after: delete last space if we're attaching.
-    replace_last = last_action.text.endswith(SPACE) and attach_last
-    action.replace = SPACE if replace_last else NO_SPACE
-
-    if meta_content:
-        action.word = meta_content
-
-        # Only prefix a space if spaces are before, last action wasn't attach, and no attach_last flag.
-        prefix = NO_SPACE if attach_last or spaces_after or last_action.attach else SPACE
-        # Only suffix a space if spaces are after or there's an attach_next flag.
-        suffix = NO_SPACE if attach_next or not spaces_after else SPACE
-        action.text = prefix + meta_content + suffix
-
+    action = ctx.new_action()
+    if ctx.last_action.next_case == CASE_CAP_FIRST_WORD:
+        action.next_case = CASE_CAP_FIRST_WORD
+    begin = meta.startswith(META_ATTACH_FLAG)
+    if begin:
+        meta = meta[len(META_ATTACH_FLAG):]
+        action.prev_attach = True
+    meta = meta[len(META_CARRY_CAPITALIZATION):]
+    end = meta.endswith(META_ATTACH_FLAG)
+    if end:
+        meta = meta[:-len(META_ATTACH_FLAG)]
+        action.next_attach = True
+    if meta or begin or end:
+        action.text = meta
     return action
 
-def _change_mode(command, action):
 
+def _apply_meta_mode(meta, ctx):
     """
     command should be:
         CAPS, LOWER, TITLE, CAMEL, SNAKE, RESET_SPACE,
@@ -907,57 +890,80 @@ def _change_mode(command, action):
         SET_SPACE:xy: Set space to xy
         RESET: Reset to normal case, space resets to ' '
     """
-
+    action = ctx.copy_last_action()
+    command = meta[len(META_MODE):]
     if command == MODE_CAPS:
-        action.case = _Action.CASE_UPPER
-
+        action.case = CASE_UPPER
     elif command == MODE_TITLE:
-        action.case = _Action.CASE_TITLE
-
+        action.case = CASE_TITLE
     elif command == MODE_LOWER:
-        action.case = _Action.CASE_LOWER
-
+        action.case = CASE_LOWER
     elif command == MODE_SNAKE:
         action.space_char = '_'
     elif command == MODE_CAMEL:
-        action.case = _Action.CASE_TITLE
+        action.case = CASE_TITLE
         action.space_char = ''
-        action.lower = True
-
+        action.next_case = CASE_LOWER_FIRST_CHAR
     elif command == MODE_RESET:
         action.space_char = SPACE
-        action.case = _Action.CASE_NONE
-
+        action.case = None
     elif command == MODE_RESET_SPACE:
         action.space_char = SPACE
-
     elif command == MODE_RESET_CASE:
-        action.case = _Action.CASE_NONE
-
+        action.case = None
     elif command.startswith(MODE_SET_SPACE):
         action.space_char = command[len(MODE_SET_SPACE):]
-
     return action
 
 
-def _apply_case(input_text, case, appended):
-    text = input_text
-    if case is _Action.CASE_LOWER:
-        text = text.lower()
-    elif case is _Action.CASE_UPPER:
-        text = text.upper()
-    elif case is _Action.CASE_TITLE:
-        # Do nothing to appended output
-        if not appended:
-            text = string.capwords(text, " ")
+def _apply_case(text, case):
+    if case is None:
+        return text
+    if case == CASE_CAP_FIRST_WORD:
+        return _capitalize_first_word(text)
+    if case == CASE_LOWER_FIRST_CHAR:
+        return _lower_first_character(text)
+    if case == CASE_UPPER_FIRST_WORD:
+        return _upper_first_word(text)
+    raise ValueError('invalid case mode: %s' % case)
+
+
+def _apply_mode(text, case, space_char, begin, last_action):
+    # Should title case be applied to the beginning of the next string?
+    lower_title_case = (begin and not
+                        last_action.case in (
+                            CASE_CAP_FIRST_WORD,
+                            CASE_UPPER_FIRST_WORD,
+                        ))
+    # Apply case, then replace space character
+    text = _apply_mode_case(text, case, lower_title_case)
+    text = _apply_mode_space_char(text, space_char)
+    # Title case is sensitive to lower flag
+    if (last_action.next_case == CASE_LOWER_FIRST_CHAR
+        and text and case == CASE_TITLE):
+        text = _lower_first_character(text)
     return text
 
 
-def _apply_space_char(text, space_char):
-    if space_char != ' ':
-        return text.replace(' ', space_char)
-    else:
+def _apply_mode_case(text, case, appended):
+    if case is None:
         return text
+    if case == CASE_LOWER:
+        return text.lower()
+    if case == CASE_UPPER:
+        return text.upper()
+    if case == CASE_TITLE:
+        # Do nothing to appended output
+        if appended:
+            return text
+        return _capitalize_all_words(text)
+    raise ValueError('invalid case mode: %s' % case)
+
+
+def _apply_mode_space_char(text, space_char):
+    if space_char == SPACE:
+        return text
+    return text.replace(SPACE, space_char)
 
 
 def _get_meta(atom):
@@ -969,55 +975,55 @@ def _get_meta(atom):
     return None
 
 
-def _apply_glue(s):
+def _glue_translation(s):
     """Mark the given string as a glue stroke."""
     return META_START + META_GLUE_FLAG + s + META_END
 
 
 def _unescape_atom(atom):
     """Replace escaped meta markups with unescaped meta markups."""
-    return atom.replace(META_ESC_START, META_START).replace(META_ESC_END,
-                                                            META_END)
+    atom = atom.replace(META_ESC_START, META_START)
+    atom = atom.replace(META_ESC_END, META_END)
+    return atom
 
 
-def _get_engine_command(atom):
-    """Return the steno engine command, if any, represented by the atom."""
-    if (atom and
-        atom.startswith(META_START + META_COMMAND) and
-        atom.endswith(META_END)):
-        return atom[len(META_START) + len(META_COMMAND):-len(META_END)]
-    return None
+def _capitalize_first_word(s):
+    """Capitalize the first letter of s.
 
-
-def _capitalize(s):
-    """Capitalize the first letter of s."""
+    - 'foo bar' -> 'Foo bar'
+    - 'STUFF' -> 'STUFF'
+    """
     return s[0:1].upper() + s[1:]
 
 
-def _lower(s):
+def _capitalize_all_words(s):
+    """Capitalize each word of s.
+
+    - 'foo bar' -> 'Foo Bar'
+    - "O'Something STUFF" -> "O'something Stuff"
+    """
+    return string.capwords(s, SPACE)
+
+
+def _lower_first_character(s):
     """Lowercase the first letter of s."""
     return s[0:1].lower() + s[1:]
 
 
-def _capitalize_nowhitespace(s):
-    """Capitalize the first letter of s (ignoring spaces)."""
-    s_no_space = s.lstrip(' ')
-    spaces = ' ' * (len(s) - len(s_no_space))
-    return spaces + s_no_space[:1].upper() + s_no_space[1:]
-
-
-def _lower_nowhitespace(s):
-    """Lowercase the first letter of s (ignoring spaces)."""
-    s_no_space = s.lstrip(' ')
-    spaces = ' ' * (len(s) - len(s_no_space))
-    return spaces + s_no_space[:1].lower() + s_no_space[1:]
-
-
-def _upper(s):
+def _upper_all_words(s):
     """Uppercase the entire s."""
     return s.upper()
 
 
+def _upper_first_word(s):
+    """Uppercase first word of s."""
+    m = WORD_RX.match(s)
+    if m is None:
+        return s
+    first_word = m.group()
+    return first_word.upper() + s[len(first_word):]
+
+
 def _rightmost_word(s):
     """Get the rightmost word in s."""
-    return s.rpartition(' ')[2]
+    return s.rpartition(SPACE)[2]

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import (
 )
 
 from plover.suggestions import Suggestion
+from plover.formatting import RetroFormatter
 
 from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
 from plover.gui_qt.i18n import get_gettext
@@ -45,7 +46,6 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
     def __init__(self, engine):
         super(SuggestionsDialog, self).__init__(engine)
         self.setupUi(self)
-        self._words = u''
         self._last_suggestions = None
         # Toolbar.
         self.layout().addWidget(ToolBar(
@@ -116,24 +116,13 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             yield ls[i:]
 
     def on_translation(self, old, new):
-        for action in old:
-            remove = len(action.text)
-            if remove > 0:
-                self._words = self._words[:-remove]
-            self._words = self._words + action.replace
-
-        for action in new:
-            remove = len(action.replace)
-            if remove > 0:
-                self._words = self._words[:-remove]
-            self._words = self._words + action.text
-
-        # Limit phrasing memory to 100 characters, because most phrases probably
-        # don't exceed this length
-        self._words = self._words[-100:]
+        with self._engine:
+            last_translations = self._engine.translator_state.translations
+            retro_formatter = RetroFormatter(last_translations)
+            recent_text = ''.join(retro_formatter.last_fragments(10))
 
         suggestion_list = []
-        split_words = self.WORDS_RX.findall(self._words)
+        split_words = self.WORDS_RX.findall(recent_text)
         for phrase in self.tails(split_words):
             phrase = u' '.join(phrase)
             suggestion_list.extend(self._engine.get_suggestions(phrase))

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -20,7 +20,7 @@ def _load_wordlist(filename):
     with open(path, encoding='utf-8') as f:
         pairs = [word.strip().rsplit(' ', 1) for word in f]
         pairs.sort(reverse=True, key=lambda x: int(x[1]))
-        words = {p[0].lower(): int(p[1]) for p in pairs}
+        words = {p[0]: int(p[1]) for p in pairs}
     return words
 
 def _key_order(keys, numbers):

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -124,7 +124,7 @@ class Translation(object):
         if not self.formatting:
             return True
         for a in self.formatting:
-            if a.text or a.replace:
+            if a.text or a.prev_replace:
                 return True
         return False
 

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -294,7 +294,6 @@ class TestBlackboxReplays(object):
         P*/P*/P*/P*/P*/P*  'PPPPPP '
         '''
 
-    @pytest.mark.xfail
     def test_bug741(self):
         r'''
         # Uppercase last word also uppercases next word's prefix.
@@ -306,7 +305,6 @@ class TestBlackboxReplays(object):
         TPAO/KPA*TS/KAUPB/TPAO  " FOO confoo"
         '''
 
-    @pytest.mark.xfail
     def test_carry_capitalization_spacing1(self):
         r'''
         'S-P': '{^ ^}',
@@ -315,7 +313,6 @@ class TestBlackboxReplays(object):
         S-P/R-R  ' \n'
         '''
 
-    @pytest.mark.xfail
     def test_carry_capitalization_spacing2(self):
         r'''
         'S-P': '{^ ^}',
@@ -323,4 +320,875 @@ class TestBlackboxReplays(object):
 
         :spaces_after
         S-P/R-R  ' \n'
+        '''
+
+    def test_orthography1(self):
+        r'''
+        'TEFT': 'test',
+        '-G': '{^ing}',
+
+        TEFT/-G  ' testing'
+        '''
+
+    def test_orthography2(self):
+        r'''
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        SKEL/-G  " canceling"
+        '''
+
+    def test_orthography3(self):
+        r'''
+        'PREPB': '{(^}',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PREPB/SKEL/-G  " (canceling"
+        '''
+
+    def test_orthography4(self):
+        r'''
+        'SKEL': '{&c}{&a}{&n}{&c}{&e}{&l}',
+        '-G': '{^ing}',
+
+        SKEL/-G  " canceling"
+        '''
+
+    def test_orthography5(self):
+        r'''
+        'TPAOEUPL': 'time',
+        '-G': '{^ing}',
+
+        TPAOEUPL/-G  ' timing'
+        '''
+
+    def test_orthography6(self):
+        r'''
+        'PRE': '{prefix-^}',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PRE/SKEL/-G  " prefix-canceling"
+        '''
+
+    def test_orthography7(self):
+        r'''
+        'PRE': '{prefix^}',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PRE/SKEL/-G  " prefixcanceling"
+        '''
+
+    def test_orthography8(self):
+        r'''
+        'PRE': '{&p}{&r}{&e}{&f}{&i}{&x}',
+        "TK-LS": "{^}",
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PRE/TK-LS/SKEL/-G  " prefixcanceling"
+        '''
+
+    def test_orthography9(self):
+        r'''
+        'PRE': '{prefix^}',
+        'SKEL': '{&c}{&a}{&n}{&c}{&e}{&l}',
+        '-G': '{^ing}',
+
+        PRE/SKEL/-G  " prefixcanceling"
+        '''
+
+    def test_orthography10(self):
+        r'''
+        'PHO*D': "{MODE:CAMEL}",
+        'PRE': '{prefix^}',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PHO*D/PRE/SKEL/-G  "prefixcanceling"
+        '''
+
+    def test_orthography11(self):
+        r'''
+        'PHO*D': "{MODE:SNAKE}",
+        'TEFT': 'test',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PHO*D/TEFT  "_test"
+        SKEL/-G     "_test_canceling"
+        '''
+
+    def test_orthography12(self):
+        r'''
+        'PHO*D': "{MODE:CAMEL}",
+        'TEFT': 'test',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PHO*D/TEFT  "test"
+        SKEL/-G     "testCanceling"
+        '''
+
+    def test_orthography13(self):
+        r'''
+        'PHO*D': "{MODE:SNAKE}",
+        'PRE': '{prefix^}',
+        'TEFT': 'test',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PHO*D/TEFT  "_test"
+        PRE/SKEL/-G     "_test_prefixcanceling"
+        '''
+
+    def test_orthography14(self):
+        r'''
+        'PHO*D': "{MODE:CAMEL}",
+        'PRE': '{prefix^}',
+        'TEFT': 'test',
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PHO*D/TEFT  "test"
+        PRE/SKEL/-G     "testPrefixcanceling"
+        '''
+
+    def test_orthography15(self):
+        r'''
+        'PHO*D': "{MODE:CAPS}",
+        'SKEL': 'cancel',
+        '-G': '{^ing}',
+
+        PHO*D/SKEL/-G  " CANCELING"
+        '''
+
+    def test_orthography16(self):
+        r'''
+        'SKEL': '{&C}{&A}{&N}{&C}{&E}{&L}',
+        '-G': '{^ing}',
+
+        SKEL/-G  " CANCELLing"
+        '''
+
+    def test_orthography17(self):
+        r'''
+        'SKEL': 'CANCEL',
+        '-G': '{^ing}',
+
+        SKEL/-G  " CANCELLing"
+        '''
+
+    def test_orthography18(self):
+        r'''
+        'TPAOEUPL': 'TIME',
+        '-G': '{^ing}',
+
+        TPAOEUPL/-G  ' TIMing'
+        '''
+
+    def test_orthography19(self):
+        r'''
+        'TPAOEUPL': '{&T}{&I}{&M}{&E}',
+        '-G': '{^ing}',
+
+        TPAOEUPL/-G  ' TIMing'
+        '''
+
+    def test_after_initial_being(self):
+        r'''
+        '-B': 'be',
+        '-B/-G': 'being',
+
+        :spaces_after
+        -B/-G  'being '
+        '''
+
+    def test_after_period(self):
+        r'''
+        'TEFT': 'test',
+        'P-P': '{.}',
+
+        :spaces_after
+        TEFT/P-P/TEFT  'test. Test '
+        '''
+
+    def test_spaces_after1(self):
+        r'''
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+        '-G': '{^ing}',
+        'P-P': '{.}',
+
+        :spaces_after
+        TEFT   'test '
+        -G     'testing '
+        P-P    'testing. '
+        TEFTD  'testing. Tested '
+        '''
+
+    def test_start_attached1(self):
+        r'''
+        'TEFT': 'test',
+
+        :start_attached
+        TEFT  'test'
+        '''
+
+    def test_start_attached2(self):
+        r'''
+        'TEFT': 'test',
+
+        :start_attached
+        :spaces_after
+        TEFT  'test '
+        '''
+
+    def test_space_placement_change1(self):
+        r'''
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+        'TEFTS': 'tests',
+
+        :spaces_before
+        TEFT/TEFTD      ' test tested'
+        :spaces_after
+        TEFTS/TEFT      ' test tested tests test '
+        '''
+
+    def test_space_placement_change2(self):
+        r'''
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+        'TEFTS': 'tests',
+
+        :spaces_after
+        TEFT/TEFTD      'test tested '
+        :spaces_before
+        TEFTS/TEFT      'test tested tests test'
+        '''
+
+    def test_undo_after_space_placement_change1(self):
+        r'''
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+
+        :spaces_before
+        TEFT/TEFTD      ' test tested'
+        :spaces_after
+        *               ' test '
+        *               ''
+        '''
+
+    def test_undo_after_space_placement_change2(self):
+        r'''
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+
+        :spaces_after
+        TEFT/TEFTD      'test tested '
+        :spaces_before
+        *               'test'
+        *               ''
+        '''
+
+    def test_undo_after_space_placement_change3(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+
+        :spaces_before
+        KPA/TEFT/TEFTD  ' Test tested'
+        :spaces_after
+        *               ' Test '
+        *               ''
+        '''
+
+    def test_undo_after_space_placement_change4(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': 'test',
+        'TEFTD': 'tested',
+
+        :spaces_after
+        KPA/TEFT/TEFTD  ' Test tested '
+        :spaces_before
+        *               ' Test'
+        *               ''
+        '''
+
+    def test_undo_with_space_placement_changes(self):
+        r'''
+        'TEFT': 'test',
+
+        TEFT/TEFT/TEFT  ' test test test'
+        :spaces_after
+        *               ' test test '
+        :spaces_before
+        *               ' test'
+        :spaces_after
+        *               ''
+        '''
+
+    def test_carry_capitalization1(self):
+        r'''
+        'KA*US': "{~|'^}cause",
+        'TEFT': 'test',
+        'P-P': '{.}',
+
+        P-P/KA*US/TEFT  ". 'Cause test"
+        '''
+
+    def test_carry_capitalization2(self):
+        r'''
+        "KR-GS": "{^~|\"}",
+
+        KR-GS  '"'
+        '''
+
+    def test_carry_capitalization3(self):
+        r'''
+        'TP*U': '{<}',
+        "TK-LS": "{^}",
+        'TEFT': 'test',
+        'S-FBGS': '{^suffix}',
+
+        TP*U/TEFT/S-FBGS/TK-LS/S-FBGS  ' TESTSUFFIXSUFFIX'
+        '''
+
+    def test_carry_capitalization4(self):
+        r'''
+        'TP*U': '{<}',
+        "TK-LS": "{^}",
+        'TEFT': 'test',
+        "S-P": "{^ ^}"
+
+        TP*U/TEFT/S-P/TEFT  ' TEST test'
+        '''
+
+    def test_carry_capitalization5(self):
+        r'''
+        'TP*U': '{<}',
+        "TK-LS": "{^}",
+        'TEFT': 'test',
+        'S-FBGS': '{^suffix}',
+        "S-P": "{^ ^}"
+
+        TP*U/TEFT/S-FBGS/S-P/S-FBGS  ' TESTSUFFIX suffix'
+        '''
+
+    def test_capitalize1(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': 'test',
+
+        KPA/TEFT  ' Test'
+        '''
+
+    def test_capitalize2(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': 'test',
+
+        :start_attached
+        KPA/TEFT  ' Test'
+        '''
+
+    def test_capitalize3(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': 'test',
+
+        :spaces_after
+        KPA/TEFT  ' Test '
+        '''
+
+    def test_capitalize4(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': 'test',
+
+        :start_attached
+        :spaces_after
+        KPA/TEFT  ' Test '
+        '''
+
+    def test_retro_capitalize1(self):
+        r'''
+        'KWEUP': 'equip',
+        'RUP': '{*-|}',
+
+        KWEUP/RUP  ' Equip'
+        '''
+
+    def test_retro_capitalize2(self):
+        r'''
+        'KWEUP': 'equip',
+        'RUP': '{*-|}',
+
+        :spaces_after
+        KWEUP/RUP  'Equip '
+        '''
+
+    def test_retro_capitalize3(self):
+        r'''
+        'TEFT': 'tèśtîñg',
+        'RUP': '{*-|}',
+
+        TEFT/RUP  ' Tèśtîñg'
+        '''
+
+    def test_retro_capitalize4(self):
+        r'''
+        'PRE': '{pre^}',
+        'TPEUBG': 'fix',
+        'RUP': '{*-|}',
+
+        PRE/TPEUBG/RUP  ' Prefix'
+        '''
+
+    def test_retro_currency1(self):
+        r'''
+        'TPHAPB': 'notanumber',
+        'R-BG': '{*($c)}',
+
+        TPHAPB/R-BG  ' notanumber'
+        '''
+
+    def test_retro_currency2(self):
+        r'''
+        'TPHAPB': 'notanumber',
+        'R-BG': '{*($c)}',
+
+        :spaces_after
+        TPHAPB/R-BG  'notanumber '
+        '''
+
+    def test_retro_currency3(self):
+        r'''
+        'R-BG': '{*($c)}',
+
+        0/R-BG  ' $0'
+        '''
+
+    def test_retro_currency4(self):
+        r'''
+        'R-BG': '{*($c)}',
+
+        :spaces_after
+        0/R-BG  '$0 '
+        '''
+
+    def test_retro_upper1(self):
+        r'''
+        'TEFT': 'test',
+        '-G': '{^ing}',
+        'PRE': '{pre^}',
+        'R*U': '{*<}',
+
+        TEFT/-G/R*U/PRE  " TESTING pre"
+        '''
+
+    def test_retro_upper2(self):
+        r'''
+        'TEFT': 'test',
+        '-G': '{^ing}',
+        'PRE': '{pre^}',
+        'R*U': '{*<}',
+
+        TEFT/R*U/-G/PRE  " TESTING pre"
+        '''
+
+    def test_retro_upper3(self):
+        r'''
+        'PRE': '{prefix^}',
+        'WORD': 'word',
+        'R*U': '{*<}',
+
+        PRE/WORD/R*U  " PREFIXWORD"
+        '''
+
+    def test_retro_upper4(self):
+        r'''
+        'S-G': 'something',
+        'R*U': '{*<}',
+
+        S-G/S-G/R*U/R*U  " something SOMETHING"
+        '''
+
+    def test_retro_upper5(self):
+        r'''
+        'TEFT': 'tèśtîñg',
+        'RUP': '{*<}',
+
+        TEFT/RUP  ' TÈŚTÎÑG'
+        '''
+
+    def test_retro_upper6(self):
+        r'''
+        'ST': 'it is',
+        'RUP': '{*<}',
+
+        ST/RUP  " it IS"
+        '''
+
+    def test_retro_upper7(self):
+        r'''
+        'TEFT': 'test',
+        "W-G": "{^ing with}",
+        'RUP': '{*<}',
+
+        TEFT/RUP/W-G  " TESTING with"
+        '''
+
+    def test_retro_upper8(self):
+        r'''
+        'TEFT': 'test',
+        "W-G": "{^ing with}",
+        'RUP': '{*<}',
+
+        TEFT/W-G/RUP  " testing WITH"
+        '''
+
+    def test_retro_upper9(self):
+        r'''
+        'TEFT': 'test',
+        "W-G": "{^ing with}",
+        'RUP': '{*<}',
+
+        TEFT/RUP/W-G/W-G  " TESTING withing with"
+        '''
+
+    def test_retro_upper10(self):
+        r'''
+        'TEFT': 'test',
+        "W": "with",
+        'RUP': '{*<}',
+
+        TEFT/RUP/W/W  " TEST with with"
+        '''
+
+    def test_upper1(self):
+        r'''
+        'TP*U': '{<}',
+        'TEFT': 'test',
+        '-G': '{^ing}',
+        'PRE': '{pre^}',
+
+        TP*U/TEFT/-G/PRE  " TESTING pre"
+        '''
+
+    def test_upper2(self):
+        r'''
+        'TP*U': '{<}',
+        'TEFT': 'test',
+        '-G': '{^ing}',
+
+        TP*U/TEFT/-G/TEFT  " TESTING test"
+        '''
+
+    def test_upper3(self):
+        r'''
+        'TP*U': '{<}',
+        'ST': 'it is',
+
+        TP*U/ST  " IT is"
+        '''
+
+    def test_upper4(self):
+        r'''
+        'TP*U': '{<}',
+        'ST': 'it{ }is',
+
+        TP*U/ST  " IT is"
+        '''
+
+    def test_upper5(self):
+        r'''
+        'TP*U': '{<}',
+        'TEFT': 'test',
+        "W-G": "{^ing with}",
+
+        TP*U/TEFT/W-G  " TESTING with"
+        '''
+
+    def test_upper6(self):
+        r'''
+        'TP*U': '{<}',
+        'P-': '{foo^}',
+        '-S': '{^bar}',
+
+        TP*U/P-/-S  " FOOBAR"
+        '''
+
+    def test_upper7(self):
+        r'''
+        'TP*U': '{<}',
+        'PRE': '{pre^}',
+        'TEFT': 'test',
+        '-G': '{^ing}',
+
+        TP*U/PRE/TEFT/-G  " PRETESTING"
+        '''
+
+    def test_upper8(self):
+        r'''
+        'TP*U': '{<}',
+        'TEFT': 'test',
+        "W-G": "{^ing with}",
+
+        TP*U/TEFT/W-G/W-G  " TESTING withing with"
+        '''
+
+    def test_upper9(self):
+        r'''
+        'TP*U': '{<}',
+        'TEFT': 'test',
+        "W": "with",
+
+        TP*U/TEFT/W/W  " TEST with with"
+        '''
+
+    def test_attach_glue_and_carry_capitalize(self):
+        r'''
+        'PH*': '{&m}',
+        'KW-GS': '{~|"}',
+
+        PH*/KW-GS  ' m "'
+        '''
+
+    def test_fingerspelling_retro_meta1(self):
+        r'''
+        'K': '{&c}',
+        'A': '{&a}',
+        'T': '{&t}',
+        'UP': '{*<}',
+
+        K/A/T  ' cat'
+        UP     ' CAT'
+        *      ' cat'
+        '''
+
+    def test_fingerspelling_retro_meta2(self):
+        r'''
+        'TPH': '{>}{&n}',
+        'O': '{>}{&o}',
+        'UP': '{*<}',
+
+        TPH/O/UP  ' NO'
+        '''
+
+    def test_fingerspelling_retro_meta3(self):
+        r'''
+        'TEFT': '{>}{&n}{>}{&o}{*<}',
+
+        TEFT  ' NO'
+        '''
+
+    def test_word_1(self):
+        r'''
+        "KA*PS": "{MODE:CAPS}",
+        "TEFT": "test",
+        "-G": "{^ing}",
+        'RUP': '{*-|}',
+
+        KA*PS/TEFT/-G  ' TESTING'
+        RUP            ' TESTING'
+        '''
+
+    def test_word_2(self):
+        r'''
+        "KA*PS": "{MODE:CAPS}",
+        "R*FT": "{MODE:RESET}",
+        "TEFT": "test",
+        "-G": "{^ing}",
+        'RUL': '{*>}',
+
+        KA*PS/TEFT/-G  ' TESTING'
+        R*FT/RUL       ' tESTING'
+        '''
+
+    def test_cat_burger_1(self):
+        r'''
+        "KAT": "cat",
+        "O*PB":  "{^on}",
+        "PWURG": "{*-|}{^burg}",
+        "*ER": "{^er}",
+        "PWURG/*ER": "burger",
+
+        KAT/O*PB/PWURG  ' Cattonburg'
+        *ER             ' catton burger'
+        '''
+
+    def test_cat_burger_2(self):
+        r'''
+        "KAT": "cat",
+        "O*PB":  "{^on}",
+        "PWURG": "{*-|}{^burg}",
+        "*ER": "{^er}",
+
+        KAT/O*PB/PWURG  ' Cattonburg'
+        *ER             ' Cattonburger'
+        '''
+
+    def test_mirrored_capitalize(self):
+        r'''
+        'KPA': '{}{-|}',
+        'TEFT': '{~|na^}{~|no^}{~|wri^}mo'
+
+        KPA/TEFT  ' NaNoWriMo'
+        '''
+
+    def test_mode_1a(self):
+        r'''
+        "PHO*D": "{MODE:CAMEL}",
+        "TEFT": "test",
+
+        :spaces_after
+        TEFT   'test '
+        PHO*D  'test '
+        TEFT   'testtest'
+        TEFT   'testtestTest'
+        '''
+
+    def test_mode_1b(self):
+        r'''
+        "PHO*D": "{MODE:CAMEL}",
+        "TEFT": "test",
+
+        :spaces_before
+        TEFT   ' test'
+        PHO*D  ' test'
+        TEFT   ' testtest'
+        TEFT   ' testtestTest'
+        '''
+
+    def test_mode_2a(self):
+        r'''
+        "PHO*D": "{MODE:CAMEL}",
+        "TEFT": "test",
+        "TKPWHRAOU": "{&g}{&l}{&u}{&e}"
+
+        :spaces_after
+        PHO*D  ''
+        TEFT       'test'
+        TKPWHRAOU  'testGlue'
+        '''
+
+    def test_mode_2b(self):
+        r'''
+        "PHO*D": "{MODE:CAMEL}",
+        "TEFT": "test",
+        "TKPWHRAOU": "{&g}{&l}{&u}{&e}"
+
+        :spaces_before
+        PHO*D  ''
+        TEFT       'test'
+        TKPWHRAOU  'testGlue'
+        '''
+
+    def test_mode_3a(self):
+        r'''
+        "PHO*D": "{MODE:CAMEL}",
+        "TEFT": "test",
+        "TKPWHRAOU": "{&g}{&l}{&u}{&e}"
+
+        :spaces_after
+        PHO*D  ''
+        TKPWHRAOU  'glue'
+        TEFT       'glueTest'
+        '''
+
+    def test_mode_3b(self):
+        r'''
+        "PHO*D": "{MODE:CAMEL}",
+        "TEFT": "test",
+        "TKPWHRAOU": "{&g}{&l}{&u}{&e}"
+
+        :spaces_before
+        PHO*D  ''
+        TKPWHRAOU  'glue'
+        TEFT       'glueTest'
+        '''
+
+    def test_fingerspelling_1a(self):
+        r'''
+        'K': '{&c}',
+        'A': '{&a}',
+        'T': '{&t}',
+
+        :spaces_after
+        K/A/T  'cat '
+        '''
+    def test_fingerspelling_1b(self):
+        r'''
+        'K': '{&c}',
+        'A': '{&a}',
+        'T': '{&t}',
+
+        K/A/T  ' cat'
+        '''
+
+    def test_fingerspelling_2a(self):
+        r'''
+        'K': '{-|}{&c}',
+        'A': '{-|}{&a}',
+        'T': '{-|}{&t}',
+
+        :spaces_after
+        K/A/T  'CAT '
+        '''
+
+    def test_fingerspelling_2b(self):
+        r'''
+        'K': '{-|}{&c}',
+        'A': '{-|}{&a}',
+        'T': '{-|}{&t}',
+
+        K/A/T  ' CAT'
+        '''
+
+    def test_numbers_1a(self):
+        r'''
+        '': ''
+
+        :spaces_after
+        1-9  '19 '
+        -79  '1979 '
+        *    '19 '
+        *    ''
+        '''
+
+    def test_numbers_1b(self):
+        r'''
+        '': ''
+
+        1-9  ' 19'
+        -79  ' 1979'
+        *    ' 19'
+        *    ''
+        '''
+
+    def test_raw_1a(self):
+        r'''
+        '': ''
+
+        :spaces_after
+        RAU   'RAU '
+        TEGT  'RAU TEGT '
+        *     'RAU '
+        *     ''
+        '''
+
+    def test_raw_1b(self):
+        r'''
+        '': ''
+
+        RAU   ' RAU'
+        TEGT  ' RAU TEGT'
+        *     ' RAU'
+        *     ''
         '''


### PR DESCRIPTION
Greatly factorize the code, by changing the way spaces are handled: stitch actions at the output stage, so there's no need for 2 different code paths (space after and spaces before) when converting atoms to actions.

Also rework last word handling:
- for suffixes: store the raw un-cased word (sans prefix, as before)
- for other use-cases (retrospective commands): rely on an helper to generate the last n words from previous translations.

Fix #554 and #741. 
