### PR TITLE
gui_qt: Add tooltips to dictionary icons

### DIFF
--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -162,19 +162,24 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
             item = QTableWidgetItem(str(n + 1))
             if dictionary.path not in loaded_dictionaries:
                 icon = 'loading'
+                tooltip = _('This dictionary is being loaded.')
             else:
                 d = loaded_dictionaries.get(dictionary.path)
                 if isinstance(d, ErroredDictionary):
                     icon = 'error'
-                    item.setToolTip(str(d.exception))
+                    tooltip = str(d.exception)
                 elif d.readonly:
                     icon = 'readonly'
+                    tooltip = _('This dictionary is read-only.')
                 elif not favorite_set and dictionary.enabled:
                     icon = 'favorite'
+                    tooltip = _('This dictionary is marked as a favorite.')
                     favorite_set = True
                 else:
                     icon = 'normal'
+                    tooltip = ''
             item.setIcon(QIcon(':/dictionary_%s.svg' % icon))
+            item.setToolTip(tooltip)
             self.table.setVerticalHeaderItem(row, item)
         if keep_selection:
             row_list = []


### PR DESCRIPTION
<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
Fixes #896.

<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
Added tooltips for the cases of

- loading
- favorite
- readonly

I left the error case as-is as it was showing a tooltip with the exception already. I wasn't sure on the exact messages to include in the tooltips, so I just took a shot at a short description of each state.

I ran `python setup.py extract_messages` to update the plover.pot file to include these new strings as well. It made some other changes outside of just line numbers for strings that have been added or no longer appear anywhere else; these appear fine at first glance to me.