### PR TITLE
windows: fix missing Visual C++ Redistributable DLL error

### DIFF
--- a/windows/installer.nsi
+++ b/windows/installer.nsi
@@ -71,6 +71,7 @@ Section "Plover ${version}" BfWSection
   File "${srcdir}\LICENSE.txt"
   File "${srcdir}\plover.exe"
   File "${srcdir}\plover_console.exe"
+  File "${srcdir}\vcruntime140.dll"
   File /r "${srcdir}\data"
   
   ;Store installation folder


### PR DESCRIPTION
Don't forget to add it to the installer too... Fix #941.
