### PR TITLE
gui_qt/add_translation: fix widget translation label

### DIFF
--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -1,5 +1,6 @@
 
 from collections import namedtuple
+from html import escape as html_escape
 
 from PyQt5.QtCore import QEvent
 from PyQt5.QtWidgets import QApplication, QWidget
@@ -33,6 +34,13 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
         self.on_config_changed(engine.config)
         engine.signal_connect('dictionaries_loaded', self.on_dictionaries_loaded)
         self.on_dictionaries_loaded(self._engine.dictionaries)
+
+        self._special_fmt = (
+            '<span style="' +
+            'background-color:' + self.palette().base().color().name() +';' +
+            'font-family:monospace;' +
+            '">%s</span>'
+        )
 
         self.strokes.installEventFilter(self)
         self.translation.installEventFilter(self)
@@ -197,17 +205,24 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
             index = len(self._dictionaries) - index - 1
         self._selected_dictionary = self._dictionaries[index].path
 
+    def _format_label(self, fmt, strokes, translation):
+        if strokes:
+            strokes = ', '.join(self._special_fmt %
+                                html_escape('/'.join(s))
+                                for s in strokes)
+        if translation:
+            translation = self._special_fmt % html_escape(translation)
+        return fmt.format(strokes=strokes, translation=translation)
+
     def on_strokes_edited(self):
         strokes = self._strokes()
         if strokes:
             translation = self._engine.raw_lookup(strokes)
-            strokes = '/'.join(strokes)
             if translation is not None:
-                fmt = _('{strokes} maps to "{translation}"')
-                translation = escape_translation(translation)
+                fmt = _('{strokes} maps to {translation}')
             else:
                 fmt = _('{strokes} is not in the dictionary')
-            info = fmt.format(strokes=strokes, translation=translation)
+            info = self._format_label(fmt, (strokes,), translation)
         else:
             info = ''
         self.strokes_info.setText(info)
@@ -216,13 +231,11 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
         translation = self._translation()
         if translation:
             strokes = self._engine.reverse_lookup(translation)
-            translation = escape_translation(translation)
             if strokes:
-                fmt = _('"{translation}" is mapped from {strokes}')
-                strokes = ', '.join('/'.join(x) for x in strokes)
+                fmt = _('{translation} is mapped to: {strokes}')
             else:
-                fmt = _('"{translation}" is not in the dictionary')
-            info = fmt.format(strokes=strokes, translation=translation)
+                fmt = _('{translation} is not in the dictionary')
+            info = self._format_label(fmt, strokes, translation)
         else:
             info = ''
         self.translation_info.setText(info)

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import QEvent
 from PyQt5.QtWidgets import QApplication, QWidget
 
 from plover.misc import shorten_path
-from plover.steno import normalize_steno
+from plover.steno import normalize_steno, sort_steno_strokes
 from plover.engine import StartingStrokeState
 from plover.translation import escape_translation, unescape_translation
 
@@ -207,9 +207,8 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
     def _format_label(self, fmt, strokes, translation):
         if strokes:
-            strokes = ', '.join(self._special_fmt %
-                                html_escape('/'.join(s))
-                                for s in strokes)
+            strokes = ', '.join(self._special_fmt % html_escape('/'.join(s))
+                                for s in sort_steno_strokes(strokes))
         if translation:
             translation = self._special_fmt % html_escape(translation)
         return fmt.format(strokes=strokes, translation=translation)

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -46,6 +46,10 @@ def normalize_steno(strokes_string):
 def sort_steno_keys(steno_keys):
     return sorted(steno_keys, key=lambda x: system.KEY_ORDER.get(x, -1))
 
+def sort_steno_strokes(strokes_list):
+    '''Return suggestions, sorted by fewest strokes, then fewest keys.'''
+    return sorted(strokes_list, key=lambda x: (len(x), sum(map(len, x))))
+
 
 class Stroke(object):
     """A standardized data model for stenotype machine strokes.

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -1,5 +1,8 @@
 import collections
 
+from plover.steno import sort_steno_strokes
+
+
 Suggestion = collections.namedtuple('Suggestion', 'text steno_list')
 
 
@@ -42,11 +45,7 @@ class Suggestions(object):
                 strokes_list = self.dictionary.reverse_lookup(modded_translation)
                 if not strokes_list:
                     continue
-                # Return suggestions, sorted by fewest strokes, then fewest keys
-                strokes_list = sorted(
-                    strokes_list,
-                    key=lambda x: (len(x), sum(map(len, x)))
-                )
+                strokes_list = sort_steno_strokes(strokes_list)
                 suggestion = Suggestion(modded_translation, strokes_list)
                 suggestions.append(suggestion)
 


### PR DESCRIPTION
- escape translations/strokes to prevent interpretation (see: https://github.com/openstenoproject/plover/issues/773#issuecomment-306220676)
- style translations/strokes to make the whole text easier to read

Example:
![2017-09-16-031342_427x305_scrot](https://user-images.githubusercontent.com/5104286/30507996-1457070e-9a8d-11e7-83f3-d78c22364c69.png)
