### PR TITLE
formatting: fix orthographic replacements

### DIFF
--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -775,7 +775,9 @@ def _apply_meta_attach(meta, ctx):
     ):
         new_word = add_suffix(last_word, meta)
         common_len = len(commonprefix([last_word, new_word]))
-        action.prev_replace = last_word[common_len:]
+        replaced = last_word[common_len:]
+        action.prev_replace = ctx.last_text(len(replaced))
+        assert replaced.lower() == action.prev_replace.lower()
         last_word = last_word[:common_len]
         meta = new_word[common_len:]
     action.text = meta

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1380,3 +1380,21 @@ class TestsBlackbox(BlackboxTester):
         PHAED/KWREUS  'madies '
         *             'made '
         '''
+
+    def test_bug966_1(self):
+        r'''
+        "-G": "{^ing}",
+        "KPA*L": "{<}",
+        "TKPWAEUPL": "game",
+
+        KPA*L/TKPWAEUPLG  ' GAMING'
+        '''
+
+    def test_bug966_2(self):
+        r'''
+        "-G": "{^ing}",
+        "KPA*L": "{<}",
+        "TKPWAEUPL": "game",
+
+        KPA*L/TKPWAEUPL/-G/*  ' GAME'
+        '''


### PR DESCRIPTION
Account for the fact that casing may have changed. Fix #966.