### PR TITLE
gui_qt: rework handling of custom widgets

### DIFF
--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 from PyQt5.QtCore import QEvent
 
 from plover.gui_qt.add_translation_dialog_ui import Ui_AddTranslationDialog
-from plover.gui_qt.add_translation_widget import AddTranslationWidget
 from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.tool import Tool
 
@@ -24,16 +23,10 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
     def __init__(self, engine, dictionary_path=None):
         super(AddTranslationDialog, self).__init__(engine)
         self.setupUi(self)
-
-        add_translation = AddTranslationWidget(engine, dictionary_path)
-        self.layout().replaceWidget(self.add_translation, add_translation)
-        add_translation.strokes.setFocus()
-        self.add_translation = add_translation
-
+        self.add_translation.select_dictionary(dictionary_path)
         engine.signal_connect('config_changed', self.on_config_changed)
         self.on_config_changed(engine.config)
         self.installEventFilter(self)
-
         self.restore_state()
         self.finished.connect(self.save_state)
 

--- a/plover/gui_qt/add_translation_dialog.ui
+++ b/plover/gui_qt/add_translation_dialog.ui
@@ -24,7 +24,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWidget" name="add_translation" native="true"/>
+    <widget class="AddTranslationWidget" name="add_translation" native="true"/>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -38,6 +38,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AddTranslationWidget</class>
+   <extends>QWidget</extends>
+   <header>plover.gui_qt.add_translation_widget</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -2,7 +2,7 @@
 from collections import namedtuple
 
 from PyQt5.QtCore import QEvent
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QApplication, QWidget
 
 from plover.misc import shorten_path
 from plover.steno import normalize_steno
@@ -21,13 +21,14 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
     EngineState = namedtuple('EngineState', 'dictionary_filter translator starting_stroke')
 
-    def __init__(self, engine, dictionary_path=None):
-        super(AddTranslationWidget, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(AddTranslationWidget, self).__init__(*args, **kwargs)
         self.setupUi(self)
+        engine = QApplication.instance().engine
         self._engine = engine
         self._dictionaries = []
         self._reverse_order = False
-        self._selected_dictionary = dictionary_path
+        self._selected_dictionary = None
         engine.signal_connect('config_changed', self.on_config_changed)
         self.on_config_changed(engine.config)
         engine.signal_connect('dictionaries_loaded', self.on_dictionaries_loaded)
@@ -71,6 +72,10 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
                                                         StartingStrokeState(True, False))
         self._engine_state = self._original_state
         self._focus = None
+
+    def select_dictionary(self, dictionary_path):
+        self._selected_dictionary = dictionary_path
+        self._update_items()
 
     def eventFilter(self, watched, event):
         if event.type() == QEvent.FocusIn:

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -10,6 +10,7 @@ from PyQt5.QtCore import (
 )
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
+    QApplication,
     QFileDialog,
     QTableWidgetItem,
     QWidget,
@@ -32,9 +33,10 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
 
     add_translation = pyqtSignal(QVariant)
 
-    def __init__(self, engine):
-        super(DictionariesWidget, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(DictionariesWidget, self).__init__(*args, **kwargs)
         self.setupUi(self)
+        engine = QApplication.instance().engine
         self._engine = engine
         self._states = []
         self._updating = False

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -4,7 +4,6 @@ from PyQt5.QtCore import QEvent, Qt
 from plover.translation import unescape_translation
 
 from plover.gui_qt.lookup_dialog_ui import Ui_LookupDialog
-from plover.gui_qt.suggestions_widget import SuggestionsWidget
 from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.tool import Tool
 
@@ -24,9 +23,6 @@ class LookupDialog(Tool, Ui_LookupDialog):
     def __init__(self, engine):
         super(LookupDialog, self).__init__(engine)
         self.setupUi(self)
-        suggestions = SuggestionsWidget()
-        self.layout().replaceWidget(self.suggestions, suggestions)
-        self.suggestions = suggestions
         self.pattern.installEventFilter(self)
         self.suggestions.installEventFilter(self)
         self.pattern.setFocus()

--- a/plover/gui_qt/lookup_dialog.ui
+++ b/plover/gui_qt/lookup_dialog.ui
@@ -44,7 +44,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="suggestions" native="true">
+    <widget class="SuggestionsWidget" name="suggestions" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
@@ -55,6 +55,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SuggestionsWidget</class>
+   <extends>QWidget</extends>
+   <header>plover.gui_qt.suggestions_widget</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -48,7 +48,7 @@ class Application(object):
 
         QApplication.setQuitOnLastWindowClosed(False)
 
-        self._engine = Engine(config, KeyboardEmulation())
+        self._app.engine = self._engine = Engine(config, KeyboardEmulation())
 
         signal.signal(signal.SIGINT, lambda signum, stack: self._engine.quit())
 

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -17,7 +17,6 @@ from plover.resource import resource_filename
 from plover.gui_qt.log_qt import NotificationHandler
 from plover.gui_qt.main_window_ui import Ui_MainWindow
 from plover.gui_qt.config_window import ConfigWindow
-from plover.gui_qt.dictionaries_widget import DictionariesWidget
 from plover.gui_qt.about_dialog import AboutDialog
 from plover.gui_qt.trayicon import TrayIcon
 from plover.gui_qt.utils import WindowState, find_menu_actions
@@ -40,9 +39,8 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         }
         all_actions = find_menu_actions(self.menubar)
         # Dictionaries.
-        self.dictionaries = DictionariesWidget(engine)
+        self.dictionaries = self.scroll_area.widget()
         self.dictionaries.add_translation.connect(self._add_translation)
-        self.scroll_area.setWidget(self.dictionaries)
         self.dictionaries.setFocus()
         edit_menu = all_actions['menu_Edit'].menu()
         edit_menu.addAction(self.dictionaries.action_Undo)

--- a/plover/gui_qt/main_window.ui
+++ b/plover/gui_qt/main_window.ui
@@ -100,7 +100,7 @@
       <property name="widgetResizable">
        <bool>true</bool>
       </property>
-      <widget class="QWidget" name="dictionaries">
+      <widget class="DictionariesWidget" name="dictionaries">
        <property name="geometry">
         <rect>
          <x>0</x>
@@ -282,6 +282,21 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DictionariesWidget</class>
+   <extends>QWidget</extends>
+   <header>plover.gui_qt.dictionaries_widget</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>scroll_area</tabstop>
+  <tabstop>machine_type</tabstop>
+  <tabstop>reconnect</tabstop>
+  <tabstop>output_enable</tabstop>
+  <tabstop>output_disable</tabstop>
+ </tabstops>
  <resources>
   <include location="resources/resources.qrc"/>
  </resources>

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -15,7 +15,6 @@ from PyQt5.QtWidgets import (
 from plover.suggestions import Suggestion
 
 from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
-from plover.gui_qt.suggestions_widget import SuggestionsWidget
 from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.utils import ToolBar
 from plover.gui_qt.tool import Tool
@@ -46,9 +45,6 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
     def __init__(self, engine):
         super(SuggestionsDialog, self).__init__(engine)
         self.setupUi(self)
-        suggestions = SuggestionsWidget()
-        self.layout().replaceWidget(self.suggestions, suggestions)
-        self.suggestions = suggestions
         self._words = u''
         self._last_suggestions = None
         # Toolbar.

--- a/plover/gui_qt/suggestions_dialog.ui
+++ b/plover/gui_qt/suggestions_dialog.ui
@@ -23,7 +23,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWidget" name="suggestions" native="true"/>
+    <widget class="SuggestionsWidget" name="suggestions" native="true"/>
    </item>
   </layout>
   <action name="action_Clear">
@@ -72,6 +72,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SuggestionsWidget</class>
+   <extends>QWidget</extends>
+   <header>plover.gui_qt.suggestions_widget</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="resources/resources.qrc"/>
  </resources>

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -20,8 +20,8 @@ class SuggestionsWidget(QWidget, Ui_SuggestionsWidget):
     #   - 1+ "translation" blocks
     #    - 1-10 "strokes" blocks
 
-    def __init__(self):
-        super(SuggestionsWidget, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(SuggestionsWidget, self).__init__(*args, **kwargs)
         self.setupUi(self)
         self._translation_char_format = QTextCharFormat()
         self._strokes_char_format = QTextCharFormat()


### PR DESCRIPTION
Use Qt designer builtin support (to [promote widgets](http://doc.qt.io/qt-5/designer-using-custom-widgets.html) to a custom class), instead of manually replacing the widget at initialization time.

Note: also set the engine at the QApplication level, so custom widget that needs it can access it through `QApplication.instance().engine`.

@morinted: you'll have to update your dictionary builder plugin.