### PR TITLE
Rework plugins directory handling

### DIFF
--- a/linux/appimage/apprun.sh
+++ b/linux/appimage/apprun.sh
@@ -59,7 +59,7 @@ appimage_uninstall()
 
 appimage_launch()
 {
-  exec "${APPDIR}/usr/bin/python3.6" -m plover.main "$@"
+  exec "${APPDIR}/usr/bin/python3.6" -s -m plover.dist_main "$@"
 }
 
 set -e

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -99,13 +99,13 @@ info ')'
 run_eval "
 appdir_python()
 {
-  env LD_LIBRARY_PATH=\"$appdir/usr/lib:$appdir/usr/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH+:\$LD_LIBRARY_PATH}\" "$appdir/usr/bin/python3.6" -s \"\$@\"
+  env \
+    PYTHONNOUSERSITE=1 \
+    LD_LIBRARY_PATH=\"$appdir/usr/lib:$appdir/usr/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH+:\$LD_LIBRARY_PATH}\" \
+    "$appdir/usr/bin/python3.6" \"\$@\"
 }
 "
 python='appdir_python'
-
-# Disable user site-packages.
-run sed -i 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/' "$appdir/usr/lib/python3.6/site.py"
 
 # Install Plover and dependencies.
 bootstrap_dist "$wheel"

--- a/osx/app_resources/plover_launcher.sh
+++ b/osx/app_resources/plover_launcher.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
-DIR=$(dirname "$0")
-exec "$DIR/../Frameworks/pythonexecutable" -m plover.main "$@"
 
+set -e
+
+DIR=$(dirname "$0")
+exec "$DIR/../Frameworks/pythonexecutable" -s -m plover.dist_main "$@"

--- a/plover/dist_main.py
+++ b/plover/dist_main.py
@@ -1,0 +1,24 @@
+
+import os
+import sys
+import subprocess
+
+from plover.oslayer.config import CONFIG_DIR, PLUGINS_PLATFORM
+
+
+def main():
+    args = sys.argv[:]
+    args[0:1] = [sys.executable, '-m', 'plover.main']
+    if '--no-user-plugins' in args[3:]:
+        args.remove('--no-user-plugins')
+        args.insert(1, '-s')
+    os.environ['PYTHONUSERBASE'] = os.path.join(CONFIG_DIR, 'plugins', PLUGINS_PLATFORM)
+    if sys.platform.startswith('win32'):
+        # Workaround https://bugs.python.org/issue19066
+        subprocess.Popen(args, cwd=os.getcwd())
+        os.exit(0)
+    os.execv(args[0], args)
+
+
+if __name__ == '__main__':
+    main()

--- a/plover/main.py
+++ b/plover/main.py
@@ -12,16 +12,13 @@ import sys
 import subprocess
 import traceback
 
-# This need to be imported before pkg_resources.
-from plover.oslayer.config import CONFIG_DIR, PLUGINS_DIR
-
 import pkg_resources
 
 if sys.platform.startswith('darwin'):
     import appnope
 
 import plover.oslayer.processlock
-from plover.config import CONFIG_FILE, Config
+from plover.config import CONFIG_DIR, CONFIG_FILE, Config
 from plover.registry import registry
 from plover import log
 from plover import __name__ as __software_name__
@@ -63,7 +60,6 @@ def main():
 
     log.info('Plover %s', __version__)
     log.info('configuration directory: %s', CONFIG_DIR)
-    log.info('plugins directory: %s', PLUGINS_DIR)
 
     registry.update()
 

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -10,20 +10,11 @@ import sysconfig
 import appdirs
 
 
-# If plover is run from a pyinstaller binary.
-if hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
-    PROGRAM_DIR = os.path.dirname(sys.executable)
-# If plover is run from an app bundle on Mac.
-elif sys.platform.startswith('darwin') and '.app' in os.path.realpath(__file__):
-    PROGRAM_DIR = os.path.abspath(os.path.join(os.path.dirname(sys.executable), *[os.path.pardir] * 3))
-else:
-    PROGRAM_DIR = os.getcwd()
-
-# If the program's directory has a plover.cfg file then run in "portable mode",
-# i.e. store all data in the same directory. This allows keeping all Plover
-# files in a portable drive.
-if os.path.isfile(os.path.join(PROGRAM_DIR, 'plover.cfg')):
-    CONFIG_DIR = PROGRAM_DIR
+# If the program's working directory has a plover.cfg file then run in
+# "portable mode", i.e. store all data in the same directory. This allows
+# keeping all Plover files in a portable drive.
+if os.path.isfile('plover.cfg'):
+    CONFIG_DIR = os.getcwd()
 else:
     CONFIG_DIR = appdirs.user_data_dir('plover', 'plover')
 

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -5,9 +5,9 @@
 
 import os
 import sys
-import sysconfig
 
 import appdirs
+import pkg_resources
 
 
 # If the program's working directory has a plover.cfg file then run in
@@ -27,21 +27,8 @@ elif sys.platform.startswith('win'):
     PLUGINS_PLATFORM = 'win'
 else:
     PLUGINS_PLATFORM = None
-if PLUGINS_PLATFORM is None:
-    PLUGINS_BASE = None
-    PLUGINS_DIR = None
-else:
-    PLUGINS_BASE = os.path.join(CONFIG_DIR, 'plugins', PLUGINS_PLATFORM)
-    scheme = '%s_user' % os.name
-    if PLUGINS_PLATFORM == 'mac' and sysconfig.get_config_var('PYTHONFRAMEWORK'):
-        scheme = 'osx_framework_user'
-    PLUGINS_DIR = sysconfig.get_path('purelib', scheme, dict(userbase=PLUGINS_BASE))
-    sys.path.insert(0, PLUGINS_DIR)
 
-# This need to be imported after patching sys.path.
-import pkg_resources
-
-plover_dist = pkg_resources.get_distribution('plover')
+plover_dist = pkg_resources.working_set.by_key['plover']
 
 ASSETS_DIR = plover_dist.get_resource_filename(__name__, 'plover/assets')
 

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,10 @@ class BinaryDistWin(Command):
                 sys.path.insert(0, os.getcwd())
                 '''
             ).lstrip())
+        # Use standard site.py so user site packages are enabled.
+        site_py = download('https://github.com/python/cpython/raw/v3.6.3/Lib/site.py',
+                           '5b5a92032c666e0e30c0b2665b8acffe2a624641')
+        shutil.copyfile(site_py, os.path.join(dist_site_packages, 'site.py'))
         # Run command helper.
         def run(*args):
             if self.verbose:
@@ -161,8 +165,8 @@ class BinaryDistWin(Command):
             shutil.copyfile(src, dst)
         # Create launchers.
         for entrypoint, gui in (
-            ('plover         = plover.main:main', True ),
-            ('plover_console = plover.main:main', False),
+            ('plover         = plover.dist_main:main', True ),
+            ('plover_console = plover.dist_main:main', False),
         ):
             run(dist_py, '-c', textwrap.dedent(
                 '''


### PR DESCRIPTION
In order to support #907 and fix https://github.com/benoit-pierre/plover_plugins_manager/issues/4, this PR drop the custom plugins directory handling in favor of a dedicated launcher for distributions:
* when Plover is installed with pip or a distribution package manager, then user plugins are assumed to be installed in the standard user site (and can be installed/updated/removed from there with the plugins manager)
* when Plover is run through a distribution, then we want to be isolated from an existing Python installation: `PYTHONUSERBASE` is set according to Plover's configuration directory (so portable mode is respected). In this mode, user plugins can be disabled by launching with `--no-user-plugins` (the embedded distribution plugins will still be loaded).

This will require a new plugins manager (>= 0.5.11.dev0). Note that this new manager supports handling user plugins even if the user site is disabled (so broken plugins can still be updated/uninstalled).

One question though, when restarting after Plover was launched with `--no-user-plugins`, should user plugins be still disabled?