### PR TITLE
Improve Gemini PR, Passport, and Procat support

### DIFF
--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -49,7 +49,7 @@ class Passport(SerialStenotypeBase):
 
         while not self.finished.isSet():
             # Grab data from the serial port.
-            raw = self.serial_port.read(self.serial_port.inWaiting())
+            raw = self.serial_port.read(max(1, self.serial_port.inWaiting()))
 
             for b in raw:
                 self._read(b)

--- a/plover/machine/procat.py
+++ b/plover/machine/procat.py
@@ -3,14 +3,16 @@
 
 """Thread-based monitoring of a ProCAT stenotype machine."""
 
+import binascii
+
+from plover import log
 from plover.machine.base import SerialStenotypeBase
 
-"""
-ProCAT machines send 4 bytes per stroke, with the last byte only consisting of
-FF. So we need only look at the first 3 bytes to see our steno. The leading
-bit is 0.
-"""
-STENO_KEY_CHART = ('', '#', 'S-', 'T-', 'K-', 'P-', 'W-', 'H-',
+
+# ProCAT machines send 4 bytes per stroke, with the last byte only consisting of
+# FF. So we need only look at the first 3 bytes to see our steno. The leading
+# bit is 0.
+STENO_KEY_CHART = (None, '#', 'S-', 'T-', 'K-', 'P-', 'W-', 'H-',
                    'R-', 'A-', 'O-', '*', '-E', '-U', '-F', '-R',
                    '-P', '-B', '-L', '-G', '-T', '-S', '-D', '-Z',
                    )
@@ -33,19 +35,15 @@ class ProCAT(SerialStenotypeBase):
     def run(self):
         """Overrides base class run method. Do not call directly."""
         self._ready()
-        while not self.finished.isSet():
-
-            # Grab data from the serial port.
-            raw = self.serial_port.read(BYTES_PER_STROKE)
-            if not raw:
+        for packet in self._iter_packets(BYTES_PER_STROKE):
+            if (packet[0] & 0x80) or packet[3] != 0xff:
+                log.error('discarding invalid packet: %s',
+                          binascii.hexlify(packet))
                 continue
-
-            # Convert the raw to a list of steno keys.
             steno_keys = self.keymap.keys_to_actions(
-                self.process_steno_packet(raw)
+                self.process_steno_packet(packet)
             )
             if steno_keys:
-                # Notify all subscribers.
                 self._notify(steno_keys)
 
     @staticmethod
@@ -56,8 +54,7 @@ class ProCAT(SerialStenotypeBase):
             for j in range(0, 8):
                 if b & 0x80 >> j:
                     key = STENO_KEY_CHART[i * 8 + j]
-                    if key:
-                        steno_keys.append(key)
+                    steno_keys.append(key)
         return steno_keys
 
 


### PR DESCRIPTION
Add an `_iter_packets(packets_size)` helper to `SerialStenotypeBase`: yield packets of `packets_size` bytes until the machine is stopped. To workaround the fact that the Toshiba Bluetooth stack on Windows does not correctly handle the read timeout setting (returning immediately if some data is already available):
- the effective timeout is re-configured to `timeout/packet_size`
- multiple reads are done (until a packet is complete)
- an incomplete packet will only be discarded if one of those reads return no data (but not on short read)

Update the Gemini PR code to use this new method and reject invalid packets. Fix #846.

Note: the Procat code should probably be updated to do the same.