### PR TITLE
Quit engine when quitting QCoreApplication to prevent Mac freeze

### DIFF
--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -49,6 +49,9 @@ class Application(object):
         QApplication.setQuitOnLastWindowClosed(False)
 
         self._app.engine = self._engine = Engine(config, KeyboardEmulation())
+        # On macOS, quitting through the dock will result
+        # in a direct call to `QCoreApplication.quit`.
+        self._app.aboutToQuit.connect(self._app.engine.quit)
 
         signal.signal(signal.SIGINT, lambda signum, stack: self._engine.quit())
 


### PR DESCRIPTION
<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
Fixes #839 
<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
```python
# On macOS, quitting through the dock will result
# in a direct call to `QCoreApplication.quit`.
```

Tested:

- Dock quit
- Menu bar quit
- Plover quit
- Terminal process quit
- Activity Monitor Quit
- Quitting a .app the same ways