### PR TITLE
log: open log file as utf-8 to handle unicode strokes and output.

### DIFF
--- a/plover/log.py
+++ b/plover/log.py
@@ -46,7 +46,8 @@ class FileHandler(RotatingFileHandler):
     def __init__(self, filename=LOG_FILENAME, format=LOG_FORMAT):
         super(FileHandler, self).__init__(filename,
                                           maxBytes=LOG_MAX_BYTES,
-                                          backupCount=LOG_COUNT)
+                                          backupCount=LOG_COUNT,
+                                          encoding='utf-8')
         self.setFormatter(logging.Formatter(format))
 
 


### PR DESCRIPTION
<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
If a system contains unicode keys in strokes or outputs unicode via a dictionary then a UnicodeEncodeError is thrown due to character map encoding issues and that entry is not logged properly (provided stroke / translation logging is enabled).

<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
I set the file handler for logging to always open as utf-8 rather than no encoding so that it does not run into the issue.

I have tested on Windows 10 and unicode characters show up in the log as expected now with no errors thrown.