### PR TITLE
Translator rework

### DIFF
--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -112,7 +112,10 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
     @staticmethod
     def _dictionary_filter(key, value):
-        # Only allow translations with special entries. Do this by looking for
+        # Allow undo...
+        if value == '=undo':
+            return False
+        # ...and translations with special entries. Do this by looking for
         # braces but take into account escaped braces and slashes.
         escaped = value.replace('\\\\', '').replace('\\{', '')
         special = '{#'  in escaped or '{PLOVER:' in escaped

--- a/plover/macro/repeat.py
+++ b/plover/macro/repeat.py
@@ -1,0 +1,11 @@
+
+from plover.steno import Stroke
+
+
+def last_stroke(translator, stroke, cmdline):
+    # Repeat last stroke
+    translations = translator.get_state().translations
+    if not translations:
+        return
+    stroke = Stroke(translations[-1].strokes[-1].steno_keys)
+    translator.translate_stroke(stroke)

--- a/plover/macro/retrospective.py
+++ b/plover/macro/retrospective.py
@@ -1,0 +1,56 @@
+
+from plover.translation import Translation
+from plover.steno import Stroke
+
+
+def toggle_asterisk(translator, stroke, cmdline):
+    # Toggle asterisk of previous stroke
+    translations = translator.get_state().translations
+    if not translations:
+        return
+    t = translations[-1]
+    translator.untranslate_translation(t)
+    keys = set(t.strokes[-1].steno_keys)
+    if '*' in keys:
+        keys.remove('*')
+    else:
+        keys.add('*')
+    translator.translate_stroke(Stroke(keys))
+
+def delete_space(translator, stroke, cmdline):
+    # Retrospective delete space
+    translations = translator.get_state().translations
+    if len(translations) < 2:
+        return
+    replaced = translations[-2:]
+    if replaced[1].is_retrospective_command:
+        return
+    english = []
+    for t in replaced:
+        if t.english is not None:
+            english.append(t.english)
+        elif len(t.rtfcre) == 1 and t.rtfcre[0].isdigit():
+            english.append('{&%s}' % t.rtfcre[0])
+    if len(english) > 1:
+        t = Translation([stroke], '{^~|^}'.join(english))
+        t.replaced = replaced
+        t.is_retrospective_command = True
+        translator.translate_translation(t)
+
+def insert_space(translator, stroke, cmdline):
+    # Retrospective insert space
+    translations = translator.get_state().translations
+    if not translations:
+        return
+    replaced = translations[-1]
+    if replaced.is_retrospective_command:
+        return
+    lookup_stroke = replaced.strokes[-1]
+    english = [t.english or '/'.join(t.rtfcre)
+               for t in replaced.replaced]
+    if english:
+        english.append(translator.lookup([lookup_stroke]) or lookup_stroke.rtfcre)
+        t = Translation([stroke], ' '.join(english))
+        t.replaced = [replaced]
+        t.is_retrospective_command = True
+        translator.translate_translation(t)

--- a/plover/macro/undo.py
+++ b/plover/macro/undo.py
@@ -1,0 +1,20 @@
+
+import sys
+
+from plover.translation import Translation
+
+
+if sys.platform.startswith('darwin'):
+    BACK_STRING = '{#Alt_L(BackSpace)}{^}'
+else:
+    BACK_STRING = '{#Control_L(BackSpace)}{^}'
+
+def undo(translator, stroke, cmdline):
+    for t in reversed(translator.get_state().translations):
+        translator.untranslate_translation(t)
+        if t.has_undo():
+            return
+    # There is no more buffer to delete from -- remove undo and add a
+    # stroke that removes last word on the user's OS, but don't add it
+    # to the state history.
+    translator.flush([Translation([stroke], BACK_STRING)])

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -32,6 +32,7 @@ class Registry(object):
         'gui.qt.machine_option',
         'gui.qt.tool',
         'machine',
+        'macro',
         'system',
     )
 

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -178,13 +178,13 @@ class Translator(object):
             self._dictionary.remove_longest_key_listener(callback)
         self._dictionary = d
         d.add_longest_key_listener(callback)
-        
+
     def get_dictionary(self):
         return self._dictionary
 
     def add_listener(self, callback):
         """Add a listener for translation outputs.
-        
+
         Arguments:
 
         callback -- A function that takes: a list of translations to undo, a
@@ -218,15 +218,15 @@ class Translator(object):
 
     def _dict_callback(self, value):
         self._resize_translations()
-        
+
     def get_state(self):
         """Get the state of the translator."""
         return self._state
-        
+
     def set_state(self, state):
         """Set the state of the translator."""
         self._state = state
-        
+
     def clear_state(self):
         """Reset the sate of the translator."""
         self._state = _State()
@@ -392,7 +392,7 @@ class Translator(object):
 
 class _State(object):
     """An object representing the current state of the translator state machine.
-    
+
     Attributes:
 
     translations -- A list of all previous translations that are still undoable.

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ packages =
 	plover.gui_none
 	plover.gui_qt
 	plover.machine
+	plover.macro
 	plover.oslayer
 	plover.system
 	plover_build_utils
@@ -73,6 +74,12 @@ plover.machine =
 	ProCAT    = plover.machine.procat:ProCAT
 	Stentura  = plover.machine.stentura:Stentura
 	TX Bolt   = plover.machine.txbolt:TxBolt
+plover.macro =
+	repeat_last_stroke            = plover.macro.repeat:last_stroke
+	retrospective_delete_space    = plover.macro.retrospective:delete_space
+	retrospective_insert_space    = plover.macro.retrospective:insert_space
+	retrospective_toggle_asterisk = plover.macro.retrospective:toggle_asterisk
+	undo                          = plover.macro.undo:undo
 plover.system =
 	English Stenotype = plover.system.english_stenotype
 setuptools.installation =

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -199,6 +199,65 @@ class TestBlackboxReplays(object):
         1/P-P/2/KR*UR  "$1.20 "
         '''
 
+    def test_undo_fingerspelling_1(self):
+        r'''
+        'T*': '{>}{&t}',
+        '*E': '{>}{&e}',
+        'S*': '{>}{&s}',
+        'T*': '{>}{&t}',
+
+        T*/*E/S*/T*  ' test'
+        */*          ' te'
+        */*          ''
+        '''
+
+    def test_undo_fingerspelling_2(self):
+        r'''
+        'T*': '{>}{&t}',
+        '*E': '{>}{&e}',
+        'S*': '{>}{&s}',
+        'T*': '{>}{&t}',
+
+        :spaces_after
+        T*/*E/S*/T*  'test '
+        */*          'te '
+        */*          ''
+        '''
+
+    def test_undo_replaced_1(self):
+        r'''
+        "TEFT": "test",
+        "TEFT/TKPWOEFT": "{}",
+
+        TEFT      ' test'
+        TKPWOEFT  ''
+        *         ' test'
+        '''
+
+    def test_undo_replaced_2(self):
+        r'''
+        "HROS": "loss",
+        "HRO*S": "lost",
+        "*P": "{*}",
+
+        HROS   ' loss'
+        *P     ' lost'
+        *      ''
+        '''
+
+    def test_undo_replaced_3(self):
+        r'''
+        'PER': 'perfect',
+        'SWAEUGS': 'situation',
+        'PER/SWAEUGS': 'persuasion',
+        'SP*': '{*?}',
+
+        PER      ' perfect'
+        SWAEUGS  ' persuasion'
+        SP*      ' perfect situation'
+        *        ' persuasion'
+        '''
+
     def test_bug557(self):
         r'''
         # Using the asterisk key to delete letters in fingerspelled words

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1279,3 +1279,27 @@ class TestBlackboxReplays(object):
         KUPBTS "countries "
         R-R "countries"
         '''
+
+    def test_bug849_1(self):
+        r'''
+        "-P": ".",
+        "*P": "{*}",
+        "TKAOU": "due",
+        "TKAO*U": "dew",
+
+        TKAOU  ' due'
+        -P      ' due .'
+        *P     ' dew'
+        '''
+
+    def test_bug849_2(self):
+        r'''
+        "KPA*": "{^}{-|}",
+        "*P": "{*}",
+        "TKAOU": "due",
+        "TKAO*U": "dew",
+
+        KPA*   ''
+        TKAOU  'Due'
+        *P     'Dew'
+        '''

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -199,6 +199,32 @@ class TestBlackboxReplays(object):
         1/P-P/2/KR*UR  "$1.20 "
         '''
 
+    def test_undo_not_defined(self):
+        r'''
+        'TEFT': 'test',
+
+        TEFT  ' test'
+        *     ''
+        '''
+
+    def test_undo_overriden(self):
+        r'''
+        'TEFT': 'test',
+        '*': 'not undo',
+
+        TEFT  ' test'
+        *     ' test not undo'
+        '''
+
+    def test_undo_macro(self):
+        r'''
+        'TEFT': 'test',
+        'TPH-D': '=undo',
+
+        TEFT   ' test'
+        TPH-D  ''
+        '''
+
     def test_undo_fingerspelling_1(self):
         r'''
         'T*': '{>}{&t}',


### PR DESCRIPTION
* factorize the translator's code
* improve retrospective asterisk toggle
* add support for macros
* allow mapping the system's undo stroke to a standard translation and mapping undo to different strokes (using the new `:undo` syntax for macros)

Fix #849.