### PR TITLE
windows: fix missing Visual C++ Redistributable DLL error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,9 @@ class BinaryDistWin(Command):
                 '''.rstrip()).format(dist_dir=dist_dir,
                                      entrypoint=entrypoint,
                                      gui=gui))
+        # Fix Visual C++ Redistributable DLL location.
+        os.rename(os.path.join(dist_dir, 'data', 'vcruntime140.dll'),
+                  os.path.join(dist_dir, 'vcruntime140.dll'))
         # Make distribution source-less.
         run(dist_py, '-m', 'plover_build_utils.source_less',
             # Don't touch pip._vendor.distlib sources,


### PR DESCRIPTION
Otherwise an error will occur when launching the plugin manager if vcruntime140.dll is not already available system wide.