### PR TITLE
linux/appimage: improve support for package installs from source

### DIFF
--- a/linux/appimage/apprun.sh
+++ b/linux/appimage/apprun.sh
@@ -4,6 +4,8 @@ appimage_setenv()
 {
   export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
   export PATH="${APPDIR}/usr/bin:${PATH}"
+  # Patch LDFLAGS so installing some Python packages from source can work.
+  export LDFLAGS="-L${APPDIR}/usr/lib/x86_64-linux-gnu -L${APPDIR}/usr/lib"
 }
 
 appimage_install()

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -90,6 +90,8 @@ then
 fi
 run "${cmd[@]}"
 run make "${make_opts[@]}"
+# Drop the need for ccache when installing some Python packages from source.
+run sed -i 's/ccache //g' "$(find build -name '_sysconfigdata_m_*.py')"
 run make "${make_opts[@]}" install >/dev/null
 )
 info ')'


### PR DESCRIPTION
- remove the need for ccache being installed
- fix possible linking errors