### PR TITLE
Fix Unicode characters outside of BMP on Windows.

### DIFF
--- a/plover/misc.py
+++ b/plover/misc.py
@@ -65,3 +65,15 @@ def boolean(value):
             return False
         raise ValueError(value)
     return bool(value)
+
+def to_surrogate_pair(char):
+    pairs = []
+    for code in char:
+        code_point = ord(code)
+        if code_point >= 0x10000:
+            high_part = (code_point - 0x10000) // 0x400 + 0xD800
+            low_part = (code_point - 0x10000) % 0x400 + 0xDC00
+            pairs += (high_part, low_part)
+        else:
+            pairs.append(code_point)
+    return pairs

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -24,6 +24,7 @@ from ctypes import windll, wintypes
 from plover.key_combo import parse_key_combo
 from plover.oslayer.winkeyboardlayout import KeyboardLayout
 from plover import log
+from plover.misc import to_surrogate_pair
 
 SendInput = windll.user32.SendInput
 LONG = ctypes.c_long
@@ -422,8 +423,9 @@ class KeyboardEmulation:
             self.keyboard_layout = KeyboardLayout(layout_id)
 
     def _key_unicode(self, char):
-        inputs = [self._keyboard(ord(code), KEYEVENTF_UNICODE)
-                  for code in char]
+        pairs = to_surrogate_pair(char)
+        inputs = [self._keyboard(code, KEYEVENTF_UNICODE)
+                  for code in pairs]
         self._send_input(*inputs)
 
     def send_backspaces(self, number_of_backspaces):

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -89,3 +89,11 @@ def test_boolean(input, output):
             misc.boolean(input)
     else:
         assert misc.boolean(input) == output
+
+def test_to_surrogate_pairs():
+    # Split unicode characters above 0xFFFF
+    assert misc.to_surrogate_pair(chr(0x1F4A6)) == [0xD83D, 0xDCA6]
+    # Do not slit characters below 0xFFFF
+    assert misc.to_surrogate_pair(chr(0x20)) == [0x20]
+    # Do not split already split characters.
+    assert misc.to_surrogate_pair(chr(0xD83D) + chr(0xDCA6)) == [0xD83D, 0xDCA6]


### PR DESCRIPTION
1. Windows requires that you split Unicode characters into surrogate pairs before submission to SendInput, if they are outside the BMP as the maximum size of the character point in SendInput is 16bits.

2. Split incoming Unicode characters into surrogate pairs if they are outside the BMP. This was done by hand based on the Unicode specification because Python appears to offer no means of splitting a surrogate pair without encoding to UTF-16, removing the BOM, and then manually cutting the bytes out and putting them back together.
