### PR TITLE
utils: tweak blackbox test assertion message

### DIFF
--- a/plover_build_utils/testing.py
+++ b/plover_build_utils/testing.py
@@ -83,8 +83,6 @@ def replay(blackbox, name, test):
     for step in re.split('(?<=[^\\\\])\n', instructions):
         # Mark current instruction's line.
         lnum += 1
-        msg = name + '\n' + '\n'.join(('> ' if n == lnum else '  ') + l
-                                      for n, l in enumerate(lines))
         step = step.strip()
         # Support for changing some settings on the fly.
         if step.startswith(':'):
@@ -104,6 +102,13 @@ def replay(blackbox, name, test):
             blackbox.translator.translate(steno_to_stroke(s))
         # Check output.
         expected_output = ast.literal_eval(output.strip())
+        msg = (
+            name + '\n' +
+            '\n'.join(('> ' if n == lnum else '  ') + l
+                      for n, l in enumerate(lines)) + '\n' +
+            '   ' + repr(blackbox.output.text) + '\n'
+            '!= ' + repr(expected_output)
+        )
         assert blackbox.output.text == expected_output, msg
 
 def replay_doc(f):


### PR DESCRIPTION
I noticed that after exporting support for blackbox tests the assertion message on failure changed from:
```
_____________________________ TestBlackboxReplays.test_carry_upper_spacing6 ______________________________
bb = <test.test_blackbox.TestBlackboxReplays object at 0x14cb56555f98>
>   new_f = lambda bb: (f(bb), replay(bb, name, test))
E   AssertionError: test_carry_upper_spacing6
E
E       "TEFT": "{<}test",
E       "W-G": "{^ing\nwith}",
E
E     > TEFT/W-G  ' TESTING\nWITH'
E       W-G       ' TESTING\nwithing\nwith'
E
E   assert ' TESTING\nwith' == ' TESTING\nWITH'
E        TESTING
E     - with
E     + WITH
test/test_blackbox.py:117: AssertionError
================================== 1 failed, 132 passed in 0.91 seconds ==================================
```
to:
```
________________________________ TestsBlackbox.test_carry_upper_spacing6 _________________________________
bb = <test.test_blackbox.TestsBlackbox object at 0x154dd5d1fa58>
>   new_f = lambda bb: (f(bb), replay(bb, name, test))
E   AssertionError: test_carry_upper_spacing6
E
E     "TEFT": "{<}test",
E     "W-G": "{^ing\nwith}",
E
E   > TEFT/W-G  ' TESTING\nWITH'
E     W-G       ' TESTING\nwithing\nwith'
plover_build_utils/testing.py:113: AssertionError
================================== 1 failed, 132 passed in 0.79 seconds ==================================
```
So tweak it to add back the resulting output:
```
________________________________ TestsBlackbox.test_carry_upper_spacing6 _________________________________
bb = <test.test_blackbox.TestsBlackbox object at 0x151e97c14a58>
>   new_f = lambda bb: (f(bb), replay(bb, name, test))
E   AssertionError: test_carry_upper_spacing6
E
E     "TEFT": "{<}test",
E     "W-G": "{^ing\nwith}",
E
E   > TEFT/W-G  ' TESTING\nWITH'
E     W-G       ' TESTING\nwithing\nwith'
E
E      ' TESTING\nwith'
E   != ' TESTING\nWITH'
plover_build_utils/testing.py:118: AssertionError
================================== 1 failed, 132 passed in 0.75 seconds ==================================
```
