### PR TITLE
Add stitch mode

### DIFF
--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1222,6 +1222,209 @@ class TestsBlackbox(BlackboxTester):
         PHO*D/TEFT/TEFT/R-FT/TEFT '...test...test test'
         '''
 
+    def test_mode_stitch(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+
+        PHO*D/TEFT ' t-e-s-t'
+        TEFT       ' t-e-s-t t-e-s-t'
+        '''
+
+    def test_mode_stitch_set_delimiter(self):
+        r'''
+        "PHO*D": "{MODE:STITCH:~}",
+        "S": "magic",
+
+        PHO*D/S ' m~a~g~i~c'
+        '''
+
+    def test_mode_stitch_orthography(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "S": "forget",
+        "T": "{^ing}",
+
+        PHO*D/S/T ' f-o-r-g-e-t-t-i-n-g'
+        '''
+
+    def test_mode_stitch_fingerspell(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "S": "{&s}",
+        "T": "{&t}",
+        "K": "{&k}",
+
+        PHO*D  ''
+        TEFT  ' t-e-s-t'
+        S     ' t-e-s-t s'
+        T     ' t-e-s-t s-t'
+        K     ' t-e-s-t s-t-k'
+        TEFT  ' t-e-s-t s-t-k t-e-s-t'
+        */*   ' t-e-s-t s-t'
+        *     ' t-e-s-t s'
+        '''
+
+    def test_mode_stitch_fingerspell_spaces_after(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "S": "{&s}",
+        "T": "{&t}",
+        "K": "{&k}",
+
+        :spaces_after
+        PHO*D  ''
+        TEFT  't-e-s-t '
+        S     't-e-s-t s '
+        T     't-e-s-t s-t '
+        K     't-e-s-t s-t-k '
+        TEFT  't-e-s-t s-t-k t-e-s-t '
+        */*   't-e-s-t s-t '
+        *     't-e-s-t s '
+        '''
+
+    def test_mode_stitch_join(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "TK-LS": "{^^}"
+
+        PHO*D      ''
+        TEFT       ' t-e-s-t'
+        TK-LS/TEFT ' t-e-s-t-t-e-s-t'
+        '''
+
+    def test_mode_aesthetic(self):
+        r'''
+        # Edge case: stitch is set to default space_char
+        "PHO*D": "{MODE:STITCH}{MODE:SET_SPACE:  }{MODE:STITCH: }{MODE:CAPS}",
+        "TEFT": "test",
+        "PHE": "me",
+
+        PHO*D ''
+        TEFT  '  T E S T'
+        PHE   '  T E S T  M E'
+        '''
+
+    def test_mode_stitch_with_nonspace_space_char(self):
+        r'''
+        # Verify that stitch doesn't try to stitch letters and the space char together.
+        "PHO*D": "{MODE:STITCH}{MODE:SET_SPACE:_}{MODE:STITCH}",
+        "TEFT": "test",
+        "PHE": "me",
+
+        PHO*D ''
+        TEFT  '_t-e-s-t'
+        PHE   '_t-e-s-t_m-e'
+        '''
+
+    def test_mode_stitch_join_to_whitespace(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "S-P": "{^ ^}"
+
+        PHO*D     ''
+        TEFT      ' t-e-s-t'
+        S-P       ' t-e-s-t '
+        TEFT      ' t-e-s-t t-e-s-t'
+        '''
+
+    def test_mode_stitch_join_to_whitespace_plus_word(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "S-P/WORD": "{^ word}"
+
+        PHO*D     ''
+        TEFT      ' t-e-s-t'
+        S-P/WORD  ' t-e-s-t w-o-r-d'
+        '''
+
+    def test_mode_stitch_multiple_words_translation1(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "HR*U": "you will"
+
+        PHO*D  ''
+        TEFT   ' t-e-s-t'
+        HR*U   ' t-e-s-t y-o-u w-i-l-l'
+        '''
+
+    def test_mode_stitch_multiple_words_translation2(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "HR*U": "you, will"
+
+        PHO*D  ''
+        TEFT   ' t-e-s-t'
+        HR*U   ' t-e-s-t y-o-u, w-i-l-l'
+        '''
+
+    def test_mode_stitch_orthography_replace1(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "PHAED": "made",
+        "KWREU": "{^y}"
+
+        PHO*D/PHAED/KWREU ' m-a-d-y'
+        '''
+
+    def test_mode_stitch_orthography_replace2(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TPHAD/KWAT": "inadequate",
+        "SEU": "{^cy}",
+
+        PHO*D/TPHAD/KWAT/SEU ' i-n-a-d-e-q-u-a-c-y'
+        '''
+
+    def test_mode_stitch_orthography_replace3(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TPHAD/KWAT": "inadequate",
+        "R-FT": "{MODE:RESET}",
+        "SEU": "{^cy}",
+
+        PHO*D/TPHAD/KWAT/R-FT/SEU ' i-n-a-d-e-q-u-a-cy'
+        '''
+
+    def test_mode_stitch_orthography_replace4(self):
+        r'''
+        # Torture test where the last stitch character isn't the last one used
+        "PHO*D": "{MODE:STITCH}",
+        "TPHO": "{MODE:STITCH:#}",
+        "TPHAD/KWAT": "inadequate",
+        "R-FT": "{MODE:RESET}",
+        "SEU": "{^cy}",
+
+        PHO*D/TPHAD/KWAT/TPHO/R-FT/SEU ' i-n-a-d-e-q-u-a-cy'
+        '''
+
+    def test_mode_stitch_punctuation(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "KW-BG": "{,}",
+
+        PHO*D/TEFT/KW-BG/TEFT ' t-e-s-t, t-e-s-t'
+        '''
+
+    def test_mode_stitch_multiple_lines_translation(self):
+        r'''
+        "PHO*D": "{MODE:STITCH}",
+        "TEFT": "test",
+        "HR*U": "you\nwill"
+
+        PHO*D  ''
+        TEFT   ' t-e-s-t'
+        HR*U   ' t-e-s-t y-o-u\nw-i-l-l'
+        '''
+
     def test_fingerspelling_1a(self):
         r'''
         'K': '{&c}',

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -17,12 +17,40 @@ class TestsBlackbox(BlackboxTester):
         TEFT/R*S  " test test"
         '''
 
+    def test_mode_title(self):
+        r'''
+        "T-LT": "{MODE:TITLE}",
+        "TEFT": "test",
+        "R-FT": "{MODE:RESET_CASE}",
+
+        T-LT/TEFT/TEFT/R-FT/TEFT  " Test Test test"
+        '''
+
+    def test_mode_title_attached(self):
+        r'''
+        "T-LT": "{MODE:TITLE}",
+        "TEFT": "test",
+        "TK-LS": "{^^}",
+        "PEUG": "pig",
+
+        T-LT/TEFT/TK-LS/PEUG/PEUG  " Testpig Pig"
+        '''
+
     def test_force_lowercase_title(self):
         r'''
         "T-LT": "{MODE:TITLE}",
         "TEFT": "{>}test",
 
         T-LT/TEFT  " test"
+        '''
+
+    def test_mode_lower(self):
+        r'''
+        "T-LT": "{MODE:LOWER}",
+        "TEFT": "TeST",
+        "R-FT": "{MODE:RESET_CASE}",
+
+        T-LT/TEFT/TEFT/R-FT/TEFT  " test test TeST"
         '''
 
     def test_bug471(self):
@@ -1176,6 +1204,24 @@ class TestsBlackbox(BlackboxTester):
         TEFT       'glueTest'
         '''
 
+    def test_mode_set_space_none(self):
+        r'''
+        "PHO*D": "{MODE:SET_SPACE:}",
+        "R-FT": "{MODE:RESET}",
+        "TEFT": "test",
+
+        PHO*D/TEFT/TEFT/R-FT/TEFT 'testtest test'
+        '''
+
+    def test_mode_set_space_multiple_characters(self):
+        r'''
+        "PHO*D": "{MODE:SET_SPACE:...}",
+        "R-FT": "{MODE:RESET}",
+        "TEFT": "test",
+
+        PHO*D/TEFT/TEFT/R-FT/TEFT '...test...test test'
+        '''
+
     def test_fingerspelling_1a(self):
         r'''
         'K': '{&c}',
@@ -1397,4 +1443,13 @@ class TestsBlackbox(BlackboxTester):
         "TKPWAEUPL": "game",
 
         KPA*L/TKPWAEUPL/-G/*  ' GAME'
+        '''
+
+    def test_bug966_3(self):
+        r'''
+        "-G": "{>}{^ing}",
+        "KPA*L": "{<}",
+        "TKPWAEUPL": "game",
+
+        KPA*L/TKPWAEUPLG  ' GAMing'
         '''

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -747,6 +747,22 @@ CHANGE_MODE_TESTS = (
     lambda:
     ('SNAKE', action(),
      action(space_char='_')),
+    # STITCH: Default hyphen
+    lambda:
+    ('STITCH', action(),
+     action(stitch_char='-')),
+    # STITCH: Custom delimiter
+    lambda:
+    ('STITCH:bob', action(),
+     action(stitch_char='bob')),
+    # STITCH: Ambiguous case
+    lambda:
+    ('STITCH:', action(),
+     action(stitch_char='-')),
+    # RESET_STITCH: No stitch
+    lambda:
+    ('RESET_STITCH', action(stitch_char='-'),
+     action()),
     # RESET_SPACE: Default space
     lambda:
     ('RESET_SPACE', action(space_char='ABCD'),
@@ -765,7 +781,13 @@ CHANGE_MODE_TESTS = (
     lambda:
     ('SET_SPACE:123 45', action(space_char='test'),
      action(space_char='123 45')),
-    # RESET: No case, default space
+    # RESET: No case or stitch, default space.
+    lambda:
+    ('RESET', action(
+        case=formatting.CASE_UPPER,
+        stitch_char='-',
+        space_char=''),
+     action()),
 )
 
 @parametrize(CHANGE_MODE_TESTS)

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -834,57 +834,6 @@ def test_meta_carry_capitalize(meta, last_action, expected):
     ctx.translated(last_action)
     assert formatting._atom_to_action('{' + meta + '}', ctx) == expected
 
-
-def _apply_case_tests():
-    test = ' some test '
-    test2 = 'test Me'
-    test3 = ' SOME TEST '
-    return (
-        # INVALID
-        lambda: (test, '', False, ValueError),
-        lambda: (test, 'TEST', False, ValueError),
-        # NO-OP
-        lambda: (test, None, False, test),
-        lambda: (test, None, True, test),
-        # TITLE
-        lambda: (test, formatting.CASE_TITLE, False, ' Some Test '),
-        # TITLE will not affect appended output
-        lambda: (test, formatting.CASE_TITLE, True, ' some test '),
-        lambda: (test2, formatting.CASE_TITLE, True, 'test Me'),
-        # LOWER
-        lambda: (test, formatting.CASE_LOWER, False, ' some test '),
-        lambda: (test3, formatting.CASE_LOWER, False, ' some test '),
-        lambda: (test2, formatting.CASE_LOWER, True, 'test me'),
-        # UPPER
-        lambda: (test.upper(), formatting.CASE_UPPER, False, ' SOME TEST '),
-        lambda: (test3, formatting.CASE_UPPER, False, ' SOME TEST '),
-        lambda: (test2, formatting.CASE_UPPER, True, 'TEST ME'),
-    )
-
-@parametrize(_apply_case_tests())
-def test_apply_case(input_text, case, appended, expected):
-    if inspect.isclass(expected):
-        with pytest.raises(expected):
-            formatting._apply_mode_case(input_text, case, appended)
-    else:
-        assert formatting._apply_mode_case(input_text, case, appended) == expected
-
-
-def _apply_space_char_tests():
-    test = ' some text '
-    test2 = "don't"
-    return (
-        lambda: (test, '_', '_some_text_'),
-        lambda: (test, '', 'sometext'),
-        lambda: (test2, '_', test2),
-        lambda: (test2, '', test2),
-    )
-
-@parametrize(_apply_space_char_tests())
-def test_apply_space_char(text, space_char, expected):
-    assert formatting._apply_mode_space_char(text, space_char) == expected
-
-
 @parametrize((
     lambda: ('', None),
     lambda: ('{abc}', 'abc'),


### PR DESCRIPTION
`{MODE:STITCH}` to enable s-t-i-t-c-h-i-n-g, supporting custom delimiter with syntax `{MODE:STITCH:delim}`

This is a revisit of #623 and a mode to similarly support the functionality given by https://github.com/morinted/plover_stitching

This mode and that plugin together fix #178 
