### PR TITLE
gui_qt: fix possible crash on Linux

### DIFF
--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -169,7 +169,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             def on_finished():
                 del self._active_dialogs[name]
                 dialog.deleteLater()
-                if manage_windows:
+                if manage_windows and previous_window is not None:
                     wmctrl.SetForegroundWindow(previous_window)
             dialog.finished.connect(on_finished)
         dialog.show()


### PR DESCRIPTION
If `_NET_ACTIVE_WINDOW` is not supported by the current window manager, then we can't track the currently focused window and should therefore not try to restore focus to it.

Fix #926.