### PR TITLE
gui_qt/paper_tape: improve handling of non-Latin keys

### DIFF
--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -9,6 +9,8 @@ from PyQt5.QtWidgets import (
     QMessageBox,
 )
 
+from wcwidth import wcwidth
+
 from plover import system
 
 from plover.gui_qt.paper_tape_ui import Ui_PaperTape
@@ -37,6 +39,7 @@ class PaperTape(Tool, Ui_PaperTape):
         self.setupUi(self)
         self._strokes = []
         self._all_keys = None
+        self._all_keys_filler = None
         self._formatter = None
         self._history_size = 2000000
         self.styles.addItems(self.STYLES)
@@ -82,6 +85,10 @@ class PaperTape(Tool, Ui_PaperTape):
         if 'system_name' in config:
             self._strokes = []
             self._all_keys = ''.join(key.strip('-') for key in system.KEYS)
+            self._all_keys_filler = [
+                ' ' * wcwidth(k)
+                for k in self._all_keys
+            ]
             self._numbers = set(system.NUMBERS.values())
             self.header.setText(self._all_keys)
             self.on_style_changed(self._style)
@@ -91,7 +98,7 @@ class PaperTape(Tool, Ui_PaperTape):
         return self.styles.currentText()
 
     def _paper_format(self, stroke):
-        text = [' '] * len(self._all_keys)
+        text = self._all_keys_filler * 1
         keys = stroke.steno_keys[:]
         if any(key in self._numbers for key in keys):
             keys.append('#')

--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -11,5 +11,6 @@ pyserial==3.4
 python-xlib==0.20; "linux" in sys_platform
 setuptools==36.2.7
 six==1.10.0
+wcwidth==0.1.7
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
 	pyserial>=2.7
 	python-xlib>=0.16; "linux" in sys_platform
 	setuptools
+	wcwidth
 packages =
 	plover
 	plover.dictionary


### PR DESCRIPTION
Use the wcwidth package to calculate each character's width.

![korean_paper_tape](https://user-images.githubusercontent.com/5104286/34082800-8a206df6-e365-11e7-9744-9e3db482c0d3.png)
