### PR TITLE
rework keymap configuration widget

### DIFF
--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -128,7 +128,7 @@ class StenotypeBase(object):
 
     @classmethod
     def get_keys(cls):
-        return tuple(set(cls.KEYS_LAYOUT.split()))
+        return tuple(cls.KEYS_LAYOUT.split())
 
     @classmethod
     def get_option_info(cls):

--- a/plover/machine/keymap.py
+++ b/plover/machine/keymap.py
@@ -21,6 +21,12 @@ class Keymap(object):
         # key -> action
         self._bindings = {}
 
+    def get_keys(self):
+        return self._keys.keys()
+
+    def get_actions(self):
+        return self._actions.keys()
+
     def set_bindings(self, bindings):
         # Set from:
         # { key1: action1, key2: action1, ... keyn: actionn }

--- a/test/test_passport.py
+++ b/test/test_passport.py
@@ -49,7 +49,7 @@ class TestCase(unittest.TestCase):
         cases = (
             # Test all keys
             ((b'!f#f+f*fAfCfBfEfDfGfFfHfKfLfOfNfQfPfSfRfUfTfWfYfXfZf^f~f',),
-            [Passport.get_keys(),]),
+            [set(Passport.get_keys()),]),
             # Anything below 8 is not registered
             ((b'S9T8A7',), [['S', 'T'],]),
             # Sequence of strokes


### PR DESCRIPTION
Make configuration easier: instead of mapping actions to keys (making it impossible to know what keys are valid and easy to screw up by using the wrong format), bind keys to actions (with a combo for easy selection of all valid actions).

Before:
![2017-09-11-234727_471x480_scrot](https://user-images.githubusercontent.com/5104286/30298459-bfa9c9f6-974b-11e7-836c-967997556f91.png)

After:
![2017-09-11-234813_471x480_scrot](https://user-images.githubusercontent.com/5104286/30298463-c3c913fc-974b-11e7-9c63-9137895fd8b5.png)
