### PR TITLE
rework `setup_requires` handling (again) and make QT GUI optional

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -29,7 +29,7 @@ sha1sums=(803bb68068feef3772e34e1b1ab34e7fa25375ae)
 
 prepare() {
   cd "$pkgname-$pkgver"
-  sed -i '/^\s*PyQt5\b.*/d' setup.py setup.cfg
+  sed -i '/^\s*PyQt5\b.*/d' setup.cfg
 }
 
 check() {

--- a/plover/main.py
+++ b/plover/main.py
@@ -55,7 +55,7 @@ def main():
                         'print list of available scripts when no argument is given')
     parser.add_argument('-l', '--log-level', choices=['debug', 'info', 'warning', 'error'],
                         default=None, help='set log level')
-    parser.add_argument('-g', '--gui', default='qt', help='set gui')
+    parser.add_argument('-g', '--gui', default=None, help='set gui')
     args = parser.parse_args(args=sys.argv[1:])
     if args.log_level is not None:
         log.set_level(args.log_level.upper())
@@ -67,7 +67,16 @@ def main():
 
     registry.update()
 
-    gui = registry.get_plugin('gui', args.gui).obj
+    if args.gui is None:
+        gui_priority = {
+            'qt': 1,
+            'none': -1,
+        }
+        gui_list = sorted(registry.list_plugins('gui'), reverse=True,
+                          key=lambda gui: gui_priority.get(gui.name, 0))
+        gui = gui_list[0].obj
+    else:
+        gui = registry.get_plugin('gui', args.gui).obj
 
     try:
         if args.script is not None:

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -50,4 +50,13 @@ else:
 # This need to be imported after patching sys.path.
 import pkg_resources
 
-ASSETS_DIR = pkg_resources.resource_filename('plover', 'assets')
+plover_dist = pkg_resources.get_distribution('plover')
+
+ASSETS_DIR = plover_dist.get_resource_filename(__name__, 'plover/assets')
+
+# Is support for the QT GUI available?
+HAS_GUI_QT = True
+for req in plover_dist.requires(('gui_qt',)):
+    if pkg_resources.working_set.find(req) is None:
+        HAS_GUI_QT = False
+        break

--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -9,7 +9,7 @@ pyobjc-framework-Quartz==4.0; "darwin" in sys_platform
 PyQt5==5.9.2
 pyserial==3.4
 python-xlib==0.20; "linux" in sys_platform
-setuptools==36.2.7
+setuptools==38.2.4
 six==1.10.0
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/rpm/package.spec
+++ b/rpm/package.spec
@@ -37,7 +37,7 @@ hackers, hobbyists, accessibility mavens, and all-around speed demons.
 %setup -q -n %{name}-%{version}
 
 %build
-sed -i '/^\s*PyQt5\b.*/d' setup.py setup.cfg
+sed -i '/^\s*PyQt5\b.*/d' setup.cfg
 %{__python3} setup.py compile_catalog build_ui build
 
 %install

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ keywords = plover
 [options]
 include_package_data = True
 zip_safe = True
+setup_requires =
+	Babel
+	PyQt5>=5.8.2
 tests_require =
 	mock
 	pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
 	pyobjc-core>=4.0; "darwin" in sys_platform
 	pyobjc-framework-Cocoa>=4.0; "darwin" in sys_platform
 	pyobjc-framework-Quartz>=4.0; "darwin" in sys_platform
-	PyQt5>=5.5
 	pyserial>=2.7
 	python-xlib>=0.16; "linux" in sys_platform
 	setuptools
@@ -53,6 +52,10 @@ packages =
 	plover.system
 	plover_build_utils
 
+[options.extras_require]
+gui_qt =
+	PyQt5>=5.5
+
 [options.entry_points]
 console_scripts =
 	plover = plover.main:main
@@ -61,7 +64,7 @@ plover.dictionary =
 	rtf  = plover.dictionary.rtfcre_dict:RtfDictionary
 plover.gui =
 	none = plover.gui_none.main
-	qt   = plover.gui_qt.main
+	qt   = plover.gui_qt.main [gui_qt]
 plover.gui.qt.machine_option =
 	plover.machine.base:SerialStenotypeBase = plover.gui_qt.machine_options:SerialOption
 	plover.machine.keyboard:Keyboard        = plover.gui_qt.machine_options:KeyboardOption

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,6 @@
 # Copyright (c) 2010 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
-__requires__ = '''
-Babel
-PyQt5>=5.8.2
-setuptools>=36.2.7
-'''
-
 from distutils import log
 import glob
 import os
@@ -31,8 +25,13 @@ from plover import (
     __copyright__,
 )
 
-from plover_build_utils.setup import BuildPy, BuildUi, Command, Test
+from plover_build_utils.setup import (
+    BuildPy, BuildUi, Command, Test,
+    ensure_setup_requires,
+)
 
+
+ensure_setup_requires('>=38.2.4')
 
 BuildPy.build_dependencies.append('build_ui')
 cmdclass = {


### PR DESCRIPTION
Trying to ensure that `setup.py` is called with the right version of setuptools is not possible in all cases when using `__requires__`: if the version wanted is installed but not the activated version (e.g. because an older version from the user site-packages takes precedence), then it will be activated too late (`pkg_resources` has already been loaded, and potentially `setuptools` too).

Additionally, setuptools now supports installing from wheel, so rework how `setup_requires` are handled; implementing `plover_build_utils.setup.ensure_setup_requires`. To be used at the beginning of `setup.py`, it will ensure:
- the correct version of setuptools is active
- the setup requirements are installed and can be imported

This make installation from source using pip possible even if the requirements needed by `setup.py` are not installed.

Finally, make the QT GUI optional:
- move the PyQt5 requirements to a dedicated `gui_qt` extra
- skip plugins related to the QT GUI if some of the necessary requirements are not installed
- if the QT GUI is not installed, automatically select the first available GUI plugin (falling back to `none` as a last restort)

This way a version of Plover with no GUI can easily be installed from wheel once we publish it to PyPi.