### PR TITLE
Select a keyboard control module for OpenBSD.

### DIFF
--- a/plover/oslayer/keyboardcontrol.py
+++ b/plover/oslayer/keyboardcontrol.py
@@ -21,7 +21,7 @@ import sys
 KEYBOARDCONTROL_NOT_FOUND_FOR_OS = \
         "No keyboard control module was found for os %s" % sys.platform
 
-if sys.platform.startswith('linux'):
+if sys.platform.startswith(('linux', 'openbsd')):
     from plover.oslayer import xkeyboardcontrol as keyboardcontrol
 elif sys.platform.startswith('win32'):
     from plover.oslayer import winkeyboardcontrol as keyboardcontrol


### PR DESCRIPTION
Note that this change is not sufficient for running plover on OpenBSD;
one must also remove the PyQt5 dependency check.
https://groups.google.com/forum/#!topic/ploversteno/dR5OKtL1Lv8

I could not find a Github Issue corresponding to OpenBSD support.