### PR TITLE
Python 3 related tweaks

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -295,7 +295,7 @@ def dictionaries_option():
     return ConfigOption('dictionaries', default, getter, setter, validate, full_key)
 
 
-class Config(object):
+class Config:
 
     def __init__(self):
         self._config = None

--- a/plover/config.py
+++ b/plover/config.py
@@ -41,7 +41,7 @@ SYSTEM_KEYMAP_OPTION = 'keymap[%s]'
 class DictionaryConfig(namedtuple('DictionaryConfig', 'path enabled')):
 
     def __new__(cls, path, enabled=True):
-        return super(DictionaryConfig, cls).__new__(cls, expand_path(path), enabled)
+        return super().__new__(cls, expand_path(path), enabled)
 
     @property
     def short_path(self):

--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -36,6 +36,6 @@ class JsonDictionary(StenoDictionary):
     def _save(self, filename):
         with open(filename, 'wb') as fp:
             writer = codecs.getwriter('utf-8')(fp)
-            json.dump(dict(('/'.join(k), v) for k, v in self.items()),
+            json.dump({'/'.join(k): v for k, v in self.items()},
                       writer, ensure_ascii=False, sort_keys=True,
                       indent=0, separators=(',', ': '))

--- a/plover/dictionary/loading_manager.py
+++ b/plover/dictionary/loading_manager.py
@@ -12,7 +12,7 @@ from plover.resource import resource_timestamp
 from plover import log
 
 
-class DictionaryLoadingManager(object):
+class DictionaryLoadingManager:
 
     def __init__(self):
         self.dictionaries = {}
@@ -52,7 +52,7 @@ class DictionaryLoadingManager(object):
         return results
 
 
-class DictionaryLoadingOperation(object):
+class DictionaryLoadingOperation:
 
     def __init__(self, filename):
         self.loading_thread = threading.Thread(target=self.load)

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -281,7 +281,7 @@ STYLESHEET_RE = re.compile(r'(?s){\\s([0-9]+).*?((?:\b\w+\b\s*)+);}')
 
 def load_stylesheet(s):
     """Returns a dictionary mapping a number to a style name."""
-    return dict((int(k), v) for k, v in STYLESHEET_RE.findall(s))
+    return {int(k): v for k, v in STYLESHEET_RE.findall(s)}
 
 HEADER = ("{\\rtf1\\ansi{\\*\\cxrev100}\\cxdict{\\*\\cxsystem Plover}" +
           "{\\stylesheet{\\s0 Normal;}}\r\n")

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -29,7 +29,7 @@ DICT_ENTRY_PATTERN = re.compile(r'(?s)(?<!\\){\\\*\\cxs (?P<steno>[^}]+)}' +
                                 r'(?=(?:(?<!\\){\\\*\\cxs [^}]+})|' +
                                 r'(?:(?:(?<!\\)(?:\r\n|\n)\s*)*}\s*\Z))')
 
-class TranslationConverter(object):
+class TranslationConverter:
     """Convert an RTF/CRE translation into plover's internal format."""
     
     def __init__(self, styles={}):

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -72,7 +72,7 @@ def with_lock(func):
     return _with_lock
 
 
-class StenoEngine(object):
+class StenoEngine:
 
     HOOKS = '''
     stroked

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -28,7 +28,7 @@ class ErroredDictionary(StenoDictionary):
     """ Placeholder for dictionaries that failed to load. """
 
     def __init__(self, path, exception):
-        super(ErroredDictionary, self).__init__()
+        super().__init__()
         self.enabled = False
         self.readonly = True
         self.path = path

--- a/plover/exception.py
+++ b/plover/exception.py
@@ -16,7 +16,7 @@ class DictionaryLoaderException(Exception):
     """Dictionary file could not be loaded."""
 
     def __init__(self, path, exception):
-        super(DictionaryLoaderException, self).__init__(path, exception)
+        super().__init__(path, exception)
         self.path = path
         self.exception = exception
 

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -88,7 +88,7 @@ META_RE = re.compile(r"""(?:%s%s|%s%s|[^%s%s])+ # One or more of anything
 WORD_RX = re.compile(r'(?:\d+(?:[.,]\d+)+|[\'\w]+[-\w\']*|[^\w\s]+)\s*', re.UNICODE)
 
 
-class RetroFormatter(object):
+class RetroFormatter:
     """Helper for iterating over the result of previous translations.
 
     Support iterating over previous actions, text, fragments of text, or words:
@@ -227,7 +227,7 @@ class _Context(RetroFormatter):
             yield action
 
 
-class Formatter(object):
+class Formatter:
     """Convert translations into output.
 
     The main entry point for this class is format, which takes in translations
@@ -368,7 +368,7 @@ class Formatter(object):
         self.last_output_spaces_after = self.spaces_after
 
 
-class TextFormatter(object):
+class TextFormatter:
     """Format a series of action into text."""
 
     def __init__(self, spaces_after):
@@ -430,7 +430,7 @@ class TextFormatter(object):
         self.appended_text = trailing_space
 
 
-class OutputHelper(object):
+class OutputHelper:
     """A helper class for minimizing the amount of change on output.
 
     This class figures out the current state, compares it to the new output and
@@ -481,7 +481,7 @@ class OutputHelper(object):
         self.flush()
 
 
-class _Action(object):
+class _Action:
     """A hybrid class that stores instructions and resulting state.
 
     A single translation may be formatted into one or more actions. The

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -200,7 +200,7 @@ class _Context(RetroFormatter):
     """
 
     def __init__(self, previous_translations, last_action):
-        super(_Context, self).__init__(previous_translations)
+        super().__init__(previous_translations)
         assert last_action is not None
         self.last_action = last_action
         self.translated_actions = []
@@ -223,7 +223,7 @@ class _Context(RetroFormatter):
         """Custom iterator with support for newly translated actions."""
         for action in reversed(self.translated_actions):
             yield action
-        for action in super(_Context, self).iter_last_actions():
+        for action in super().iter_last_actions():
             yield action
 
 

--- a/plover/gui_none/add_translation.py
+++ b/plover/gui_none/add_translation.py
@@ -64,7 +64,7 @@ class AddTranslation(object):
                 return
             self._strokes = tuple(s.rtfcre for s in strokes)
             self._clear_state(undo=True)
-            self._translation = u''
+            self._translation = ''
             self._status = 'translations'
             self._engine.hook_connect('send_string', self.send_string)
             self._engine.hook_connect('send_backspaces', self.send_backspaces)

--- a/plover/gui_none/add_translation.py
+++ b/plover/gui_none/add_translation.py
@@ -2,7 +2,7 @@
 from plover.engine import StartingStrokeState
 
 
-class AddTranslation(object):
+class AddTranslation:
 
     def __init__(self, engine):
         self._status = None

--- a/plover/gui_qt/about_dialog.py
+++ b/plover/gui_qt/about_dialog.py
@@ -13,7 +13,7 @@ class AboutDialog(QDialog, Ui_AboutDialog):
     ROLE = 'about'
 
     def __init__(self, engine):
-        super(AboutDialog, self).__init__()
+        super().__init__()
         self.setupUi(self)
         credits = []
         for c in plover.__credits__:

--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -21,7 +21,7 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
     SHORTCUT = 'Ctrl+N'
 
     def __init__(self, engine, dictionary_path=None):
-        super(AddTranslationDialog, self).__init__(engine)
+        super().__init__(engine)
         self.setupUi(self)
         self.add_translation.select_dictionary(dictionary_path)
         engine.signal_connect('config_changed', self.on_config_changed)
@@ -40,8 +40,8 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
 
     def accept(self):
         self.add_translation.save_entry()
-        super(AddTranslationDialog, self).accept()
+        super().accept()
 
     def reject(self):
         self.add_translation.reject()
-        super(AddTranslationDialog, self).reject()
+        super().reject()

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -24,7 +24,7 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
     EngineState = namedtuple('EngineState', 'dictionary_filter translator starting_stroke')
 
     def __init__(self, *args, **kwargs):
-        super(AddTranslationWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setupUi(self)
         engine = QApplication.instance().engine
         self._engine = engine

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -249,7 +249,7 @@ class BooleanAsDualChoiceOption(ChoiceOption):
         super().__init__(choices)
 
 
-class ConfigOption(object):
+class ConfigOption:
 
     def __init__(self, display_name, option_name, widget_class,
                  help_text='', dependents=()):

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -39,7 +39,7 @@ class NopeOption(QLabel):
     valueChanged = pyqtSignal(bool)
 
     def __init__(self):
-        super(NopeOption, self).__init__()
+        super().__init__()
         self.setText(_('Nothing to see here!'))
 
     def setValue(self, value):
@@ -51,7 +51,7 @@ class BooleanOption(QCheckBox):
     valueChanged = pyqtSignal(bool)
 
     def __init__(self):
-        super(BooleanOption, self).__init__()
+        super().__init__()
         self.stateChanged.connect(lambda: self.valueChanged.emit(self.isChecked()))
 
     def setValue(self, value):
@@ -61,7 +61,7 @@ class BooleanOption(QCheckBox):
 class IntOption(QSpinBox):
 
     def __init__(self, maximum=None, minimum=None):
-        super(IntOption, self).__init__()
+        super().__init__()
         if maximum is not None:
             self.setMaximum(maximum)
         if minimum is not None:
@@ -73,7 +73,7 @@ class ChoiceOption(QComboBox):
     valueChanged = pyqtSignal(str)
 
     def __init__(self, choices=None):
-        super(ChoiceOption, self).__init__()
+        super().__init__()
         self._choices = {} if choices is None else choices
         self._reversed_choices = {
             translation: choice
@@ -96,7 +96,7 @@ class FileOption(QWidget, Ui_FileWidget):
     valueChanged = pyqtSignal(str)
 
     def __init__(self, dialog_title, dialog_filter):
-        super(FileOption, self).__init__()
+        super().__init__()
         self._dialog_title = dialog_title
         self._dialog_filter = dialog_filter
         self.setupUi(self)
@@ -127,7 +127,7 @@ class KeymapOption(QTableWidget):
     class ItemDelegate(QStyledItemDelegate):
 
         def __init__(self, action_list):
-            super(KeymapOption.ItemDelegate, self).__init__()
+            super().__init__()
             self._action_list = action_list
 
         def createEditor(self, parent, option, index):
@@ -136,10 +136,10 @@ class KeymapOption(QTableWidget):
                 combo.addItem('')
                 combo.addItems(self._action_list)
                 return combo
-            return super(KeymapOption.ItemDelegate, self).createEditor(parent, option, index)
+            return super().createEditor(parent, option, index)
 
     def __init__(self):
-        super(KeymapOption, self).__init__()
+        super().__init__()
         self._value = []
         self._updating = False
         self.setColumnCount(2)
@@ -190,7 +190,7 @@ class MultipleChoicesOption(QTableWidget):
     valueChanged = pyqtSignal(QVariant)
 
     def __init__(self, choices=None, labels=(_('Choice'), _('Selected'))):
-        super(MultipleChoicesOption, self).__init__()
+        super().__init__()
         self._value = {}
         self._updating = False
         self._choices = {} if choices is None else choices
@@ -246,7 +246,7 @@ class BooleanAsDualChoiceOption(ChoiceOption):
 
     def __init__(self, choice_false, choice_true):
         choices = { False: choice_false, True: choice_true }
-        super(BooleanAsDualChoiceOption, self).__init__(choices)
+        super().__init__(choices)
 
 
 class ConfigOption(object):
@@ -267,7 +267,7 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
     ROLE = 'configuration'
 
     def __init__(self, engine):
-        super(ConfigWindow, self).__init__()
+        super().__init__()
         self.setupUi(self)
         self._engine = engine
         machines = {
@@ -443,7 +443,7 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
         # Disable Enter/Return key to trigger "OK".
         if event.key() in (Qt.Key_Enter, Qt.Key_Return):
             return
-        super(ConfigWindow, self).keyPressEvent(event)
+        super().keyPressEvent(event)
 
     def on_option_changed(self, option, value):
         self._config[option.option_name] = value

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -53,7 +53,7 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
     add_translation = pyqtSignal(QVariant)
 
     def __init__(self, *args, **kwargs):
-        super(DictionariesWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setupUi(self)
         engine = QApplication.instance().engine
         self._engine = engine

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -30,9 +30,9 @@ from plover.gui_qt.utils import ToolBar
 
 
 def _dictionary_formats(include_readonly=True):
-    return set(plugin.name
-               for plugin in registry.list_plugins('dictionary')
-               if include_readonly or not plugin.obj.readonly)
+    return {plugin.name
+            for plugin in registry.list_plugins('dictionary')
+            if include_readonly or not plugin.obj.readonly}
 
 def _dictionary_filters(include_readonly=True):
     formats = sorted(_dictionary_formats(include_readonly=include_readonly))

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -35,7 +35,7 @@ class DictionaryItem(namedtuple('DictionaryItem', 'strokes translation dictionar
 class DictionaryItemDelegate(QStyledItemDelegate):
 
     def __init__(self, dictionary_list):
-        super(DictionaryItemDelegate, self).__init__()
+        super().__init__()
         self._dictionary_list = dictionary_list
 
     def createEditor(self, parent, option, index):
@@ -48,13 +48,13 @@ class DictionaryItemDelegate(QStyledItemDelegate):
             combo = QComboBox(parent)
             combo.addItems(dictionary_paths)
             return combo
-        return super(DictionaryItemDelegate, self).createEditor(parent, option, index)
+        return super().createEditor(parent, option, index)
 
 
 class DictionaryItemModel(QAbstractTableModel):
 
     def __init__(self, dictionary_list, sort_column, sort_order):
-        super(DictionaryItemModel, self).__init__()
+        super().__init__()
         self._dictionary_list = dictionary_list
         self._operations = []
         self._entries = []
@@ -276,7 +276,7 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
     ROLE = 'dictionary_editor'
 
     def __init__(self, engine, dictionary_paths):
-        super(DictionaryEditor, self).__init__()
+        super().__init__()
         self.setupUi(self)
         self._engine = engine
         with engine:

--- a/plover/gui_qt/engine.py
+++ b/plover/gui_qt/engine.py
@@ -53,7 +53,7 @@ class Engine(StenoEngine, QThread):
         if sys.platform.startswith('darwin'):
             import appnope
             appnope.nope()
-        super(Engine, self).run()
+        super().run()
 
     def signal_connect(self, name, callback):
         self._signals[name].connect(callback)

--- a/plover/gui_qt/log_qt.py
+++ b/plover/gui_qt/log_qt.py
@@ -11,7 +11,7 @@ class NotificationHandler(QObject, logging.Handler):
     emitSignal = pyqtSignal(int, str)
 
     def __init__(self):
-        super(NotificationHandler, self).__init__()
+        super().__init__()
         self.setLevel(log.WARNING)
         self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
 

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -21,7 +21,7 @@ class LookupDialog(Tool, Ui_LookupDialog):
     SHORTCUT = 'Ctrl+L'
 
     def __init__(self, engine):
-        super(LookupDialog, self).__init__(engine)
+        super().__init__(engine)
         self.setupUi(self)
         self.pattern.installEventFilter(self)
         self.suggestions.installEventFilter(self)

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -19,7 +19,7 @@ class SerialOption(QWidget, Ui_SerialWidget):
     valueChanged = pyqtSignal(QVariant)
 
     def __init__(self):
-        super(SerialOption, self).__init__()
+        super().__init__()
         self.setupUi(self)
         self._value = {}
 
@@ -100,7 +100,7 @@ class KeyboardOption(QWidget, Ui_KeyboardWidget):
     valueChanged = pyqtSignal(QVariant)
 
     def __init__(self):
-        super(KeyboardOption, self).__init__()
+        super().__init__()
         self.setupUi(self)
         self.arpeggiate.setToolTip(_(
             'Arpeggiate allows using non-NKRO keyboards.\n'

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -19,7 +19,7 @@ from plover.gui_qt.engine import Engine
 from plover.gui_qt.i18n import get_language, install_gettext
 
 
-class Application(object):
+class Application:
 
     def __init__(self, config, use_qt_notifications):
 

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -27,7 +27,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
     ROLE = 'main'
 
     def __init__(self, engine, use_qt_notifications):
-        super(MainWindow, self).__init__()
+        super().__init__()
         self.setupUi(self)
         if hasattr(self, 'setUnifiedTitleAndToolBarOnMac'):
             self.setUnifiedTitleAndToolBarOnMac(True)

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -35,7 +35,7 @@ class PaperTape(Tool, Ui_PaperTape):
     STYLES = (STYLE_PAPER, STYLE_RAW)
 
     def __init__(self, engine):
-        super(PaperTape, self).__init__(engine)
+        super().__init__(engine)
         self.setupUi(self)
         self._strokes = []
         self._all_keys = None

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -44,7 +44,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
     #    - 1-10 "strokes" frames
 
     def __init__(self, engine):
-        super(SuggestionsDialog, self).__init__(engine)
+        super().__init__(engine)
         self.setupUi(self)
         self._last_suggestions = None
         # Toolbar.

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -36,15 +36,15 @@ class SuggestionsWidget(QWidget, Ui_SuggestionsWidget):
             cursor.insertBlock()
             cursor.setCharFormat(self._translation_char_format)
             cursor.block().setUserState(self.STYLE_TRANSLATION)
-            cursor.insertText(escape_translation(suggestion.text) + u':')
+            cursor.insertText(escape_translation(suggestion.text) + ':')
             if not suggestion.steno_list:
-                cursor.insertText(u' ' + _('no suggestions'))
+                cursor.insertText(' ' + _('no suggestions'))
                 continue
             for strokes_list in suggestion.steno_list[:10]:
                 cursor.insertBlock()
                 cursor.setCharFormat(self._strokes_char_format)
                 cursor.block().setUserState(self.STYLE_STROKES)
-                cursor.insertText(u'   ' + u'/'.join(strokes_list))
+                cursor.insertText('   ' + '/'.join(strokes_list))
         cursor.insertText('\n')
         # Keep current position when not at the end of the document.
         if scroll_at_end:

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -21,7 +21,7 @@ class SuggestionsWidget(QWidget, Ui_SuggestionsWidget):
     #    - 1-10 "strokes" blocks
 
     def __init__(self, *args, **kwargs):
-        super(SuggestionsWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setupUi(self)
         self._translation_char_format = QTextCharFormat()
         self._strokes_char_format = QTextCharFormat()

--- a/plover/gui_qt/tool.py
+++ b/plover/gui_qt/tool.py
@@ -15,7 +15,7 @@ class Tool(QDialog, WindowState):
     # Note: the class documentation is automatically used as tooltip.
 
     def __init__(self, engine):
-        super(Tool, self).__init__()
+        super().__init__()
         self._update_title()
         self._engine = engine
 
@@ -23,5 +23,5 @@ class Tool(QDialog, WindowState):
         self.setWindowTitle('Plover: ' + self.TITLE)
 
     def setupUi(self, widget):
-        super(Tool, self).setupUi(widget)
+        super().setupUi(widget)
         self._update_title()

--- a/plover/gui_qt/trayicon.py
+++ b/plover/gui_qt/trayicon.py
@@ -11,7 +11,7 @@ from plover import log
 class TrayIcon(QObject):
 
     def __init__(self):
-        super(TrayIcon, self).__init__()
+        super().__init__()
         self._supported = QSystemTrayIcon.isSystemTrayAvailable()
         self._context_menu = None
         self._enabled = False

--- a/plover/key_combo.py
+++ b/plover/key_combo.py
@@ -18,111 +18,111 @@ KEYNAME_TO_CHAR = {
     #     if us == kn or not us:
     #         continue
     # print '    %-20r: %8r, # %s' % (kn, us, us)
-    'aacute'            :  u'\xe1', # á
-    'acircumflex'       :  u'\xe2', # â
-    'acute'             :  u'\xb4', # ´
-    'adiaeresis'        :  u'\xe4', # ä
-    'ae'                :  u'\xe6', # æ
-    'agrave'            :  u'\xe0', # à
-    'ampersand'         :     u'&', # &
-    'apostrophe'        :     u"'", # '
-    'aring'             :  u'\xe5', # å
-    'asciicircum'       :     u'^', # ^
-    'asciitilde'        :     u'~', # ~
-    'asterisk'          :     u'*', # *
-    'at'                :     u'@', # @
-    'atilde'            :  u'\xe3', # ã
-    'backslash'         :    u'\\', # \
-    'bar'               :     u'|', # |
-    'braceleft'         :     u'{', # {
-    'braceright'        :     u'}', # }
-    'bracketleft'       :     u'[', # [
-    'bracketright'      :     u']', # ]
-    'brokenbar'         :  u'\xa6', # ¦
-    'ccedilla'          :  u'\xe7', # ç
-    'cedilla'           :  u'\xb8', # ¸
-    'cent'              :  u'\xa2', # ¢
-    'clear'             :   '\x0b', # 
-    'colon'             :     u':', # :
-    'comma'             :     u',', # ,
-    'copyright'         :  u'\xa9', # ©
-    'currency'          :  u'\xa4', # ¤
-    'degree'            :  u'\xb0', # °
-    'diaeresis'         :  u'\xa8', # ¨
-    'division'          :  u'\xf7', # ÷
-    'dollar'            :     u'$', # $
-    'eacute'            :  u'\xe9', # é
-    'ecircumflex'       :  u'\xea', # ê
-    'ediaeresis'        :  u'\xeb', # ë
-    'egrave'            :  u'\xe8', # è
-    'equal'             :     u'=', # =
-    'eth'               :  u'\xf0', # ð
-    'exclam'            :     u'!', # !
-    'exclamdown'        :  u'\xa1', # ¡
-    'grave'             :     u'`', # `
-    'greater'           :     u'>', # >
-    'guillemotleft'     :  u'\xab', # «
-    'guillemotright'    :  u'\xbb', # »
-    'hyphen'            :  u'\xad', # ­
-    'iacute'            :  u'\xed', # í
-    'icircumflex'       :  u'\xee', # î
-    'idiaeresis'        :  u'\xef', # ï
-    'igrave'            :  u'\xec', # ì
-    'less'              :     u'<', # <
-    'macron'            :  u'\xaf', # ¯
-    'masculine'         :  u'\xba', # º
-    'minus'             :     u'-', # -
-    'mu'                :  u'\xb5', # µ
-    'multiply'          :  u'\xd7', # ×
-    'nobreakspace'      :  u'\xa0', #  
-    'notsign'           :  u'\xac', # ¬
-    'ntilde'            :  u'\xf1', # ñ
-    'numbersign'        :     u'#', # #
-    'oacute'            :  u'\xf3', # ó
-    'ocircumflex'       :  u'\xf4', # ô
-    'odiaeresis'        :  u'\xf6', # ö
-    'ograve'            :  u'\xf2', # ò
-    'onehalf'           :  u'\xbd', # ½
-    'onequarter'        :  u'\xbc', # ¼
-    'onesuperior'       :  u'\xb9', # ¹
-    'ooblique'          :  u'\xd8', # Ø
-    'ordfeminine'       :  u'\xaa', # ª
-    'oslash'            :  u'\xf8', # ø
-    'otilde'            :  u'\xf5', # õ
-    'paragraph'         :  u'\xb6', # ¶
-    'parenleft'         :     u'(', # (
-    'parenright'        :     u')', # )
-    'percent'           :     u'%', # %
-    'period'            :     u'.', # .
-    'periodcentered'    :  u'\xb7', # ·
-    'plus'              :     u'+', # +
-    'plusminus'         :  u'\xb1', # ±
-    'question'          :     u'?', # ?
-    'questiondown'      :  u'\xbf', # ¿
-    'quotedbl'          :     u'"', # "
-    'quoteleft'         :     u'`', # `
-    'quoteright'        :     u"'", # '
-    'registered'        :  u'\xae', # ®
-    'return'            :     '\r', # 
-    'section'           :  u'\xa7', # §
-    'semicolon'         :     u';', # ;
-    'slash'             :     u'/', # /
-    'space'             :     u' ', #  
-    'ssharp'            :  u'\xdf', # ß
-    'sterling'          :  u'\xa3', # £
-    'tab'               :     '\t', # 	
-    'thorn'             :  u'\xfe', # þ
-    'threequarters'     :  u'\xbe', # ¾
-    'threesuperior'     :  u'\xb3', # ³
-    'twosuperior'       :  u'\xb2', # ²
-    'uacute'            :  u'\xfa', # ú
-    'ucircumflex'       :  u'\xfb', # û
-    'udiaeresis'        :  u'\xfc', # ü
-    'ugrave'            :  u'\xf9', # ù
-    'underscore'        :     u'_', # _
-    'yacute'            :  u'\xfd', # ý
-    'ydiaeresis'        :  u'\xff', # ÿ
-    'yen'               :  u'\xa5', # ¥
+    'aacute'            :  '\xe1', # á
+    'acircumflex'       :  '\xe2', # â
+    'acute'             :  '\xb4', # ´
+    'adiaeresis'        :  '\xe4', # ä
+    'ae'                :  '\xe6', # æ
+    'agrave'            :  '\xe0', # à
+    'ampersand'         :     '&', # &
+    'apostrophe'        :     "'", # '
+    'aring'             :  '\xe5', # å
+    'asciicircum'       :     '^', # ^
+    'asciitilde'        :     '~', # ~
+    'asterisk'          :     '*', # *
+    'at'                :     '@', # @
+    'atilde'            :  '\xe3', # ã
+    'backslash'         :    '\\', # \
+    'bar'               :     '|', # |
+    'braceleft'         :     '{', # {
+    'braceright'        :     '}', # }
+    'bracketleft'       :     '[', # [
+    'bracketright'      :     ']', # ]
+    'brokenbar'         :  '\xa6', # ¦
+    'ccedilla'          :  '\xe7', # ç
+    'cedilla'           :  '\xb8', # ¸
+    'cent'              :  '\xa2', # ¢
+    'clear'             :  '\x0b', # 
+    'colon'             :     ':', # :
+    'comma'             :     ',', # ,
+    'copyright'         :  '\xa9', # ©
+    'currency'          :  '\xa4', # ¤
+    'degree'            :  '\xb0', # °
+    'diaeresis'         :  '\xa8', # ¨
+    'division'          :  '\xf7', # ÷
+    'dollar'            :     '$', # $
+    'eacute'            :  '\xe9', # é
+    'ecircumflex'       :  '\xea', # ê
+    'ediaeresis'        :  '\xeb', # ë
+    'egrave'            :  '\xe8', # è
+    'equal'             :     '=', # =
+    'eth'               :  '\xf0', # ð
+    'exclam'            :     '!', # !
+    'exclamdown'        :  '\xa1', # ¡
+    'grave'             :     '`', # `
+    'greater'           :     '>', # >
+    'guillemotleft'     :  '\xab', # «
+    'guillemotright'    :  '\xbb', # »
+    'hyphen'            :  '\xad', # ­
+    'iacute'            :  '\xed', # í
+    'icircumflex'       :  '\xee', # î
+    'idiaeresis'        :  '\xef', # ï
+    'igrave'            :  '\xec', # ì
+    'less'              :     '<', # <
+    'macron'            :  '\xaf', # ¯
+    'masculine'         :  '\xba', # º
+    'minus'             :     '-', # -
+    'mu'                :  '\xb5', # µ
+    'multiply'          :  '\xd7', # ×
+    'nobreakspace'      :  '\xa0', #  
+    'notsign'           :  '\xac', # ¬
+    'ntilde'            :  '\xf1', # ñ
+    'numbersign'        :     '#', # #
+    'oacute'            :  '\xf3', # ó
+    'ocircumflex'       :  '\xf4', # ô
+    'odiaeresis'        :  '\xf6', # ö
+    'ograve'            :  '\xf2', # ò
+    'onehalf'           :  '\xbd', # ½
+    'onequarter'        :  '\xbc', # ¼
+    'onesuperior'       :  '\xb9', # ¹
+    'ooblique'          :  '\xd8', # Ø
+    'ordfeminine'       :  '\xaa', # ª
+    'oslash'            :  '\xf8', # ø
+    'otilde'            :  '\xf5', # õ
+    'paragraph'         :  '\xb6', # ¶
+    'parenleft'         :     '(', # (
+    'parenright'        :     ')', # )
+    'percent'           :     '%', # %
+    'period'            :     '.', # .
+    'periodcentered'    :  '\xb7', # ·
+    'plus'              :     '+', # +
+    'plusminus'         :  '\xb1', # ±
+    'question'          :     '?', # ?
+    'questiondown'      :  '\xbf', # ¿
+    'quotedbl'          :     '"', # "
+    'quoteleft'         :     '`', # `
+    'quoteright'        :     "'", # '
+    'registered'        :  '\xae', # ®
+    'return'            :    '\r', # 
+    'section'           :  '\xa7', # §
+    'semicolon'         :     ';', # ;
+    'slash'             :     '/', # /
+    'space'             :     ' ', #  
+    'ssharp'            :  '\xdf', # ß
+    'sterling'          :  '\xa3', # £
+    'tab'               :    '\t', # 	
+    'thorn'             :  '\xfe', # þ
+    'threequarters'     :  '\xbe', # ¾
+    'threesuperior'     :  '\xb3', # ³
+    'twosuperior'       :  '\xb2', # ²
+    'uacute'            :  '\xfa', # ú
+    'ucircumflex'       :  '\xfb', # û
+    'udiaeresis'        :  '\xfc', # ü
+    'ugrave'            :  '\xf9', # ù
+    'underscore'        :     '_', # _
+    'yacute'            :  '\xfd', # ý
+    'ydiaeresis'        :  '\xff', # ÿ
+    'yen'               :  '\xa5', # ¥
 }
 for char in (
     '0123456789'
@@ -148,10 +148,10 @@ def parse_key_combo(combo_string, key_name_to_key_code=None):
     count = 0
 
     def _raise_error(exception, details):
-        msg = u'%s in "%s"' % (
+        msg = '%s in "%s"' % (
             details,
             combo_string[:count] +
-            u'[' + token + u']' +
+            '[' + token + ']' +
             combo_string[count+len(token):],
         )
         raise exception(msg)
@@ -165,7 +165,7 @@ def parse_key_combo(combo_string, key_name_to_key_code=None):
 
         elif re.match(r'\w', token):
 
-            if token.endswith(u'('):
+            if token.endswith('('):
                 key_name = token[:-1].rstrip().lower()
                 release = False
             else:
@@ -176,7 +176,7 @@ def parse_key_combo(combo_string, key_name_to_key_code=None):
             if key_code is None:
                 _raise_error(ValueError, 'unknown key')
             elif key_code in down_keys:
-                _raise_error(ValueError, u'key "%s" already pressed' % key_name)
+                _raise_error(ValueError, 'key "%s" already pressed' % key_name)
 
             key_events.append((key_code, True))
 
@@ -185,19 +185,19 @@ def parse_key_combo(combo_string, key_name_to_key_code=None):
             else:
                 down_keys.append(key_code)
 
-        elif token == u')':
+        elif token == ')':
             if not down_keys:
-                _raise_error(SyntaxError, u'unbalanced ")"')
+                _raise_error(SyntaxError, 'unbalanced ")"')
             key_code = down_keys.pop()
             key_events.append((key_code, False))
 
         else:
-            _raise_error(SyntaxError, u'invalid character "%s"' % token)
+            _raise_error(SyntaxError, 'invalid character "%s"' % token)
 
         count += len(token)
 
     if down_keys:
-        _raise_error(SyntaxError, u'unbalanced "("')
+        _raise_error(SyntaxError, 'unbalanced "("')
 
     return key_events
 

--- a/plover/log.py
+++ b/plover/log.py
@@ -38,7 +38,7 @@ class NoExceptionTracebackFormatter(logging.Formatter):
     def formatException(self, exc_info):
         etype, evalue, tb = exc_info
         lines = traceback.format_exception_only(etype, evalue)
-        return u''.join(lines)
+        return ''.join(lines)
 
 
 class FileHandler(RotatingFileHandler):

--- a/plover/log.py
+++ b/plover/log.py
@@ -31,7 +31,7 @@ class NoExceptionTracebackFormatter(logging.Formatter):
         orig_exc_text = record.exc_text
         record.exc_text = None
         try:
-            return super(NoExceptionTracebackFormatter, self).format(record)
+            return super().format(record)
         finally:
             record.exc_text = orig_exc_text
 
@@ -44,10 +44,10 @@ class NoExceptionTracebackFormatter(logging.Formatter):
 class FileHandler(RotatingFileHandler):
 
     def __init__(self, filename=LOG_FILENAME, format=LOG_FORMAT):
-        super(FileHandler, self).__init__(filename,
-                                          maxBytes=LOG_MAX_BYTES,
-                                          backupCount=LOG_COUNT,
-                                          encoding='utf-8')
+        super().__init__(filename,
+                         maxBytes=LOG_MAX_BYTES,
+                         backupCount=LOG_COUNT,
+                         encoding='utf-8')
         self.setFormatter(logging.Formatter(format))
 
 
@@ -55,7 +55,7 @@ class PrintHandler(logging.StreamHandler):
     """ Handler using L{print_} to output messages. """
 
     def __init__(self, format=LOG_FORMAT):
-        super(PrintHandler, self).__init__(sys.stderr)
+        super().__init__(sys.stderr)
         self.setFormatter(logging.Formatter(format))
 
 

--- a/plover/log.py
+++ b/plover/log.py
@@ -59,7 +59,7 @@ class PrintHandler(logging.StreamHandler):
         self.setFormatter(logging.Formatter(format))
 
 
-class Logger(object):
+class Logger:
 
     def __init__(self):
         self._print_handler = PrintHandler()

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -22,7 +22,7 @@ STATE_RUNNING = 'connected'
 STATE_ERROR = 'disconnected'
 
 
-class StenotypeBase(object):
+class StenotypeBase:
     """The base class for all Stenotype classes."""
 
     # Layout of physical keys.

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -23,7 +23,7 @@ class Keyboard(StenotypeBase):
 
     def __init__(self, params):
         """Monitor the keyboard's events."""
-        super(Keyboard, self).__init__()
+        super().__init__()
         self._arpeggiate = params['arpeggiate']
         self._is_suppressed = False
         # Currently held keys.
@@ -57,7 +57,7 @@ class Keyboard(StenotypeBase):
         self._suppress()
 
     def set_keymap(self, keymap):
-        super(Keyboard, self).set_keymap(keymap)
+        super().set_keymap(keymap)
         self._update_bindings()
 
     def start_capture(self):

--- a/plover/machine/keyboard.py
+++ b/plover/machine/keyboard.py
@@ -112,7 +112,7 @@ class Keyboard(StenotypeBase):
         ):
             return
         self._last_stroke_key_down_count = self._stroke_key_down_count
-        steno_keys = set(self._bindings.get(k) for k in self._stroke_keys)
+        steno_keys = {self._bindings.get(k) for k in self._stroke_keys}
         steno_keys -= {None}
         if steno_keys:
             self._notify(steno_keys)

--- a/plover/machine/keymap.py
+++ b/plover/machine/keymap.py
@@ -4,7 +4,7 @@ from collections import defaultdict, OrderedDict
 from plover import log
 
 
-class Keymap(object):
+class Keymap:
 
     def __init__(self, keys, actions):
         # List of supported actions.

--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -25,7 +25,7 @@ class Passport(SerialStenotypeBase):
     SERIAL_PARAMS.update(baudrate=38400)
 
     def __init__(self, params):
-        super(Passport, self).__init__(params)
+        super().__init__(params)
         self.packet = []
 
     def _read(self, b):

--- a/plover/machine/stentura.py
+++ b/plover/machine/stentura.py
@@ -546,7 +546,7 @@ def _send_receive(port, stop, packet, buf, max_tries=3):
     raise _ConnectionLostException()
 
 
-class _SequenceCounter(object):
+class _SequenceCounter:
     """A mod 256 counter."""
     def __init__(self, seq=0):
         """Init a new counter starting at seq."""

--- a/plover/machine/txbolt.py
+++ b/plover/machine/txbolt.py
@@ -47,7 +47,7 @@ class TxBolt(plover.machine.base.SerialStenotypeBase):
     '''
 
     def __init__(self, params):
-        super(TxBolt, self).__init__(params)
+        super().__init__(params)
         self._reset_stroke_state()
 
     def _reset_stroke_state(self):

--- a/plover/oslayer/keyboardcontrol.py
+++ b/plover/oslayer/keyboardcontrol.py
@@ -60,23 +60,23 @@ if __name__ == '__main__':
     ke = KeyboardEmulation()
 
     pressed = set()
-    status = u'pressed: '
+    status = 'pressed: '
 
     def test(key, action):
         global status
         print(key, action)
-        if u'pressed' == action:
+        if 'pressed' == action:
             pressed.add(key)
         elif key in pressed:
             pressed.remove(key)
-        new_status = u'pressed: ' + u'+'.join(pressed)
+        new_status = 'pressed: ' + '+'.join(pressed)
         if status != new_status:
             ke.send_backspaces(len(status))
             ke.send_string(new_status)
             status = new_status
 
-    kc.key_down = lambda k: test(k, u'pressed')
-    kc.key_up = lambda k: test(k, u'released')
+    kc.key_down = lambda k: test(k, 'pressed')
+    kc.key_up = lambda k: test(k, 'released')
     kc.suppress_keyboard(KeyboardCapture.SUPPORTED_KEYS)
     kc.start()
     print('Press CTRL-c to quit.')

--- a/plover/oslayer/log_dbus.py
+++ b/plover/oslayer/log_dbus.py
@@ -18,7 +18,7 @@ class DbusNotificationHandler(logging.Handler):
     """ Handler using DBus notifications to show messages. """
 
     def __init__(self):
-        super(DbusNotificationHandler, self).__init__()
+        super().__init__()
         self._bus = dbus.SessionBus()
         self._proxy = self._bus.get_object(SERVICE, INTERFACE)
         self._notify = dbus.Interface(self._proxy, SERVICE)

--- a/plover/oslayer/log_osx.py
+++ b/plover/oslayer/log_osx.py
@@ -11,7 +11,7 @@ class OSXNotificationHandler(logging.Handler):
     """ Handler using OS X Notification Center to show messages. """
 
     def __init__(self):
-        super(OSXNotificationHandler, self).__init__()
+        super().__init__()
         self.setLevel(log.WARNING)
         self.setFormatter(log.NoExceptionTracebackFormatter('%(message)s'))
 

--- a/plover/oslayer/log_plyer.py
+++ b/plover/oslayer/log_plyer.py
@@ -20,7 +20,7 @@ class PlyerNotificationHandler(logging.Handler):
     """ Handler using Plyer's notifications to show messages. """
 
     def __init__(self):
-        super(PlyerNotificationHandler, self).__init__()
+        super().__init__()
         self.setLevel(log.WARNING)
         self.setFormatter(log.NoExceptionTracebackFormatter('%(levelname)s: %(message)s'))
 

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -166,7 +166,7 @@ def keycode_needs_fn_mask(keycode):
 class KeyboardCapture(threading.Thread):
     """Implementation of KeyboardCapture for OSX."""
 
-    _KEYBOARD_EVENTS = set([kCGEventKeyDown, kCGEventKeyUp])
+    _KEYBOARD_EVENTS = {kCGEventKeyDown, kCGEventKeyUp}
 
     def __init__(self):
         threading.Thread.__init__(self, name="KeyboardEventTapThread")

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -300,7 +300,7 @@ class KeyboardCapture(threading.Thread):
             handler(key)
 
 
-class KeyboardEmulation(object):
+class KeyboardEmulation:
 
     RAW_PRESS, STRING_PRESS = range(2)
 

--- a/plover/oslayer/osxkeyboardlayout.py
+++ b/plover/oslayer/osxkeyboardlayout.py
@@ -54,13 +54,13 @@ kTISPropertyInputSourceID = ctypes.c_void_p.in_dll(
     carbon, 'kTISPropertyInputSourceID')
 kTISPropertyInputSourceIsASCIICapable = ctypes.c_void_p.in_dll(
     carbon, 'kTISPropertyInputSourceIsASCIICapable')
-COMMAND = u'⌘'
-SHIFT = u'⇧'
-OPTION = u'⌥'
-CONTROL = u'⌃'
-CAPS = u'⇪'
-UNKNOWN = u'?'
-UNKNOWN_L = u'?_L'
+COMMAND = '⌘'
+SHIFT = '⇧'
+OPTION = '⌥'
+CONTROL = '⌃'
+CAPS = '⇪'
+UNKNOWN = '?'
+UNKNOWN_L = '?_L'
 
 KEY_CODE_VISUALIZATION = """
 ┌───────────────────Layout of Apple Extended Keyboard II───────────────────────┐
@@ -78,15 +78,15 @@ Valid keycodes not visible on layout:
 """
 
 SPECIAL_KEY_NAMES = {
-    u'\x1b': u'Esc',   # Will map both Esc and Clear (key codes 53 and 71)
-    u'\xa0': u'nbsp',
-    u'\x08': u'Bksp',
-    u'\x05': u'Help',
-    u'\x01': u'Home',
-    u'\x7f': u'Del',
-    u'\x04': u'End',
-    u'\x0c': u'PgDn',
-    u'\x0b': u'PgUp',  # \x0b is also the clear character signal
+    '\x1b': 'Esc',   # Will map both Esc and Clear (key codes 53 and 71)
+    '\xa0': 'nbsp',
+    '\x08': 'Bksp',
+    '\x05': 'Help',
+    '\x01': 'Home',
+    '\x7f': 'Del',
+    '\x04': 'End',
+    '\x0c': 'PgDn',
+    '\x0b': 'PgUp',  # \x0b is also the clear character signal
 }
 
 DEFAULT_SEQUENCE = (None, 0),
@@ -97,7 +97,7 @@ def is_printable(string):
         category = unicodedata.category(character)
         if category[0] in 'C':
             # Exception: the "Apple" character that most Mac layouts have
-            return False if string != u"" else True
+            return False if string != "" else True
         elif category == 'Zs' and character != ' ':
             return False
         elif category in 'Zl, Zp':
@@ -174,35 +174,35 @@ class KeyboardLayout(object):
     def _deadkeys_by_symbols(self):
         # We store deadkeys as "characters"; dkX, where X is the symbol.
         symbols = {
-            '`': u'`',
-            '´': u'´',
-            '^': (u'^', u'ˆ'),
-            '~': (u'~', u'˜'),
-            '¨': u'¨',
+            '`': '`',
+            '´': '´',
+            '^': ('^', 'ˆ'),
+            '~': ('~', '˜'),
+            '¨': '¨',
         }
         deadkeys_by_symbol = {}
         for symbol, equivalent_symbols in symbols.items():
             for equivalent_symbol in equivalent_symbols:
-                sequence = self.char_to_key_sequence(u'dk%s' % equivalent_symbol)
+                sequence = self.char_to_key_sequence('dk%s' % equivalent_symbol)
                 if sequence[0][0] is not None:
                     deadkeys_by_symbol[symbol] = sequence
         return deadkeys_by_symbol
 
     def format_modifier_header(self):
         modifiers = (
-            u'| {}\t'.format(KeyboardLayout._modifier_string(mod)).expandtabs(8)
+            '| {}\t'.format(KeyboardLayout._modifier_string(mod)).expandtabs(8)
             for mod in sorted(self._modifier_masks.values())
         )
-        header = u'Keycode\t{}'.format(''.join(modifiers))
+        header = 'Keycode\t{}'.format(''.join(modifiers))
         return '%s\n%s' % (header, re.sub(r'[^|]', '-', header))
 
     def format_keycode_keys(self, keycode):
         """Returns all the variations of the keycode with modifiers"""
-        keys = (u'| {}\t'.format(get_printable_string(
+        keys = ('| {}\t'.format(get_printable_string(
             self._key_sequence_to_char[keycode, mod])).expandtabs(8)
                 for mod in sorted(self._modifier_masks.values()))
 
-        return u'{}\t{}'.format(keycode, ''.join(keys)).expandtabs(8)
+        return '{}\t{}'.format(keycode, ''.join(keys)).expandtabs(8)
 
     @staticmethod
     def _modifier_dictionary(modifier_mask):
@@ -412,9 +412,9 @@ class KeyboardLayout(object):
             for j, key in enumerate(
                     struct.unpack_from('H' * csize, buf, table_offset)):
                 if key == 65535:
-                    key_sequence_to_char[j, mod] = u'mod'
+                    key_sequence_to_char[j, mod] = 'mod'
                 elif key >= 0xFFFE:
-                    key_sequence_to_char[j, mod] = u'<{}>'.format(key)
+                    key_sequence_to_char[j, mod] = '<{}>'.format(key)
                 elif key & 0x0C000 == 0x4000:
                     dead = key & ~0xC000
                     if dead < len(deadkeys):
@@ -431,9 +431,9 @@ class KeyboardLayout(object):
                                     deadkey_state_to_key_sequence[nextstate] = new_deadkey
                             if nextstate - 1 < len(dkterms):
                                 base_key = lookupseq(dkterms[nextstate - 1])
-                                dead_key_name = u'dk{}'.format(base_key)
+                                dead_key_name = 'dk{}'.format(base_key)
                             else:
-                                dead_key_name = u'dk#{}'.format(nextstate)
+                                dead_key_name = 'dk#{}'.format(nextstate)
                             key_sequence_to_char[j, mod] = dead_key_name
                             save_shortest_key_sequence(dead_key_name, (j, mod))
                         elif eformat == 1 or (eformat == 0 and not nextstate):
@@ -460,9 +460,9 @@ class KeyboardLayout(object):
                     save_shortest_key_sequence(ch, ((dj, dmod), (j, mod)))
                     key_sequence_to_char[(dj, dmod), (j, mod)] = ch
 
-        char_to_key_sequence[u'\n'] = (36, 0)
-        char_to_key_sequence[u'\r'] = (36, 0)
-        char_to_key_sequence[u'\t'] = (48, 0)
+        char_to_key_sequence['\n'] = (36, 0)
+        char_to_key_sequence['\r'] = (36, 0)
+        char_to_key_sequence['\t'] = (48, 0)
 
         return char_to_key_sequence, key_sequence_to_char, modifier_masks
 
@@ -481,19 +481,18 @@ if __name__ == '__main__':
         for code, mod in layout.char_to_key_sequence(char):
             if code is not None:
                 sequence.append(
-                    (code, u'{}{}'.format(
-                         layout._modifier_string(mod),
-                         layout.key_code_to_char(code, 0)
-                     )
-                    )
+                    (code, '{}{}'.format(
+                        layout._modifier_string(mod),
+                        layout.key_code_to_char(code, 0)
+                    ))
                 )
             else:
                 unmapped_characters.append(char)
         if sequence:
-            print(u'Name:\t\t{}\nCharacter:\t{}\nSequence:\t‘{}’\nBase codes:\t‘{}’\n'.format(
-                keyname, char, u'’, ‘'.join(combo[1] for combo in sequence),
-                u'’, ‘'.join(str(combo[0]) for combo in sequence)
+            print('Name:\t\t{}\nCharacter:\t{}\nSequence:\t‘{}’\nBase codes:\t‘{}’\n'.format(
+                keyname, char, '’, ‘'.join(combo[1] for combo in sequence),
+                '’, ‘'.join(str(combo[0]) for combo in sequence)
             ))
-    print(u'No mapping on this layout for characters: ‘{}’'.format(
-        u'’, ‘'.join(unmapped_characters)
+    print('No mapping on this layout for characters: ‘{}’'.format(
+        '’, ‘'.join(unmapped_characters)
     ))

--- a/plover/oslayer/osxkeyboardlayout.py
+++ b/plover/oslayer/osxkeyboardlayout.py
@@ -113,7 +113,7 @@ def get_printable_string(s):
     )
 
 
-class KeyboardLayout(object):
+class KeyboardLayout:
     def __init__(self, watch_layout=True):
         self._char_to_key_sequence = None
         self._key_sequence_to_char = None

--- a/plover/oslayer/processlock.py
+++ b/plover/oslayer/processlock.py
@@ -17,7 +17,7 @@ if sys.platform.startswith('win32'):
     from ctypes import windll
 
 
-    class PloverLock(object):
+    class PloverLock:
 
         # A GUID from http://createguid.com/
         guid = 'plover_{F8C06652-2C51-410B-8D15-C94DF96FC1F9}'
@@ -50,7 +50,7 @@ else:
     import os
 
 
-    class PloverLock(object):
+    class PloverLock:
 
         def __init__(self):
             # Check the environment for items to make the lockfile unique

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -141,7 +141,7 @@ def pid_exists(pid):
 class HeartBeat(threading.Thread):
 
     def __init__(self, ppid, atexit):
-        super(HeartBeat, self).__init__()
+        super().__init__()
         self._ppid = ppid
         self._atexit = atexit
         self._finished = threading.Event()
@@ -166,7 +166,7 @@ class KeyboardCaptureProcess(multiprocessing.Process):
     PASSTHROUGH_KEYS = CONTROL_KEYS | SHIFT_KEYS | ALT_KEYS | WIN_KEYS
 
     def __init__(self):
-        super(KeyboardCaptureProcess, self).__init__()
+        super().__init__()
         self.daemon = True
         self._ppid = os.getpid()
         self._update_registry()
@@ -301,7 +301,7 @@ class KeyboardCaptureProcess(multiprocessing.Process):
 
     def start(self):
         self.daemon = True
-        super(KeyboardCaptureProcess, self).start()
+        super().start()
         self._tid = self._queue.get()
 
     def stop(self):
@@ -326,7 +326,7 @@ class KeyboardCapture(threading.Thread):
     """Listen to all keyboard events."""
 
     def __init__(self):
-        super(KeyboardCapture, self).__init__()
+        super().__init__()
         self._suppressed_keys = set()
         self.key_down = lambda key: None
         self.key_up = lambda key: None
@@ -336,7 +336,7 @@ class KeyboardCapture(threading.Thread):
     def start(self):
         self._proc.start()
         self._proc.suppress_keyboard(self._suppressed_keys)
-        super(KeyboardCapture, self).start()
+        super().start()
 
     def run(self):
         while True:

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -159,10 +159,10 @@ class HeartBeat(threading.Thread):
 
 class KeyboardCaptureProcess(multiprocessing.Process):
 
-    CONTROL_KEYS = set((0xA2, 0xA3))
-    SHIFT_KEYS = set((0xA0, 0xA1))
-    ALT_KEYS = set((0xA4, 0xA5))
-    WIN_KEYS = set((0x5B, 0x5C))
+    CONTROL_KEYS = {0xA2, 0xA3}
+    SHIFT_KEYS = {0xA0, 0xA1}
+    ALT_KEYS = {0xA4, 0xA5}
+    WIN_KEYS = {0x5B, 0x5C}
     PASSTHROUGH_KEYS = CONTROL_KEYS | SHIFT_KEYS | ALT_KEYS | WIN_KEYS
 
     def __init__(self):

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -356,7 +356,7 @@ class KeyboardCapture(threading.Thread):
         self._proc.suppress_keyboard(self._suppressed_keys)
 
 
-class KeyboardEmulation(object):
+class KeyboardEmulation:
 
     def __init__(self):
         self.keyboard_layout = KeyboardLayout()

--- a/plover/oslayer/winkeyboardlayout.py
+++ b/plover/oslayer/winkeyboardlayout.py
@@ -326,7 +326,7 @@ DEAD_KEYNAME = {
 }
 
 
-class KeyboardLayout(object): # {{{
+class KeyboardLayout: # {{{
 
     def __init__(self, layout_id=None, debug=False):
         if layout_id is None:

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1073,9 +1073,9 @@ KEYSYM_TO_UCS = {
   0x20ab: 0x20ab, #                    DongSign ₫ DONG SIGN
   0x20ac: 0x20ac, #                    EuroSign € EURO SIGN
 }
-UCS_TO_KEYSYM = dict((ucs, keysym)
-                     for keysym, ucs
-                     in KEYSYM_TO_UCS.items())
+UCS_TO_KEYSYM = {ucs: keysym
+                 for keysym, ucs
+                 in KEYSYM_TO_UCS.items()}
 
 def is_latin1(code):
     return 0x20 <= code <= 0x7e or 0xa0 <= code <= 0xff
@@ -1102,10 +1102,10 @@ def keysym_to_string(keysym):
         if code is None:
             keysym_str = XK.keysym_to_string(keysym)
             if keysym_str is None:
-                keysym_str = u''
+                keysym_str = ''
             for c in keysym_str:
                 if c not in string.printable:
-                    keysym_str = u''
+                    keysym_str = ''
                     break
             return keysym_str
     return chr(code)
@@ -1123,7 +1123,7 @@ class KeyboardEmulation(object):
             self.custom_mapping = custom_mapping
 
         def __str__(self):
-            return u'%u:%x=%x[%s]%s' % (
+            return '%u:%x=%x[%s]%s' % (
                 self.keycode, self.modifiers,
                 self.keysym, keysym_to_string(self.keysym),
                 '' if self.custom_mapping is None else '*',
@@ -1339,7 +1339,7 @@ class KeyboardEmulation(object):
                 del self._keymap[previous_keysym]
             mapping.keysym = keysym
             self._keymap[keysym] = mapping
-            log.debug(u'new mapping: %s', mapping)
+            log.debug('new mapping: %s', mapping)
             # Move custom mapping back at the end of
             # the queue so we don't use it too soon.
             self._custom_mappings_queue.append(mapping)

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -144,7 +144,7 @@ KEY_TO_KEYCODE = dict(zip(KEYCODE_TO_KEY.values(), KEYCODE_TO_KEY.keys()))
 class XEventLoop(threading.Thread):
 
     def __init__(self, name='xev'):
-        super(XEventLoop, self).__init__()
+        super().__init__()
         self.name += '-' + name
         self._display = display.Display()
         self._pipe = os.pipe()
@@ -191,7 +191,7 @@ class KeyboardCapture(XEventLoop):
 
     def __init__(self):
         """Prepare to listen for keyboard events."""
-        super(KeyboardCapture, self).__init__(name='capture')
+        super().__init__(name='capture')
         self._window = self._display.screen().root
         if not self._display.has_extension('XInputExtension'):
             raise Exception('Xlib\'s XInput extension is required, but could not be found.')
@@ -256,11 +256,11 @@ class KeyboardCapture(XEventLoop):
         suppressed_keys = self._suppressed_keys
         self._suppressed_keys = set()
         self.suppress_keyboard(suppressed_keys)
-        super(KeyboardCapture, self).start()
+        super().start()
 
     def cancel(self):
         self.suppress_keyboard()
-        super(KeyboardCapture, self).cancel()
+        super().cancel()
 
     def _grab_key(self, keycode):
         for deviceid in self._devices:

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1111,10 +1111,10 @@ def keysym_to_string(keysym):
     return chr(code)
 
 
-class KeyboardEmulation(object):
+class KeyboardEmulation:
     """Emulate keyboard events."""
 
-    class Mapping(object):
+    class Mapping:
 
         def __init__(self, keycode, modifiers, keysym, custom_mapping=None):
             self.keycode = keycode

--- a/plover/oslayer/xwmctrl.py
+++ b/plover/oslayer/xwmctrl.py
@@ -3,7 +3,7 @@ from Xlib.error import BadWindow
 from Xlib.protocol.event import ClientMessage
 
 
-class WmCtrl(object):
+class WmCtrl:
 
     def __init__(self):
         self._display = display.Display()

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -7,7 +7,7 @@ from plover.oslayer.config import HAS_GUI_QT, PLUGINS_PLATFORM
 from plover import log
 
 
-class Plugin(object):
+class Plugin:
 
     def __init__(self, plugin_type, name, obj):
         self.plugin_type = plugin_type
@@ -22,7 +22,7 @@ class Plugin(object):
 PluginDistribution = namedtuple('PluginDistribution', 'dist plugins')
 
 
-class Registry(object):
+class Registry:
 
     PLUGIN_TYPES = (
         'command',

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -51,7 +51,7 @@ def sort_steno_strokes(strokes_list):
     return sorted(strokes_list, key=lambda x: (len(x), sum(map(len, x))))
 
 
-class Stroke(object):
+class Stroke:
     """A standardized data model for stenotype machine strokes.
 
     This class standardizes the representation of a stenotype chord. A stenotype

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -14,7 +14,7 @@ import shutil
 from plover.resource import ASSET_SCHEME, resource_filename, resource_timestamp
 
 
-class StenoDictionary(object):
+class StenoDictionary:
     """A steno dictionary.
 
     This dictionary maps immutable sequences to translations and tracks the
@@ -179,7 +179,7 @@ class StenoDictionary(object):
         self._longest_listener_callbacks.remove(callback)
 
 
-class StenoDictionaryCollection(object):
+class StenoDictionaryCollection:
 
     def __init__(self, dicts=[]):
         self.dicts = []

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -6,7 +6,7 @@ from plover.steno import sort_steno_strokes
 Suggestion = collections.namedtuple('Suggestion', 'text steno_list')
 
 
-class Suggestions(object):
+class Suggestions:
     def __init__(self, dictionary):
         self.dictionary = dictionary
 

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -14,18 +14,18 @@ class Suggestions(object):
         suggestions = []
 
         mods = [
-            u'%s',  # Same
-            u'{^%s}',  # Prefix
-            u'{^}%s',
-            u'{^%s^}',  # Infix
-            u'{^}%s{^}',
-            u'{%s^}',  # Suffix
-            u'%s{^}',
-            u'{&%s}',  # Fingerspell
-            u'{#%s}',  # Command
+            '%s',  # Same
+            '{^%s}',  # Prefix
+            '{^}%s',
+            '{^%s^}',  # Infix
+            '{^}%s{^}',
+            '{%s^}',  # Suffix
+            '%s{^}',
+            '{&%s}',  # Fingerspell
+            '{#%s}',  # Command
         ]
 
-        possible_translations = set([translation])
+        possible_translations = {translation}
 
         # Only strip spaces, so patterns with \n or \t are correctly handled.
         stripped_translation = translation.strip(' ')

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -44,8 +44,8 @@ _EXPORTS = {
     'SUFFIX_KEYS'              : lambda mod: _suffix_keys(mod.SUFFIX_KEYS),
     'UNDO_STROKE_STENO'        : lambda mod: mod.UNDO_STROKE_STENO,
     'IMPLICIT_HYPHEN_KEYS'     : lambda mod: set(mod.IMPLICIT_HYPHEN_KEYS),
-    'IMPLICIT_HYPHENS'         : lambda mod: set(l.replace('-', '')
-                                                 for l in mod.IMPLICIT_HYPHEN_KEYS),
+    'IMPLICIT_HYPHENS'         : lambda mod: {l.replace('-', '')
+                                              for l in mod.IMPLICIT_HYPHEN_KEYS},
     'ORTHOGRAPHY_WORDS'        : lambda mod: _load_wordlist(mod.ORTHOGRAPHY_WORDLIST),
     'ORTHOGRAPHY_RULES'        : lambda mod: [(re.compile(pattern, re.I), replacement)
                                               for pattern, replacement in mod.ORTHOGRAPHY_RULES],

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -78,7 +78,7 @@ def _mapping_to_macro(mapping, stroke):
     return Macro(macro, stroke, cmdline) if macro else None
 
 
-class Translation(object):
+class Translation:
     """A data model for the mapping between a sequence of Strokes and a string.
 
     This class represents the mapping between a sequence of Stroke objects and
@@ -158,7 +158,7 @@ class Translation(object):
         return False
 
 
-class Translator(object):
+class Translator:
     """Converts a stenotype key stream to a translation stream.
 
     An instance of this class serves as a state machine for processing key
@@ -381,7 +381,7 @@ class Translator(object):
         return None
 
 
-class _State(object):
+class _State:
     """An object representing the current state of the translator state machine.
 
     Attributes:

--- a/plover_build_utils/install_wheels.py
+++ b/plover_build_utils/install_wheels.py
@@ -74,7 +74,7 @@ import sys
 from pkg_resources import load_entry_point
 
 # Work around isatty attribute being read-only with Python 2.
-class NoTTY(object):
+class NoTTY:
     def __init__(self, fp):
         self._fp = fp
     def isatty(self):

--- a/plover_build_utils/install_wheels.py
+++ b/plover_build_utils/install_wheels.py
@@ -12,9 +12,9 @@ WHEELS_CACHE = os.path.join('.cache', 'wheels')
 def _split_opts(text):
     args = text.split()
     assert (len(args) % 2) == 0
-    return dict((name, int(nb_args))
-                for name, nb_args
-                in zip(*([iter(args)] * 2)))
+    return {name: int(nb_args)
+            for name, nb_args
+            in zip(*([iter(args)] * 2))}
 
 
 # Allowed `pip install/wheel` options.

--- a/plover_build_utils/testing.py
+++ b/plover_build_utils/testing.py
@@ -11,7 +11,7 @@ from plover.steno_dictionary import StenoDictionary
 from plover.translation import Translator
 
 
-class CaptureOutput(object):
+class CaptureOutput:
 
     def __init__(self):
         self.instructions = []
@@ -119,7 +119,7 @@ def replay_doc(f):
     return functools.wraps(f)(new_f)
 
 
-class BlackboxTester(object):
+class BlackboxTester:
 
     @classmethod
     def setup_class(cls):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -14,7 +14,7 @@ class TestCase(unittest.TestCase):
 
     def assertRaisesWithMessage(self, exception, msg):
         outer_self = self
-        class ContextManager(object):
+        class ContextManager:
             def __enter__(self):
                 pass
             def __exit__(self, exc_type, exc_value, traceback):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -30,7 +30,7 @@ def dict_replace(d, update):
     return d
 
 
-class FakeMachine(object):
+class FakeMachine:
 
     KEYMAP_MACHINE_TYPE = 'Keyboard'
 
@@ -55,7 +55,7 @@ class FakeMachine(object):
 FakeMachine.DEFAULT_OPTIONS = {k: v[0] for k, v in FakeMachine.get_option_info().items()}
 
 
-class FakeSystem(object):
+class FakeSystem:
     KEYS = english_stenotype.KEYS
     IMPLICIT_HYPHEN_KEYS = ()
     SUFFIX_KEYS = ()

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -16,7 +16,7 @@ from plover.steno_dictionary import StenoDictionaryCollection
 from .utils import make_dict
 
 
-class FakeConfig(object):
+class FakeConfig:
 
     DEFAULTS = {
         'auto_start'                : False,
@@ -82,7 +82,7 @@ class FakeMachine(StenotypeBase):
     def set_suppression(self, enabled):
         self.is_suppressed = enabled
 
-class FakeKeyboardEmulation(object):
+class FakeKeyboardEmulation:
 
     def send_backspaces(self, b):
         pass

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -61,7 +61,7 @@ class FakeMachine(StenotypeBase):
     instance = None
 
     def __init__(self, options):
-        super(FakeMachine, self).__init__()
+        super().__init__()
         self.options = options
         self.is_suppressed = False
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -31,7 +31,7 @@ def action(**kwargs):
                 kwargs[k] = v
     return formatting._Action(**kwargs)
 
-class MockTranslation(object):
+class MockTranslation:
     def __init__(self, rtfcre=tuple(), english=None, formatting=None):
         self.rtfcre = rtfcre
         self.english = english
@@ -709,7 +709,7 @@ def test_meta_carry_capitalize(meta, last_action, expected):
     assert formatting._atom_to_action('{' + meta + '}', ctx) == expected
 
 
-class TestApplyModeCase(object):
+class TestApplyModeCase:
 
     test = ' some test '
     test2 = 'test Me'
@@ -746,7 +746,7 @@ class TestApplyModeCase(object):
             assert formatting._apply_mode_case(input_text, case, appended) == expected
 
 
-class TestApplyModeSpaceChar(object):
+class TestApplyModeSpaceChar:
 
     test = ' some text '
     test2 = "don't"
@@ -898,7 +898,7 @@ def test_output_optimization(undo, do, expected_instructions):
     assert output.instructions == expected_instructions
 
 
-class TestRetroFormatter(object):
+class TestRetroFormatter:
 
     def setup_method(self):
         self.formatter = formatting.Formatter()

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -746,7 +746,7 @@ class TestApplyModeCase(object):
             assert formatting._apply_mode_case(input_text, case, appended) == expected
 
 
-def TestApplyModeSpaceChar(object):
+class TestApplyModeSpaceChar(object):
 
     test = ' some text '
     test2 = "don't"
@@ -759,7 +759,7 @@ def TestApplyModeSpaceChar(object):
     )
 
     @parametrize(TESTS)
-    def test_apply_space_char(text, space_char, expected):
+    def test_apply_space_char(self, text, space_char, expected):
         assert formatting._apply_mode_space_char(text, space_char) == expected
 
 

--- a/test/test_json_dict.py
+++ b/test/test_json_dict.py
@@ -16,12 +16,12 @@ class JsonDictionaryTestCase(unittest.TestCase):
     def test_load_dictionary(self):
 
         for contents, expected in (
-            (u'{"S": "a"}'.encode('utf-8'), {('S', ): u'a'}),
+            ('{"S": "a"}'.encode('utf-8'), {('S', ): 'a'}),
             # Default encoding is utf-8.
-            (u'{"S": "café"}'.encode('utf-8'), {('S', ): u'café'}),
+            ('{"S": "café"}'.encode('utf-8'), {('S', ): 'café'}),
             # But if that fails, the implementation
             # must automatically retry with latin-1.
-            (u'{"S": "café"}'.encode('latin-1'), {('S', ): u'café'}),
+            ('{"S": "café"}'.encode('latin-1'), {('S', ): 'café'}),
         ):
             with make_dict(contents) as filename:
                 d = JsonDictionary.load(filename)
@@ -29,13 +29,13 @@ class JsonDictionaryTestCase(unittest.TestCase):
 
         for contents, exception in (
             # Invalid JSON.
-            (u'{"foo", "bar",}', ValueError),
+            ('{"foo", "bar",}', ValueError),
             # Invalid JSON.
-            (u'foo', ValueError),
+            ('foo', ValueError),
             # Cannot convert to dict.
-            (u'"foo"', ValueError),
+            ('"foo"', ValueError),
             # Ditto.
-            (u'4.2', TypeError),
+            ('4.2', TypeError),
         ):
             with make_dict(contents.encode('utf-8')) as filename:
                 self.assertRaises(exception, JsonDictionary.load, filename)
@@ -44,19 +44,19 @@ class JsonDictionaryTestCase(unittest.TestCase):
         for contents, expected in (
             # Simple test.
             ({('S', ): 'a'},
-             u'{\n"S": "a"\n}'),
+             '{\n"S": "a"\n}'),
             # Check strokes format: '/' separated.
-            ({('SAPL', '-PL'): u'sample'},
-             u'{\n"SAPL/-PL": "sample"\n}'),
+            ({('SAPL', '-PL'): 'sample'},
+             '{\n"SAPL/-PL": "sample"\n}'),
             # Contents should be saved as UTF-8, no escaping.
-            ({('S', ): u'café'},
-             u'{\n"S": "café"\n}'),
+            ({('S', ): 'café'},
+             '{\n"S": "café"\n}'),
             # Check escaping of special characters.
-            ({('S', ): u'{^"\n\t"^}'},
-             u'{\n"S": "' + r'{^\"\n\t\"^}' + u'"\n}'),
+            ({('S', ): '{^"\n\t"^}'},
+             '{\n"S": "' + r'{^\"\n\t\"^}' + '"\n}'),
             # Keys are sorted on save.
-            ({('B', ): u'bravo', ('A', ): u'alpha', ('C', ): u'charlie'},
-             u'{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}'),
+            ({('B', ): 'bravo', ('A', ): 'alpha', ('C', ): 'charlie'},
+             '{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}'),
         ):
             with make_dict(b'foo') as filename:
                 d = JsonDictionary.create(filename)

--- a/test/test_loading_manager.py
+++ b/test/test_loading_manager.py
@@ -18,7 +18,7 @@ class DictionaryLoadingManagerTestCase(unittest.TestCase):
 
     def test_loading(self):
 
-        class FakeDictionaryContents(object):
+        class FakeDictionaryContents:
 
             def __init__(self, contents, timestamp):
                 self.contents = contents
@@ -29,7 +29,7 @@ class DictionaryLoadingManagerTestCase(unittest.TestCase):
                     return self.contents == other.contents
                 return self.contents == other
 
-        class FakeDictionaryInfo(object):
+        class FakeDictionaryInfo:
 
             def __init__(self, name, contents):
                 self.name = name
@@ -39,7 +39,7 @@ class DictionaryLoadingManagerTestCase(unittest.TestCase):
             def __repr__(self):
                 return 'FakeDictionaryInfo(%r, %r)' % (self.name, self.contents)
 
-        class MockLoader(object):
+        class MockLoader:
             def __init__(self, files):
                 self.files = files
                 self.load_counts = defaultdict(int)

--- a/test/test_passport.py
+++ b/test/test_passport.py
@@ -11,7 +11,7 @@ from mock import patch
 from plover.machine.passport import Passport
 
 
-class MockSerial(object):
+class MockSerial:
 
     inputs = []
     index = 0

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -173,8 +173,8 @@ class TestCase(unittest.TestCase):
         with mock.patch.multiple(patch_path, normalize_steno=normalize,
                                  TranslationConverter=Converter):
             for contents, expected in cases:
-                expected = dict((normalize(k), convert(v))
-                                for k, v in expected.items())
+                expected = {normalize(k): convert(v)
+                            for k, v in expected.items()}
                 with make_dict((header + contents + footer).encode('cp1252')) as filename:
                     d = RtfDictionary.load(filename)
                     self.assertEqual(dict(d.items()), expected)

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -126,7 +126,7 @@ class TestCase(unittest.TestCase):
 
         this = self
 
-        class Converter(object):
+        class Converter:
             def __init__(self, styles):
                 this.assertEqual(styles, expected_styles)
 

--- a/test/test_stentura.py
+++ b/test/test_stentura.py
@@ -65,7 +65,7 @@ def parse_request(request):
                      'p3', 'p4', 'p5', 'crc', 'data', 'data_crc'], header))
 
 
-class MockPacketPort(object):
+class MockPacketPort:
     def __init__(self, responses, requests=None):
         self._responses = responses
         self.writes = 0
@@ -209,7 +209,7 @@ class TestCase(unittest.TestCase):
                 test[0]), test[1], test[2])
 
     def test_read_data_simple(self):
-        class MockPort(object):
+        class MockPort:
             def read(self, count):
                 if count != 5:
                     raise Exception("Incorrect number read.")
@@ -226,7 +226,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(buf, b'123412345' + (b'\x00' * 11))
 
     def test_read_data_stop_set(self):
-        class MockPort(object):
+        class MockPort:
             def read(self, count):
                 return b"0000"
         buf = bytearray()
@@ -236,7 +236,7 @@ class TestCase(unittest.TestCase):
             stentura._read_data(MockPort(), event, buf, 0, 4)
 
     def test_read_data_timeout(self):
-        class MockPort(object):
+        class MockPort:
             def read(self, count):
                 # When serial time out occurs read() returns
                 # less characters as requested
@@ -248,7 +248,7 @@ class TestCase(unittest.TestCase):
             stentura._read_data(port, threading.Event(), buf, 0, 4)
 
     def test_read_packet_simple(self):
-        class MockPort(object):
+        class MockPort:
             def __init__(self, packet):
                 self._packet = packet
 
@@ -265,7 +265,7 @@ class TestCase(unittest.TestCase):
             self.assertSequenceEqual(response, packet)
 
     def test_read_packet_fail(self):
-        class MockPort(object):
+        class MockPort:
             def __init__(self, data_section_length=0, set1=False, set2=False,
                          give_too_much_data=False, give_timeout=False):
                 self._set1 = set1
@@ -322,7 +322,7 @@ class TestCase(unittest.TestCase):
             stentura._read_packet(port, port.event, buf)
 
     def test_write_to_port(self):
-        class MockPort(object):
+        class MockPort:
             def __init__(self, chunk):
                 self._chunk = chunk
                 self.data = b''
@@ -431,7 +431,7 @@ class TestCase(unittest.TestCase):
             self.assertEqual(byte, len(data) % 512)
 
     def test_loop(self):
-        class Event(object):
+        class Event:
             def __init__(self, count, data, stop=False):
                 self.count = count
                 self.data = data
@@ -440,7 +440,7 @@ class TestCase(unittest.TestCase):
             def __repr__(self):
                 return '<{}, {}, {}>'.format(self.count, self.data, self.stop)
 
-        class MockPort(object):
+        class MockPort:
             def __init__(self, events=[]):
                 self._file = b''
                 self._out = b''

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -209,7 +209,7 @@ class TranslatorTestCase(unittest.TestCase):
         # makes sure that translate calls it properly. But since I already wrote
         # this test I'm going to keep it.
 
-        class Output(object):
+        class Output:
             def __init__(self):
                 self._output = []
                 
@@ -418,7 +418,7 @@ class StateTestCase(unittest.TestCase):
 
 class TranslateStrokeTestCase(unittest.TestCase):
 
-    class CaptureOutput(object):
+    class CaptureOutput:
         output = namedtuple('output', 'undo do prev')
         
         def __init__(self):

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -48,7 +48,7 @@ else:
 class CommandExecutionException(Exception):
 
     def __init__(self, args, exitcode, stdout='', stderr=''):
-        super(CommandExecutionException, self).__init__()
+        super().__init__()
         self.args = args
         self.exitcode = exitcode
         self.stdout = stdout
@@ -117,7 +117,7 @@ class Environment(object):
 class WineEnvironment(Environment):
 
     def __init__(self, prefix):
-        super(WineEnvironment, self).__init__()
+        super().__init__()
         self._prefix = os.path.abspath(prefix)
         self._env['WINEPREFIX'] = self._prefix
         self._env['WINEARCH'] = 'win32'
@@ -179,10 +179,10 @@ class WineEnvironment(Environment):
             cmd = ('wine',) + tuple(args)
         else:
             cmd = args
-        return super(WineEnvironment, self).run(cmd, cwd, redirection)
+        return super().run(cmd, cwd, redirection)
 
     def _get_env(self):
-        env = super(WineEnvironment, self)._get_env()
+        env = super()._get_env()
         for var in (
             'PYTHONPATH',
             # Make sure GTK environment variables don't spill over to the Wine environment.
@@ -208,7 +208,7 @@ class WineEnvironment(Environment):
 class Win32Environment(Environment):
 
     def __init__(self):
-        super(Win32Environment, self).__init__()
+        super().__init__()
         self._path = None
 
     def setup(self):
@@ -547,7 +547,7 @@ class WineHelper(Helper):
     ) + Helper.DEPENDENCIES
 
     def __init__(self):
-        super(WineHelper, self).__init__()
+        super().__init__()
         self._env = WineEnvironment(os.path.join(WIN_DIR, '.wine'))
 
     def cmd_run(self, executable, *args):
@@ -556,13 +556,13 @@ class WineHelper(Helper):
         executable: executable to run (the executable will be automatically run with Wine when it ends with ".exe")
         args: additional arguments to pass to the executable
         '''
-        super(WineHelper, self).cmd_run(executable, *args)
+        super().cmd_run(executable, *args)
 
 
 class Win32Helper(Helper):
 
     def __init__(self):
-        super(Win32Helper, self).__init__()
+        super().__init__()
         self._env = Win32Environment()
 
 

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -55,7 +55,7 @@ class CommandExecutionException(Exception):
         self.stderr = stderr
 
 
-class Environment(object):
+class Environment:
 
     def __init__(self):
         self.dry_run = False
@@ -240,7 +240,7 @@ class Win32Environment(Environment):
             os.unlink(batch)
 
 
-class Helper(object):
+class Helper:
 
     DEPENDENCIES = (
         ('nsis', 'http://prdownloads.sourceforge.net/nsis/nsis-3.01-setup.exe',


### PR DESCRIPTION
* run sources through [upgrade](https://github.com/asottile/pyupgrade#pyupgrade): `pyupgrade --py3-plus $(git ls-files '*.py')`
* use Python 3 simplified syntax for calls to `super`
* simplify class declarations (Python does not have old style class declarations)

Note: that last change brought to light the fact that space chars tests were not being run, so a fix for this is included.