### PR TITLE
formatting: change word handling, take 2

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -731,7 +731,7 @@ def _atom_to_action(atom, ctx):
             case = CASE_UPPER_FIRST_WORD
         text = _apply_case(text, case)
         if case == CASE_UPPER_FIRST_WORD:
-            action.upper_carry = not ' ' in text
+            action.upper_carry = not _has_word_boundary(text)
         # Apply mode.
         action.text = _apply_mode(text, action.case, action.space_char,
                                   action.prev_attach, ctx.last_action)
@@ -760,7 +760,7 @@ def _apply_meta_attach(meta, ctx):
         last_word and
         not meta.isspace() and
         ctx.last_action.orthography and
-        begin and (not end or ' ' in meta)
+        begin and (not end or _has_word_boundary(meta))
     ):
         new_word = add_suffix(last_word, meta)
         common_len = len(commonprefix([last_word, new_word]))
@@ -1023,4 +1023,21 @@ def _upper_first_word(s):
 
 def _rightmost_word(s):
     """Get the rightmost word in s."""
-    return s.rpartition(SPACE)[2]
+    words = WORD_RX.findall(s)
+    if not words:
+        return ''
+    last_word = words[-1]
+    if last_word[-1].isspace():
+        return ''
+    return last_word
+
+
+def _has_word_boundary(s):
+    """Return True if s contains a word boundary
+    (e.g.: more than 1 word, or white space).
+    """
+    if not s:
+        return False
+    if s[0].isspace() or s[-1].isspace():
+        return True
+    return len(WORD_RX.findall(s)) > 1

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -83,7 +83,7 @@ META_RE = re.compile(r"""(?:%s%s|%s%s|[^%s%s])+ # One or more of anything
 #             """, re.VERBOSE)
 
 
-WORD_RX = re.compile(r'((\d+([.,]\d+)+|\w+[-\w]*|[^\w\s]+)\s*)', re.UNICODE)
+WORD_RX = re.compile(r'(?:\d+(?:[.,]\d+)+|\w+[-\w]*|[^\w\s]+)\s*', re.UNICODE)
 
 
 class RetroFormatter(object):
@@ -164,8 +164,8 @@ class RetroFormatter(object):
         """
         for fragment in self.iter_last_fragments():
             # Split each fragment into words.
-            for match in reversed(rx.findall(fragment)):
-                yield match[0].rstrip() if strip else match[0]
+            for word in reversed(rx.findall(fragment)):
+                yield word.rstrip() if strip else word
 
     def last_words(self, count=1, strip=False, rx=WORD_RX):
         """Return the last <count> words."""

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -83,7 +83,7 @@ META_RE = re.compile(r"""(?:%s%s|%s%s|[^%s%s])+ # One or more of anything
 #             """, re.VERBOSE)
 
 
-WORD_RX = re.compile(r'(?:\d+(?:[.,]\d+)+|\w+[-\w]*|[^\w\s]+)\s*', re.UNICODE)
+WORD_RX = re.compile(r'(?:\d+(?:[.,]\d+)+|[\'\w]+[-\w\']*|[^\w\s]+)\s*', re.UNICODE)
 
 
 class RetroFormatter(object):

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -801,8 +801,6 @@ def _apply_meta_retro_case(meta, ctx):
     if last_words:
         action.prev_replace = last_words[0]
         action.text = _apply_case(last_words[0], meta)
-        if meta == CASE_UPPER_FIRST_WORD:
-            action.upper_carry = True
     else:
         action.text = ''
     return action

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -884,7 +884,7 @@ class TestBlackboxReplays(object):
         'PRE': '{pre^}',
         'R*U': '{*<}',
 
-        TEFT/R*U/-G/PRE  " TESTING pre"
+        TEFT/R*U/-G/PRE  " TESTing pre"
         '''
 
     def test_retro_upper3(self):
@@ -926,7 +926,7 @@ class TestBlackboxReplays(object):
         "W-G": "{^ing with}",
         'RUP': '{*<}',
 
-        TEFT/RUP/W-G  " TESTING with"
+        TEFT/RUP/W-G  " TESTing with"
         '''
 
     def test_retro_upper8(self):
@@ -944,7 +944,7 @@ class TestBlackboxReplays(object):
         "W-G": "{^ing with}",
         'RUP': '{*<}',
 
-        TEFT/RUP/W-G/W-G  " TESTING withing with"
+        TEFT/RUP/W-G/W-G  " TESTing withing with"
         '''
 
     def test_retro_upper10(self):

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1329,3 +1329,67 @@ class TestBlackboxReplays(object):
         TKAOU  'Due'
         *P     'Dew'
         '''
+
+    def test_carry_upper_spacing1(self):
+        r'''
+        "TEFT": "{<}test",
+        "-G": "{^ing}",
+        "S-P": "{^ ^}",
+        "S-G": "something",
+
+        TEFT/-G  ' TESTING'
+        S-P      ' TESTING '
+        S-G      ' TESTING something'
+        '''
+
+    def test_carry_upper_spacing2(self):
+        r'''
+        "TEFT": "{<}test",
+        "W-G": "{^ing with}",
+        "S-G": "something",
+
+        TEFT/W-G  ' TESTING with'
+        S-G      ' TESTING with something'
+        '''
+
+    def test_carry_upper_spacing3(self):
+        r'''
+        "TEFT": "{<}test",
+        "-G": "{^ing}",
+        "R-R": "{^\n^}",
+        "S-G": "something",
+
+        TEFT/-G  ' TESTING'
+        R-R      ' TESTING\n'
+        S-G      ' TESTING\nsomething'
+        '''
+
+    def test_carry_upper_spacing4(self):
+        r'''
+        "TEFT": "{<}test",
+        "W-G": "{^ing\twith}",
+
+        TEFT/W-G  ' TESTING\twith'
+        W-G      ' TESTING\twithing\twith'
+        '''
+
+    def test_carry_upper_spacing5(self):
+        r'''
+        "TEFT": "{<}test",
+        "-G": "{^ing}",
+        "TA*B": "{^\t^}",
+        "S-G": "something",
+
+        TEFT/-G  ' TESTING'
+        TA*B     ' TESTING\t'
+        S-G      ' TESTING\tsomething'
+        '''
+
+    def test_carry_upper_spacing6(self):
+        r'''
+        "TEFT": "{<}test",
+        "W-G": "{^ing\nwith}",
+
+        TEFT/W-G  ' TESTING\nwith'
+        W-G       ' TESTING\nwithing\nwith'
+        '''

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -956,6 +956,93 @@ class TestBlackboxReplays(object):
         TEFT/RUP/W/W  " TEST with with"
         '''
 
+    def test_retro_upper11(self):
+        r'''
+        "PREPB": "{~|(^}",
+        'TEFT': 'test',
+        'RUP': '{*<}',
+
+        PREPB/TEFT/RUP  " (TEST"
+        '''
+
+    def test_retro_upper12(self):
+        r'''
+        'PRE': '{pre^}',
+        "PREPB": "{~|(^}",
+        'TEFT': 'test',
+        'RUP': '{*<}',
+
+        PRE/PREPB/TEFT/RUP  " pre(TEST"
+        '''
+
+    def test_retro_upper13(self):
+        r'''
+        "PEUD": "pid",
+        "TPAOEUL": "file",
+        "H*PB": "{^-^}",
+        'RUP': '{*<}',
+
+        PEUD/RUP/H*PB/TPAOEUL  ' PID-file'
+        '''
+
+    def test_retro_upper14(self):
+        r'''
+        "PEUD": "pid",
+        "TPAOEUL": "file",
+        "H*PB": "{^-^}",
+        'RUP': '{*<}',
+
+        PEUD/H*PB/TPAOEUL/RUP  ' PID-FILE'
+        '''
+
+    def test_retro_upper15(self):
+        r'''
+        "OEU": "{^/^}",
+        "T*": "{>}{&t}",
+        "A*": "{>}{&a}",
+        "KR*": "{>}{&c}",
+        "O*": "{>}{&o}",
+        "S*": "{>}{&s}",
+        'RUP': '{*<}',
+
+        T*/A*/OEU/KR*/O*/S*/RUP  ' ta/COS'
+        '''
+
+    def test_retro_upper16(self):
+        r'''
+        "S*": "{>}{&s}",
+        "T*": "{>}{&t}",
+        "O*": "{>}{&o}",
+        "STA*R": "{^*^}",
+        "*E": "{>}{&e}",
+        "*U": "{>}{&u}",
+        "P*": "{>}{&p}",
+        "PW*": "{>}{&b}",
+        'RUP': '{*<}',
+
+        S*/T*/O*/STA*R/*E/*U/P*/PW*/RUP  ' sto*EUPB'
+        '''
+
+    def test_retro_upper17(self):
+        r'''
+        "*U": "{>}{&u}",
+        "S*": "{>}{&s}",
+        "A*": "{>}{&a}",
+        "P-P": "{^.^}",
+        'RUP': '{*<}',
+
+        *U/P-P/S*/P-P/A*/P-P/RUP  ' u.s.a.'
+        '''
+
+    def test_retro_upper18(self):
+        r'''
+        "TPAO": "foo",
+        "KPATS": "{*-|}",
+        "AES": "{^'s}",
+
+        TPAO/AES/KPATS " Foo's"
+        '''
+
     def test_upper1(self):
         r'''
         'TP*U': '{<}',

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -322,37 +322,37 @@ TRANSLATION_TO_ACTIONS_TESTS = (
 
     ('0 {*($c)}', action(),
      [action(text_and_word='0', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$0', trailing_space=' ', prev_replace='0'),
+      action(prev_attach=True, text='$0', word='0', trailing_space=' ', prev_replace='0'),
      ]),
 
     ('0.00 {*($c)}', action(),
      [action(text_and_word='0.00', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$0.00', trailing_space=' ', prev_replace='0.00'),
+      action(prev_attach=True, text='$0.00', word='0.00', trailing_space=' ', prev_replace='0.00'),
      ]),
 
     ('1234 {*($c)}', action(),
      [action(text_and_word='1234', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$1,234', trailing_space=' ', prev_replace='1234'),
+      action(prev_attach=True, text='$1,234', word='1,234', trailing_space=' ', prev_replace='1234'),
      ]),
 
     ('1234567 {*($c)}', action(),
      [action(text_and_word='1234567', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$1,234,567', trailing_space=' ', prev_replace='1234567'),
+      action(prev_attach=True, text='$1,234,567', word='1,234,567', trailing_space=' ', prev_replace='1234567'),
      ]),
 
     ('1234.5 {*($c)}', action(),
      [action(text_and_word='1234.5', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$1,234.50', trailing_space=' ', prev_replace='1234.5'),
+      action(prev_attach=True, text='$1,234.50', word='1,234.50', trailing_space=' ', prev_replace='1234.5'),
      ]),
 
     ('1234.56 {*($c)}', action(),
      [action(text_and_word='1234.56', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$1,234.56', trailing_space=' ', prev_replace='1234.56'),
+      action(prev_attach=True, text='$1,234.56', word='1,234.56', trailing_space=' ', prev_replace='1234.56'),
      ]),
 
     ('1234.567 {*($c)}', action(),
      [action(text_and_word='1234.567', trailing_space=' '),
-      action(prev_attach=True, text_and_word='$1,234.57', trailing_space=' ', prev_replace='1234.567'),
+      action(prev_attach=True, text='$1,234.57', word='1,234.57', trailing_space=' ', prev_replace='1234.567'),
      ]),
 
     ('equip {^} {^ed}', action(),
@@ -785,7 +785,22 @@ def test_capitalize_first_word(s, expected):
     assert formatting._capitalize_first_word(s) == expected
 
 
-@parametrize([('', ''), ('abc', 'abc'), ('a word', 'word'), ('word.', 'word.')])
+RIGHTMOST_WORD_TESTS = (
+    ('', ''),
+    ('\n', ''),
+    ('\t', ''),
+    ('abc', 'abc'),
+    ('a word', 'word'),
+    ('word.', '.'),
+    ('word ', ''),
+    ('word\n', ''),
+    ('word\t', ''),
+    (' word', 'word'),
+    ('\nword', 'word'),
+    ('\tword', 'word'),
+)
+
+@parametrize(RIGHTMOST_WORD_TESTS)
 def test_rightmost_word(s, expected):
     assert formatting._rightmost_word(s) == expected
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -306,13 +306,13 @@ TRANSLATION_TO_ACTIONS_TESTS = (
 
     ('equip {*<}', action(),
      [action(text_and_word='equip', trailing_space=' '),
-      action(prev_attach=True, text='EQUIP', trailing_space=' ', word_and_prev_replace='equip', upper_carry=True),
+      action(prev_attach=True, text='EQUIP', trailing_space=' ', word_and_prev_replace='equip'),
      ]),
 
     ('equip {^ed} {*<}', action(),
      [action(text_and_word='equip', trailing_space=' '),
       action(prev_attach=True, text='ped', trailing_space=' ', word='equipped'),
-      action(prev_attach=True, text='EQUIPPED', trailing_space=' ', word_and_prev_replace='equipped', upper_carry=True),
+      action(prev_attach=True, text='EQUIPPED', trailing_space=' ', word_and_prev_replace='equipped'),
      ]),
 
     ('notanumber {*($c)}', action(),
@@ -532,7 +532,7 @@ ATOM_TO_ACTION_TESTS = (
             trailing_space=' ')),
 
     ('{*<}', action(text_and_word='test', trailing_space=' '),
-     action(prev_attach=True, text='TEST', word_and_prev_replace='test', trailing_space=' ', upper_carry=True)),
+     action(prev_attach=True, text='TEST', word_and_prev_replace='test', trailing_space=' ')),
 
     ('{PLOVER:test_command}', action(text_and_word='test', trailing_space=' '),
      action(word='test', command='test_command', trailing_space=' ')),


### PR DESCRIPTION
Alternative too #860.

* don't carry on retro upper
 * more consistent handling of words: use the same word definition for `_rightmost_word`
 * better detection of word boundaries: extend check to all whitespace characters, not just space

Fix #836 and #837, but **not** #838 (with this implementation the behavior is expected).
