### PR TITLE
drop Python 2 leftovers

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -13,7 +13,6 @@ depends=(
   'python-pyqt5'
   'python-pyserial'
   'python-setuptools'
-  'python-six'
   'python-xlib'
 )
 makedepends=(

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -1,8 +1,6 @@
 
 from collections import namedtuple
-import sys
 
-from six import reraise
 import pkg_resources
 
 from plover.oslayer.config import PLUGINS_PLATFORM
@@ -57,7 +55,7 @@ class Registry(object):
             log.error('error loading %s plugin: %s (from %s)', plugin_type,
                       entrypoint.name, entrypoint.module_name, exc_info=True)
             if not self._suppress_errors:
-                reraise(*sys.exc_info())
+                raise
         else:
             plugin = self.register_plugin(plugin_type, entrypoint.name, obj)
             # Keep track of distributions providing plugins.

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
 	PyQt5>=5.5
 	pyserial>=2.7
 	setuptools
-	six
 packages =
 	plover
 	plover.dictionary

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -6,8 +6,6 @@ import operator
 import re
 import textwrap
 
-from six import text_type
-
 import pytest
 
 from plover import system


### PR DESCRIPTION
We don't need to use six anymore or directly require it.