### PR TITLE
gui_qt: Add open config folder action

### DIFF
--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -1,7 +1,9 @@
 
 from functools import partial
 import json
-import webbrowser
+import os
+import sys
+import subprocess
 
 from PyQt5.QtCore import QCoreApplication, Qt
 from PyQt5.QtGui import QCursor, QIcon, QKeySequence
@@ -242,7 +244,13 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         self._configure()
 
     def on_open_config_folder(self):
-        webbrowser.open(CONFIG_DIR)
+        # webbrowser.open does not work on Mac so we need OS-specific logic
+        if sys.platform.startswith('win'):
+            os.startfile(CONFIG_DIR)
+        elif sys.platform.startswith('linux'):
+            subprocess.run(['xdg-open', CONFIG_DIR])
+        elif sys.platform.startswith('darwin'):
+            subprocess.run(['open', CONFIG_DIR])
 
     def on_reconnect(self):
         self._engine.reset_machine()

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -1,6 +1,7 @@
 
 from functools import partial
 import json
+import webbrowser
 
 from PyQt5.QtCore import QCoreApplication, Qt
 from PyQt5.QtGui import QCursor, QIcon, QKeySequence
@@ -11,6 +12,7 @@ from PyQt5.QtWidgets import (
 
 from plover import log
 from plover.oslayer import wmctrl
+from plover.oslayer.config import CONFIG_DIR
 from plover.registry import registry
 from plover.resource import resource_filename
 
@@ -67,6 +69,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             'menu_Tools',
             '',
             'action_Configure',
+            'action_OpenConfigFolder',
             '',
             'menu_Help',
             '',
@@ -237,6 +240,9 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
 
     def on_configure(self):
         self._configure()
+
+    def on_open_config_folder(self):
+        webbrowser.open(CONFIG_DIR)
 
     def on_reconnect(self):
         self._engine.reset_machine()

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -244,13 +244,12 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         self._configure()
 
     def on_open_config_folder(self):
-        # webbrowser.open does not work on Mac so we need OS-specific logic
         if sys.platform.startswith('win'):
             os.startfile(CONFIG_DIR)
         elif sys.platform.startswith('linux'):
-            subprocess.run(['xdg-open', CONFIG_DIR])
+            subprocess.call(['xdg-open', CONFIG_DIR])
         elif sys.platform.startswith('darwin'):
-            subprocess.run(['open', CONFIG_DIR])
+            subprocess.call(['open', CONFIG_DIR])
 
     def on_reconnect(self):
         self._engine.reset_machine()

--- a/plover/gui_qt/main_window.ui
+++ b/plover/gui_qt/main_window.ui
@@ -163,6 +163,7 @@
     <addaction name="action_Reconnect"/>
     <addaction name="separator"/>
     <addaction name="action_Configure"/>
+    <addaction name="action_OpenConfigFolder"/>
     <addaction name="separator"/>
     <addaction name="action_Show"/>
     <addaction name="action_Quit"/>
@@ -234,6 +235,18 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+,</string>
+   </property>
+  </action>
+  <action name="action_OpenConfigFolder">
+   <property name="icon">
+    <iconset resource="resources/resources.qrc">
+     <normaloff>:/folder.svg</normaloff>:/folder.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Open config &amp;folder</string>
+   </property>
+   <property name="toolTip">
+    <string>Open the configuration folder.</string>
    </property>
   </action>
   <action name="action_About">
@@ -322,6 +335,22 @@
    <signal>triggered()</signal>
    <receiver>MainWindow</receiver>
    <slot>on_configure()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>140</x>
+     <y>57</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_OpenConfigFolder</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>on_open_config_folder()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>
@@ -449,6 +478,7 @@
  <slots>
   <slot>on_reconnect()</slot>
   <slot>on_configure()</slot>
+  <slot>on_open_config_folder()</slot>
   <slot>on_manage_dictionaries()</slot>
   <slot>on_quit()</slot>
   <slot>on_toggle_output(bool)</slot>

--- a/plover/gui_qt/resources/folder.svg
+++ b/plover/gui_qt/resources/folder.svg
@@ -1,0 +1,4 @@
+<svg version="1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" enable-background="new 0 0 48 48">
+    <path fill="#FFA000" d="M40,12H22l-4-4H8c-2.2,0-4,1.8-4,4v8h40v-4C44,13.8,42.2,12,40,12z"/>
+    <path fill="#FFCA28" d="M40,12H8c-2.2,0-4,1.8-4,4v20c0,2.2,1.8,4,4,4h32c2.2,0,4-1.8,4-4V16C44,13.8,42.2,12,40,12z"/>
+</svg>

--- a/plover/gui_qt/resources/resources.qrc
+++ b/plover/gui_qt/resources/resources.qrc
@@ -1,29 +1,30 @@
 <RCC>
-    <qresource prefix="/">
-        <file>up.svg</file>
-        <file>down.svg</file>
-        <file>tape.svg</file>
-        <file>save.svg</file>
-        <file>undo.svg</file>
-        <file>settings.svg</file>
-        <file>state-disabled.svg</file>
-        <file>state-disconnected.svg</file>
-        <file>state-enabled.svg</file>
-        <file>reconnect.svg</file>
-        <file>plover.png</file>
-        <file>font_selector.svg</file>
-        <file>lookup.svg</file>
-        <file>pin.svg</file>
-        <file>translation_add.svg</file>
-        <file>trash.svg</file>
-        <file>add.svg</file>
-        <file>lightbulb.svg</file>
-        <file>pencil.svg</file>
-        <file>remove.svg</file>
-        <file>dictionary_error.svg</file>
-        <file>dictionary_favorite.svg</file>
-        <file>dictionary_normal.svg</file>
-        <file>dictionary_readonly.svg</file>
-        <file>dictionary_loading.svg</file>
-    </qresource>
+  <qresource prefix="/">
+    <file>folder.svg</file>
+    <file>up.svg</file>
+    <file>down.svg</file>
+    <file>tape.svg</file>
+    <file>save.svg</file>
+    <file>undo.svg</file>
+    <file>settings.svg</file>
+    <file>state-disabled.svg</file>
+    <file>state-disconnected.svg</file>
+    <file>state-enabled.svg</file>
+    <file>reconnect.svg</file>
+    <file>plover.png</file>
+    <file>font_selector.svg</file>
+    <file>lookup.svg</file>
+    <file>pin.svg</file>
+    <file>translation_add.svg</file>
+    <file>trash.svg</file>
+    <file>add.svg</file>
+    <file>lightbulb.svg</file>
+    <file>pencil.svg</file>
+    <file>remove.svg</file>
+    <file>dictionary_error.svg</file>
+    <file>dictionary_favorite.svg</file>
+    <file>dictionary_normal.svg</file>
+    <file>dictionary_readonly.svg</file>
+    <file>dictionary_loading.svg</file>
+  </qresource>
 </RCC>


### PR DESCRIPTION
<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
Fixes #697.

<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
I added an entry for "Open config folder" to the File menu that opens up the configuration folder.

![image](https://user-images.githubusercontent.com/4577561/42416991-d356fb26-8242-11e8-9039-48cd4105c4f4.png)

The icon used is from [Icons8 Flat Color Icons](https://github.com/icons8/flat-color-icons).

Perhaps the oddest part here is the use of webbrowser.open to open the folder. os.startfile is Windows exclusive, so I searched around for cross platform ways to open folders and files and ended up on that standard library function accomplishing the desired behavior despite the name. Alternatively something like this could be implemented, but I figured if webbrowser.open works it's simpler to rely on it:

```python
import subprocess, os
if sys.platform.startswith('darwin'):
    subprocess.call(('open', filepath))
elif os.name == 'nt':
    os.startfile(filepath)
elif os.name == 'posix':
    subprocess.call(('xdg-open', filepath))
```

I've only verified behavior on Windows, so Mac / Linux testing would be nice.