### PR TITLE
Config rework

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -151,14 +151,6 @@ class Config(object):
         writer = codecs.getwriter('utf8')(fp)
         self._config.write(writer)
 
-    def clone(self):
-        f = BytesIO()
-        self.save(f)
-        c = Config()
-        f.seek(0, 0)
-        c.load(f)
-        return c
-
     def set_machine_type(self, machine_type):
         self._set(MACHINE_CONFIG_SECTION, MACHINE_TYPE_OPTION,
                          machine_type)

--- a/plover/config.py
+++ b/plover/config.py
@@ -4,7 +4,6 @@
 """Configuration management."""
 
 from collections import namedtuple
-from io import BytesIO
 import codecs
 import configparser
 import json
@@ -13,12 +12,10 @@ import os
 from plover.exception import InvalidConfigurationError
 from plover.machine.keymap import Keymap
 from plover.registry import registry
-from plover.oslayer.config import ASSETS_DIR, CONFIG_DIR
+from plover.oslayer.config import CONFIG_DIR
 from plover.misc import expand_path, shorten_path
 from plover import log
 
-
-SPINNER_FILE = os.path.join(ASSETS_DIR, 'spinner.gif')
 
 # Config path.
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'plover.cfg')
@@ -82,10 +79,6 @@ SYSTEM_DICTIONARIES_OPTION = 'dictionaries'
 
 PLUGINS_CONFIG_SECTION = 'Plugins'
 ENABLED_EXTENSIONS_OPTION = 'enabled_extensions'
-
-# Logging constants.
-LOG_EXTENSION = '.log'
-
 
 MIN_FRAME_OPACITY = 0
 MAX_FRAME_OPACITY = 100

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -24,8 +24,6 @@ from PyQt5.QtWidgets import (
 )
 
 from plover.config import MINIMUM_OUTPUT_CONFIG_UNDO_LEVELS
-from plover.machine.base import SerialStenotypeBase
-from plover.machine.keyboard import Keyboard
 from plover.misc import expand_path, shorten_path
 from plover.registry import registry
 

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from PyQt5.QtCore import QVariant, pyqtSignal
 from PyQt5.QtWidgets import QWidget
 
@@ -22,7 +24,7 @@ class SerialOption(QWidget, Ui_SerialWidget):
         self._value = {}
 
     def setValue(self, value):
-        self._value = value
+        self._value = copy(value)
         port = value['port']
         if port is None or port == 'None':
             self.on_scan()
@@ -109,7 +111,7 @@ class KeyboardOption(QWidget, Ui_KeyboardWidget):
         self._value = {}
 
     def setValue(self, value):
-        self._value = value
+        self._value = copy(value)
         self.arpeggiate.setChecked(value['arpeggiate'])
 
     def on_arpeggiate_changed(self, value):

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -13,6 +13,7 @@ import serial
 
 from plover import log
 from plover.machine.keymap import Keymap
+from plover.misc import boolean
 
 
 STATE_STOPPED = 'stopped'
@@ -228,7 +229,6 @@ class SerialStenotypeBase(ThreadedStenotypeBase):
     @classmethod
     def get_option_info(cls):
         """Get the default options for this machine."""
-        bool_converter = lambda s: s == 'True'
         sb = lambda s: int(float(s)) if float(s).is_integer() else float(s)
         converters = {
             'port': str,
@@ -237,8 +237,8 @@ class SerialStenotypeBase(ThreadedStenotypeBase):
             'parity': str,
             'stopbits': sb,
             'timeout': float,
-            'xonxoff': bool_converter,
-            'rtscts': bool_converter,
+            'xonxoff': boolean,
+            'rtscts': boolean,
         }
         return {
             setting: (default, converters[setting])

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -5,6 +5,7 @@
 "For use with a computer keyboard (preferably NKRO) as a steno machine."
 
 from plover.machine.base import StenotypeBase
+from plover.misc import boolean
 from plover.oslayer.keyboardcontrol import KeyboardCapture
 
 
@@ -120,7 +121,6 @@ class Keyboard(StenotypeBase):
 
     @classmethod
     def get_option_info(cls):
-        bool_converter = lambda s: s == 'True'
         return {
-            'arpeggiate': (False, bool_converter),
+            'arpeggiate': (False, boolean),
         }

--- a/plover/misc.py
+++ b/plover/misc.py
@@ -55,3 +55,13 @@ def normalize_path(path):
     if path.startswith(ASSET_SCHEME):
         return path
     return os.path.normcase(os.path.realpath(path))
+
+def boolean(value):
+    if isinstance(value, str):
+        v = value.lower()
+        if v in ('1', 'yes', 'true', 'on'):
+            return True
+        if v in ('0', 'no', 'false', 'off'):
+            return False
+        raise ValueError(value)
+    return bool(value)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -102,18 +102,6 @@ class ConfigTestCase(unittest.TestCase):
                              '[%s]\n%s = %s\n\n' % (case.section, case.option,
                                                     case.value3))
 
-    def test_clone(self):
-        s = '[%s]%s = %s\n\n' % (config.MACHINE_CONFIG_SECTION, 
-                                 config.MACHINE_TYPE_OPTION, 'foo')
-        c = config.Config()
-        c.load(make_config(s))
-        f1 = make_config()
-        c.save(f1)
-        c2 = c.clone()
-        f2 = make_config()
-        c2.save(f2)
-        self.assertEqual(f1.getvalue(), f2.getvalue())
-
     def test_machine_specific_options(self):
         defaults = {k: v[0] for k, v in FakeMachine.get_option_info().items()}
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,35 +3,43 @@
 
 """Unit tests for config.py."""
 
-from collections import namedtuple
 from io import BytesIO
+import inspect
 import json
 import os
 import sys
-import unittest
+import textwrap
 
-from mock import patch
+import pytest
 
 from plover import config, system
 from plover.config import DictionaryConfig
+from plover.machine.keyboard import Keyboard
 from plover.machine.keymap import Keymap
 from plover.misc import expand_path, normalize_path
 from plover.registry import Registry
-from plover.oslayer.config import CONFIG_DIR
+from plover.system import english_stenotype
 
 
-if sys.platform.startswith('win32'):
-    ABS_PATH = os.path.normcase(r'c:\foo\bar')
-else:
-    ABS_PATH = '/foo/bar'
+def dedent_strip(s):
+    return textwrap.dedent(s).strip()
 
-
-def make_config(contents=''):
-    return BytesIO(b'\n'.join(line.strip().encode('utf-8')
-                              for line in contents.split('\n')))
+def dict_replace(d, update):
+    d = dict(d)
+    d.update(update)
+    return d
 
 
 class FakeMachine(object):
+
+    KEYMAP_MACHINE_TYPE = 'Keyboard'
+
+    def get_keys():
+        return Keyboard.get_keys()
+
+    def get_actions():
+        return Keyboard.get_actions()
+
     @staticmethod
     def get_option_info():
         bool_converter = lambda s: s == 'True'
@@ -44,327 +52,401 @@ class FakeMachine(object):
             'booloption2': (False, bool_converter)
         }
 
+FakeMachine.DEFAULT_OPTIONS = {k: v[0] for k, v in FakeMachine.get_option_info().items()}
 
-class ConfigTestCase(unittest.TestCase):
 
-    def test_simple_fields(self):
-        Case = namedtuple('Case', ['field', 'section', 'option', 'default', 
-                                   'value1', 'value2', 'value3'])
+class FakeSystem(object):
+    KEYS = english_stenotype.KEYS
+    IMPLICIT_HYPHEN_KEYS = ()
+    SUFFIX_KEYS = ()
+    NUMBER_KEY = english_stenotype.NUMBER_KEY
+    NUMBERS = english_stenotype.NUMBERS
+    UNDO_STROKE_STENO = english_stenotype.UNDO_STROKE_STENO
+    ORTHOGRAPHY_RULES = []
+    ORTHOGRAPHY_RULES_ALIASES = {}
+    ORTHOGRAPHY_WORDLIST = None
+    KEYMAPS = {
+        'Faky faky': english_stenotype.KEYMAPS['Keyboard'],
+    }
+    DEFAULT_DICTIONARIES = ('utilisateur.json', 'principal.json')
 
-        cases = (
-        ('machine_type', config.MACHINE_CONFIG_SECTION, 
-         config.MACHINE_TYPE_OPTION, config.DEFAULT_MACHINE_TYPE, 'Gemini PR', 'TX Bolt',
-         'Passport'),
-        ('log_file_name', config.LOGGING_CONFIG_SECTION, config.LOG_FILE_OPTION, 
-         normalize_path(os.path.join(CONFIG_DIR, config.DEFAULT_LOG_FILE)),
-         os.path.join(ABS_PATH, 'l1'), os.path.join(ABS_PATH, 'log'), os.path.join(ABS_PATH, 'sawzall')),
-        ('enable_stroke_logging', config.LOGGING_CONFIG_SECTION, 
-         config.ENABLE_STROKE_LOGGING_OPTION, 
-         config.DEFAULT_ENABLE_STROKE_LOGGING, False, True, False),
-        ('enable_translation_logging', config.LOGGING_CONFIG_SECTION, 
-         config.ENABLE_TRANSLATION_LOGGING_OPTION, 
-         config.DEFAULT_ENABLE_TRANSLATION_LOGGING, False, True, False),
-        ('auto_start', config.MACHINE_CONFIG_SECTION, 
-         config.MACHINE_AUTO_START_OPTION, config.DEFAULT_MACHINE_AUTO_START, 
-         True, False, True),
-        ('show_stroke_display', config.STROKE_DISPLAY_SECTION, 
-         config.STROKE_DISPLAY_SHOW_OPTION, config.DEFAULT_STROKE_DISPLAY_SHOW, 
-         True, False, True),
-        ('space_placement', config.OUTPUT_CONFIG_SECTION, 
-         config.OUTPUT_CONFIG_SPACE_PLACEMENT_OPTION, config.DEFAULT_OUTPUT_CONFIG_SPACE_PLACEMENT, 
-         'Before Output', 'After Output', 'None'),
-        )
 
-        for case in cases:
-            case = Case(*case)
-            c = config.Config()
-            getter = getattr(c, 'get_' + case.field)
-            setter = getattr(c, 'set_' + case.field)
-            # Check the default value.
-            self.assertEqual(getter(), case.default)
-            # Set a value...
-            setter(case.value1)
-            # ...and make sure it is really set.
-            self.assertEqual(getter(), case.value1)
-            # Load from a file...
-            f = make_config('[%s]\n%s: %s' % (case.section, case.option,
-                                              case.value2))
-            c.load(f)
-            # ..and make sure the right value is set.
-            self.assertEqual(getter(), case.value2)
-            # Set a value...
-            setter(case.value3)
-            f = make_config()
-            # ...save it...
-            c.save(f)
-            # ...and make sure it's right.
-            self.assertEqual(f.getvalue().decode('utf-8'),
-                             '[%s]\n%s = %s\n\n' % (case.section, case.option,
-                                                    case.value3))
+def test_config_dict():
+    short_path = os.path.normcase(os.path.normpath('~/foo/bar'))
+    full_path = os.path.normcase(os.path.expanduser(os.path.normpath('~/foo/bar')))
+    # Path should be expanded.
+    assert DictionaryConfig(short_path).path == full_path
+    assert DictionaryConfig(full_path).path == full_path
+    # Short path is available through `short_path`.
+    assert DictionaryConfig(full_path).short_path == short_path
+    assert DictionaryConfig(short_path).short_path == short_path
+    # Enabled default to True.
+    assert DictionaryConfig('foo').enabled == True
+    assert DictionaryConfig('foo', False).enabled == False
+    # When converting to a dict (for dumping to JSON),
+    # a dictionary with the shortened path is used.
+    assert DictionaryConfig(full_path).to_dict() == \
+            {'path': short_path, 'enabled': True}
+    assert DictionaryConfig(short_path, False).to_dict() == \
+            {'path': short_path, 'enabled': False}
+    # Test from_dict creation helper.
+    assert DictionaryConfig.from_dict({'path': short_path}) == \
+            DictionaryConfig(short_path)
+    assert DictionaryConfig.from_dict({'path': full_path, 'enabled': False}) == \
+            DictionaryConfig(short_path, False)
 
-    def test_machine_specific_options(self):
-        defaults = {k: v[0] for k, v in FakeMachine.get_option_info().items()}
 
-        machine_name = 'machine foo'
-        registry = Registry()
-        registry.register_plugin('machine', machine_name, FakeMachine)
-        with patch('plover.config.registry', registry):
-            c = config.Config()
-            
-            # Check default value.
-            actual = c.get_machine_specific_options(machine_name)
-            self.assertEqual(actual, defaults)
+if sys.platform.startswith('win32'):
+    ABS_PATH = os.path.normcase(r'c:/foo/bar')
+else:
+    ABS_PATH = '/foo/bar'
 
-            # Make sure setting a value is reflecting in the getter.
-            options = {
-                'stroption1': 'something',
-                'intoption1': 5,
-                'floatoption1': 5.9,
-                'booloption1': False,
-            }
-            c.set_machine_specific_options(options, machine_name)
-            actual = c.get_machine_specific_options(machine_name)
-            expected = dict(list(defaults.items()) + list(options.items()))
-            self.assertEqual(actual, expected)
-            
-            # Test loading a file. Unknown option is ignored.
-            s = '\n'.join(('[machine foo]', 'stroption1 = foo', 
-                           'intoption1 = 3', 'booloption1 = True', 
-                           'booloption2 = False', 'unknown = True'))
-            f = make_config(s)
-            c.load(f)
-            expected = {
-                'stroption1': 'foo',
-                'intoption1': 3,
-                'booloption1': True,
-                'booloption2': False,
-            }
-            expected = dict(list(defaults.items()) + list(expected.items()))
-            actual = c.get_machine_specific_options(machine_name)
-            self.assertEqual(actual, expected)
-            
-            # Test saving a file.
-            f = make_config()
-            c.save(f)
-            self.assertEqual(f.getvalue().decode('utf-8'), s + '\n\n')
-            
-            # Test reading invalid values.
-            s = '\n'.join(['[machine foo]', 'floatoption1 = None', 
-                           'booloption2 = True'])
-            f = make_config(s)
-            c.load(f)
-            expected = {
-                'floatoption1': 1,
-                'booloption2': True,
-            }
-            expected = dict(list(defaults.items()) + list(expected.items()))
-            actual = c.get_machine_specific_options(machine_name)
-            self.assertEqual(actual, expected)
-            # Check we can get/set the current machine options.
-            c.set_machine_type(machine_name)
-            self.assertEqual(c.get_machine_specific_options(), expected)
-            expected['stroption1'] = 'foobar'
-            expected['booloption2'] = False
-            expected['floatoption1'] = 42.0
-            c.set_machine_specific_options(expected)
-            self.assertEqual(c.get_machine_specific_options(), expected)
+DEFAULT_KEYMAP = Keymap(Keyboard.get_keys(), english_stenotype.KEYS + Keyboard.get_actions())
+DEFAULT_KEYMAP.set_mappings(english_stenotype.KEYMAPS['Keyboard'])
 
-    def test_config_dict(self):
-        short_path = os.path.normcase(os.path.normpath('~/foo/bar'))
-        full_path = os.path.normcase(os.path.expanduser(os.path.normpath('~/foo/bar')))
-        # Path should be expanded.
-        self.assertEqual(DictionaryConfig(short_path).path, full_path)
-        self.assertEqual(DictionaryConfig(full_path).path, full_path)
-        # Short path is available through `short_path`.
-        self.assertEqual(DictionaryConfig(full_path).short_path, short_path)
-        self.assertEqual(DictionaryConfig(short_path).short_path, short_path)
-        # Enabled default to True.
-        self.assertEqual(DictionaryConfig('foo').enabled, True)
-        self.assertEqual(DictionaryConfig('foo', False).enabled, False)
-        # When converting to a dict (for dumping to JSON),
-        # a dictionary with the shortened path is used.
-        self.assertEqual(DictionaryConfig(full_path).to_dict(),
-                         {'path': short_path, 'enabled': True})
-        self.assertEqual(DictionaryConfig(short_path, False).to_dict(),
-                         {'path': short_path, 'enabled': False})
-        # Test from_dict creation helper.
-        self.assertEqual(config.DictionaryConfig.from_dict(
-            {'path': short_path}), DictionaryConfig(short_path))
-        self.assertEqual(config.DictionaryConfig.from_dict(
-            {'path': full_path, 'enabled': False}), DictionaryConfig(short_path, False))
+DEFAULTS = {
+    'space_placement': 'Before Output',
+    'start_attached': False,
+    'start_capitalized': False,
+    'undo_levels': config.DEFAULT_UNDO_LEVELS,
+    'log_file_name': expand_path('strokes.log'),
+    'enable_stroke_logging': False,
+    'enable_translation_logging': False,
+    'start_minimized': False,
+    'show_stroke_display': False,
+    'show_suggestions_display': False,
+    'translation_frame_opacity': 100,
+    'classic_dictionaries_display_order': False,
+    'enabled_extensions': set(),
+    'auto_start': False,
+    'machine_type': 'Keyboard',
+    'machine_specific_options': { 'arpeggiate': False },
+    'system_name': config.DEFAULT_SYSTEM_NAME,
+    'system_keymap': DEFAULT_KEYMAP,
+    'dictionaries': [DictionaryConfig(p) for p in english_stenotype.DEFAULT_DICTIONARIES]
+}
 
-    def test_dictionary_config(self):
-        short_path = os.path.normcase(os.path.normpath('~/foo/bar'))
-        full_path = os.path.normcase(os.path.expanduser(os.path.normpath('~/foo/bar')))
-        dc = DictionaryConfig(short_path)
-        # Path should be expanded.
-        self.assertEqual(dc.path, full_path)
-        # Shortened path is available through short_path.
-        self.assertEqual(dc.short_path, short_path)
-        # Enabled default to True.
-        self.assertEqual(dc.enabled, True)
-        # Check conversion to dict: short path should be used.
-        self.assertEqual(dc.to_dict(), {'path': short_path, 'enabled': True})
-        # Test replace method.
-        dc = dc.replace(enabled=False)
-        self.assertEqual(dc.path, full_path)
-        self.assertEqual(dc.enabled, False)
-        # Test creation from dict.
-        self.assertEqual(DictionaryConfig.from_dict({'path': short_path, 'enabled': False}), dc)
+CONFIG_TESTS = (
 
-    def test_dictionaries_option(self):
-        section = config.SYSTEM_CONFIG_SECTION % config.DEFAULT_SYSTEM_NAME
-        option = config.SYSTEM_DICTIONARIES_OPTION
-        legacy_section = config.LEGACY_DICTIONARY_CONFIG_SECTION
-        legacy_option = config.LEGACY_DICTIONARY_FILE_OPTION
-        c = config.Config()
-        config_dir = os.path.normcase(os.path.realpath(config.CONFIG_DIR))
-        # Check the default value.
-        self.assertEqual(c.get_dictionaries(),
-                         [DictionaryConfig(path)
-                          for path in system.DEFAULT_DICTIONARIES])
-        # Load from a file encoded the ancient way...
-        filename = normalize_path('/some_file')
-        f = make_config('[%s]\n%s: %s' % (legacy_section, legacy_option, filename))
-        c.load(f)
-        # ..and make sure the right value is set.
-        self.assertEqual(c.get_dictionaries(), [DictionaryConfig(filename)])
-        # Load from a file encoded the old way...
-        filenames = [os.path.join(ABS_PATH, f) for f in ('b', 'a', 'd', 'c')]
-        dictionaries = [DictionaryConfig(path) for path in filenames]
-        value = '\n'.join('%s%d: %s' % (legacy_option, d, v)
-                              for d, v in enumerate(reversed(filenames), start=1))
-        f = make_config('[%s]\n%s' % (legacy_section, value))
-        c.load(f)
-        # ...and make sure the right value is set.
-        self.assertEqual(c.get_dictionaries(), dictionaries)
-        # Check the config is saved back converted to the new way.
-        f = make_config()
-        c.save(f)
-        new_config_contents = '[%s]\n%s = %s\n\n' % (
-            section, option, json.dumps([
-                {'path': path, 'enabled': True}
-                for path in filenames
-            ], sort_keys=True))
-        self.assertEqual(f.getvalue().decode('utf-8'), new_config_contents)
-        # Load from a file encoded the new way...
-        f = make_config(new_config_contents)
-        c.load(f)
-        # ...and make sure the right value is set.
-        self.assertEqual(c.get_dictionaries(), dictionaries)
-        # Set a value...
-        dictionaries.reverse()
-        filenames.reverse()
-        c.set_dictionaries(dictionaries)
-        f = make_config()
-        # ...save it...
-        c.save(f)
-        # ...and make sure it's right.
-        new_config_contents = '[%s]\n%s = %s\n\n' % (
-            section, option, json.dumps([
-                {'path': path, 'enabled': True}
-                for path in filenames
-            ], sort_keys=True))
-        self.assertEqual(f.getvalue().decode('utf-8'), new_config_contents)
-        # The new way must take precedence over the old way.
-        legacy_value = '\n'.join('%s%d = %s' % (legacy_option, d, v)
-                              for d, v in enumerate(['/foo', '/bar'], start=1))
-        f = make_config(new_config_contents + '\n[%s]\n%s\n' % ( legacy_section, legacy_value))
-        c.load(f)
-        self.assertEqual(c.get_dictionaries(), dictionaries)
+    ('defaults',
+     '''
+     ''',
+     DEFAULTS,
+     {}, {},
+     '''
+     ''',
+    ),
 
-    def test_system_keymap(self):
-        mappings_list = [
-            ['-D', ['[']],
-            ['*', ["t", "g", "y", "h"]],
-            # Keys can be a list of key names or a single key name.
-            ['arpeggiate', 'space'],
-            ['S-', ['a', 'q']],
-        ]
-        mappings_dict = dict(mappings_list)
-        machine = 'Keyboard'
-        section = config.SYSTEM_CONFIG_SECTION % config.DEFAULT_SYSTEM_NAME
-        option = config.SYSTEM_KEYMAP_OPTION % machine.lower()
-        cfg = config.Config()
-        # Must return a Keymap instance.
-        keymap = cfg.get_system_keymap(machine)
-        self.assertIsInstance(keymap, Keymap)
-        # Can be set from a Keymap.
-        keymap.set_mappings(mappings_list)
-        cfg.set_system_keymap(keymap, machine)
-        self.assertEqual(cfg.get_system_keymap(machine), keymap)
-        # Can also be set from a dictionary.
-        cfg.set_system_keymap(mappings_dict, machine)
-        self.assertEqual(cfg.get_system_keymap(machine), keymap)
-        # Or from a compatible iterable of pairs (action, keys).
-        cfg.set_system_keymap(mappings_list, machine)
-        self.assertEqual(cfg.get_system_keymap(machine), keymap)
-        # The config format should allow both:
-        # - a list of pairs (action, keys)
-        # - a dictionary (mapping each action to keys)
-        def make_config_file(mappings):
-            return make_config('[%s]\n%s = %s\n\n' % (section, option, json.dumps(mappings)))
-        for mappings in (mappings_list, mappings_dict):
-            cfg = config.Config()
-            cfg.load(make_config_file(mappings))
-            self.assertEqual(cfg.get_system_keymap(machine), keymap)
-        # On save, a sorted list of pairs (action, keys) is expected.
-        # (to reduce differences between saves)
-        cfg = config.Config()
-        cfg.set_system_keymap(keymap, machine)
-        contents = make_config()
-        cfg.save(contents)
-        expected = make_config_file(sorted(keymap.get_mappings().items()))
-        self.assertEqual(contents.getvalue(), expected.getvalue())
-        # Check an invalid keymap is replaced by the default one.
-        cfg = config.Config()
-        default_keymap = cfg.get_system_keymap(machine)
-        cfg.load(make_config('[%s]\n%s = pouet!' % (section, option)))
-        self.assertEqual(cfg.get_system_keymap(machine), default_keymap)
+    ('simple_options',
+     '''
+     [Output Configuration]
+     space_placement = After Output
+     start_attached = true
+     start_capitalized = yes
+     undo_levels = 42
+     ''',
+     dict_replace(DEFAULTS, {
+         'space_placement': 'After Output',
+         'start_attached': True,
+         'start_capitalized': True,
+         'undo_levels': 42,
+     }),
+     {
+         'space_placement': 'Before Output',
+         'start_attached': False,
+         'start_capitalized': False,
+         'undo_levels': 200,
+     },
+     None,
+     '''
+     [Output Configuration]
+     space_placement = Before Output
+     start_attached = False
+     start_capitalized = False
+     undo_levels = 200
+     ''',
+    ),
 
-    def test_as_dict_update(self):
-        opt_list = '''
-            auto_start
-            classic_dictionaries_display_order
-            dictionaries
-            enable_stroke_logging
-            enable_translation_logging
-            enabled_extensions
-            log_file_name
-            machine_specific_options
-            machine_type
-            show_stroke_display
-            show_suggestions_display
-            space_placement
-            start_attached
-            start_capitalized
-            start_minimized
-            system_keymap
-            system_name
-            translation_frame_opacity
-            undo_levels
-        '''.split()
-        cfg = config.Config()
-        excepted_dict = {
-            opt: getattr(cfg, 'get_' + opt)()
-            for opt in opt_list
-        }
-        self.assertEqual(cfg.as_dict(), excepted_dict)
-        update = {
-            'auto_start'           : False,
-            'dictionaries'         : [DictionaryConfig('user.json', False)],
-            'enable_stroke_logging': False,
-            'space_placement'      : 'After Output',
-            'start_minimized'      : False,
-        }
-        cfg.update(**update)
-        excepted_dict.update(update)
-        self.assertEqual(cfg.as_dict(), excepted_dict)
+    ('machine_options',
+     '''
+     [Machine Configuration]
+     auto_start = True
+     machine_type = keyboard
 
-    def test_invalid_machine(self):
-        cfg = config.Config()
-        cfg.load(make_config(
-            '[%s]\n%s: %s' % (config.MACHINE_CONFIG_SECTION,
-                              'machine_type',  'foobar')
-        ))
-        self.assertEqual(cfg.get_machine_type(), config.DEFAULT_MACHINE_TYPE)
+     [Keyboard]
+     arpeggiate = True
+     ''',
+     dict_replace(DEFAULTS, {
+         'auto_start': True,
+         'machine_specific_options': dict_replace(
+             DEFAULTS['machine_specific_options'], {
+                 'arpeggiate': True,
+             }),
+     }),
+     {
+         'machine_type': 'faKY FAky',
+         'machine_specific_options': {
+                 'stroption1': 42,
+                 'floatoption1': '4.2',
+                 'booloption1': False,
+         },
+         'system_name': 'FAUX SYSTÈME',
+         'system_keymap': str(DEFAULT_KEYMAP),
+     },
+     {
+         'machine_type': 'Faky faky',
+         'machine_specific_options': dict_replace(
+             FakeMachine.DEFAULT_OPTIONS, {
+                 'stroption1': '42',
+                 'floatoption1': 4.2,
+                 'booloption1': False,
+             }),
+         'system_name': 'Faux système',
+         'system_keymap': DEFAULT_KEYMAP,
+         'dictionaries': [DictionaryConfig('utilisateur.json'),
+                          DictionaryConfig('principal.json')],
+     },
+     '''
+     [Machine Configuration]
+     auto_start = True
+     machine_type = Faky faky
+
+     [Keyboard]
+     arpeggiate = True
+
+     [Faky faky]
+     booloption1 = False
+     booloption2 = False
+     floatoption1 = 4.2
+     intoption1 = 3
+     stroption1 = 42
+     stroption2 = abc
+
+     [System]
+     name = Faux système
+
+     [System: Faux système]
+     keymap[faky faky] = %s
+     ''' % DEFAULT_KEYMAP,
+    ),
+
+    ('machine_bool_option',
+     '''
+     ''',
+     DEFAULTS,
+     {
+         'machine_specific_options': {
+                 'arpeggiate': True,
+         },
+     },
+     {
+         'machine_specific_options': {
+             'arpeggiate': True,
+         }
+     },
+     '''
+     [Keyboard]
+     arpeggiate = True
+     '''
+    ),
+
+    ('legacy_dictionaries_1',
+     '''
+     [Dictionary Configuration]
+     dictionary_file = main.json
+     ''',
+     dict_replace(DEFAULTS, {
+         'dictionaries': [DictionaryConfig('main.json')],
+     }),
+     {
+         'dictionaries': ['user.json', 'main.json'],
+     },
+     {
+         'dictionaries': [DictionaryConfig('user.json'),
+                          DictionaryConfig('main.json')],
+     },
+     '''
+     [System: English Stenotype]
+     dictionaries = [{"enabled": true, "path": "user.json"}, {"enabled": true, "path": "main.json"}]
+     '''
+    ),
+
+    ('legacy_dictionaries_2',
+     '''
+     [Dictionary Configuration]
+     dictionary_file1 = main.json
+     dictionary_file3 = user.json
+     ''',
+     dict_replace(DEFAULTS, {
+         'dictionaries': [DictionaryConfig('user.json'),
+                          DictionaryConfig('main.json')],
+     }),
+     {
+         'dictionaries': ['user.json', 'commands.json', 'main.json'],
+     },
+     {
+         'dictionaries': [DictionaryConfig('user.json'),
+                          DictionaryConfig('commands.json'),
+                          DictionaryConfig('main.json')],
+     },
+     '''
+     [System: English Stenotype]
+     dictionaries = [{"enabled": true, "path": "user.json"}, {"enabled": true, "path": "commands.json"}, {"enabled": true, "path": "main.json"}]
+     '''
+    ),
+
+    ('dictionaries',
+     '''
+     [System: English Stenotype]
+     dictionaries = %s
+     ''' % json.dumps([os.path.join(ABS_PATH, 'user.json'),
+                       "english/main.json"]),
+     dict_replace(DEFAULTS, {
+         'dictionaries': [DictionaryConfig(os.path.join(ABS_PATH, 'user.json')),
+                          DictionaryConfig('english/main.json')],
+     }),
+     {
+         'dictionaries': [DictionaryConfig(os.path.join(ABS_PATH, 'user.json')),
+                          DictionaryConfig('english/main.json')],
+     },
+     {
+         'dictionaries': [DictionaryConfig(os.path.join(ABS_PATH, 'user.json')),
+                          DictionaryConfig('english/main.json')],
+     },
+     '''
+     [System: English Stenotype]
+     dictionaries = %s
+     ''' % json.dumps([{"enabled": True, "path": os.path.join(ABS_PATH, 'user.json')},
+                       {"enabled": True, "path": os.path.join('english', 'main.json')}])
+    ),
+
+    ('invalid_config',
+     '''
+     [Startup]
+     Start Minimized = True
+
+     [Machine Configuratio
+     machine_type = Faky faky
+     ''',
+     config.InvalidConfigurationError,
+     {},
+     {},
+     '''
+     '''
+    ),
+
+    ('invalid_options_1',
+     '''
+     [System]
+     name = foobar
+     ''',
+     DEFAULTS,
+     {},
+     {},
+     None,
+    ),
+
+    ('invalid_options_2',
+     '''
+     [Machine Configuration]
+     machine_type = Faky faky
+
+     [Faky faky]
+     booloption2 = 50
+     intoption1 = 3.14
+     ''',
+     dict_replace(DEFAULTS, {
+         'machine_type': 'Faky faky',
+         'machine_specific_options': FakeMachine.DEFAULT_OPTIONS,
+     }),
+     {},
+     {},
+     None,
+    ),
+
+    ('invalid_update_1',
+     '''
+     [Translation Frame]
+     opacity = 75
+     ''',
+     dict_replace(DEFAULTS, {
+         'translation_frame_opacity': 75,
+     }),
+     {
+         'start_minimized': False,
+         'show_stroke_display': True,
+         'translation_frame_opacity': 101,
+     },
+     config.InvalidConfigOption,
+     None,
+    ),
+
+    ('invalid_update_2',
+     '''
+     ''',
+     DEFAULTS,
+     {
+         'machine_type': 'FakeMachine',
+         'machine_specific_options': dict_replace(
+             FakeMachine.DEFAULT_OPTIONS, {
+                 'stroption1': '42',
+             }),
+     },
+     config.InvalidConfigOption,
+     None,
+    ),
+
+)
+
+
+def make_config(contents=''):
+    return BytesIO(b'\n'.join(line.strip().encode('utf-8')
+                              for line in contents.split('\n')))
+def config_contents(f):
+    return f.getvalue().decode('utf-8').strip()
+
+
+@pytest.mark.parametrize(('original_contents', 'original_config',
+                          'config_update', 'validated_config_update',
+                          'resulting_contents'),
+                         [t[1:] for t in CONFIG_TESTS],
+                         ids=[t[0] for t in CONFIG_TESTS])
+def test_config(original_contents, original_config,
+                config_update, validated_config_update,
+                resulting_contents, monkeypatch):
+    registry = Registry()
+    registry.register_plugin('machine', 'Keyboard', Keyboard)
+    registry.register_plugin('machine', 'Faky faky', FakeMachine)
+    registry.register_plugin('system', 'English Stenotype', english_stenotype)
+    registry.register_plugin('system', 'Faux système', FakeSystem)
+    monkeypatch.setattr('plover.config.registry', registry)
+    # Check initial contents.
+    f = make_config(original_contents)
+    cfg = config.Config()
+    if inspect.isclass(original_config):
+        with pytest.raises(original_config):
+            cfg.load(f)
+        original_config = dict(DEFAULTS)
+        cfg.clear()
+    else:
+        cfg.load(f)
+    cfg_dict = cfg.as_dict()
+    for name, value in original_config.items():
+        assert cfg[name] == value
+        assert cfg_dict[name] == value
+    # Check updated contents.
+    if inspect.isclass(validated_config_update):
+        with pytest.raises(validated_config_update):
+            cfg.update(**config_update)
+        assert cfg.as_dict() == cfg_dict
+    else:
+        if validated_config_update is None:
+            validated_config_update = config_update
+        cfg.update(**config_update)
+        cfg_dict.update(validated_config_update)
+        assert cfg.as_dict() == cfg_dict
+    f = make_config()
+    cfg.save(f)
+    if resulting_contents is None:
+        resulting_contents = original_contents
+    assert config_contents(f) == dedent_strip(resulting_contents)

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -46,6 +46,9 @@ class FakeConfig(object):
     def load(self, fp):
         pass
 
+    def __getitem__(self, key):
+        return self._options[key]
+
     def as_dict(self):
         return dict(self._options)
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -4,6 +4,7 @@
 
 """Tests for misc.py."""
 
+import inspect
 import os
 import sys
 
@@ -56,3 +57,35 @@ def test_dictionary_path(short_path, full_path):
         function = '%s_path' % function
         result = getattr(misc, function)(input)
         assert result == expected, function
+
+@pytest.mark.parametrize(('input', 'output'), (
+    # Boolean.
+    (False, False),
+    (True, True),
+    # True string values.
+    ('1', True),
+    ('yes', True),
+    ('true', True),
+    ('on', True),
+    # False string values.
+    ('0', False),
+    ('no', False),
+    ('false', False),
+    ('off', False),
+    # Invalid string values.
+    ('yep', ValueError),
+    ('nope', ValueError),
+    # Other types.
+    (0, False),
+    (1, True),
+    (42, True),
+    (4.2, True),
+    (0.0, False),
+    (None, False),
+))
+def test_boolean(input, output):
+    if inspect.isclass(output):
+        with pytest.raises(output):
+            misc.boolean(input)
+    else:
+        assert misc.boolean(input) == output


### PR DESCRIPTION
Right now, configuration settings are only validated for correctness when loading from the configuration file. While this is not really an issue when those are changed through our GUI, plugins can now update the configuration (e.g. the `plover_dict_commands` plugin).

This PR overhaul the way the configuration is handled so:
- all custom set/get accessors are removed in favor of a standard mapping API:
```
config.set_machine_type("Keyboard") -> config["machine_type"] = "Keyboard"
```
- all options are validated on set/update too
- updates are all or nothing: nothing is updated if one of the options is invalid