### PR TITLE
engine: mark errorred dictionaries as readonly

### DIFF
--- a/plover/engine.py
+++ b/plover/engine.py
@@ -30,6 +30,7 @@ class ErroredDictionary(StenoDictionary):
     def __init__(self, path, exception):
         super(ErroredDictionary, self).__init__()
         self.enabled = False
+        self.readonly = True
         self.path = path
         self.exception = exception
 


### PR DESCRIPTION
This will prevent them from being selectable when adding a translation. Fix #840.