### PR TITLE
Add regex search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,12 @@ nosetests.xml
 # mac files
 .DS_store
 
-# emacs backups
+# Vim/emacs backups
 *~
+
+# Vim swap/undo files
+*.swp
+*.un
 
 # deleted files
 \#*#

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -475,6 +475,14 @@ class StenoEngine:
     def get_suggestions(self, translation):
         return Suggestions(self._dictionaries).find(translation)
 
+    @with_lock
+    def get_regex_suggestions(self, translation):
+        return Suggestions(self._dictionaries).findRegex(translation)
+    
+    @with_lock
+    def get_stroke_suggestion(self, translation):
+        return Suggestions(self._dictionaries).findTranslation(translation)
+
     @property
     @with_lock
     def translator_state(self):

--- a/plover/gui_qt/lookup_dialog.ui
+++ b/plover/gui_qt/lookup_dialog.ui
@@ -23,6 +23,16 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="SuggestionsWidget" name="suggestions" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
@@ -43,13 +53,13 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="SuggestionsWidget" name="suggestions" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="regexCheck">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="text">
+      <string>Regex Search</string>
      </property>
     </widget>
    </item>
@@ -72,8 +82,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>257</x>
+     <y>239</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -88,8 +98,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>264</x>
+     <y>239</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -113,8 +123,25 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>regexCheck</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>LookupDialog</receiver>
+   <slot>on_modeChange(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>136</x>
+     <y>135</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>on_lookup(QString)</slot>
+  <slot>on_modeChange(int)</slot>
  </slots>
 </ui>

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -52,6 +52,12 @@ class SuggestionsWidget(QWidget, Ui_SuggestionsWidget):
 
     def clear(self):
         self.suggestions.clear()
+        
+    def replace(self, suggestion_list):
+        self.clear()
+        self.append(suggestion_list)
+        scrollbar = self.suggestions.verticalScrollBar()
+        scrollbar.setValue(scrollbar.minimum())
 
     def _reformat(self):
         document = self.suggestions.document()

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -50,3 +50,16 @@ class Suggestions:
                 suggestions.append(suggestion)
 
         return suggestions
+    
+    def findRegex(self, translation):
+        matches = self.dictionary.regex_reverse_lookup(translation)
+        suggestions = [Suggestion(m, sort_steno_strokes(k)) for (m,k) in matches]
+        suggestions.sort(key=lambda s: s.text)
+        return suggestions
+    
+    def findTranslation(self, translation):
+        formatted_tr = tuple(translation.split("/"))
+        strokes = self.dictionary.lookup(formatted_tr)
+        if strokes is not None:
+            return Suggestion(translation+" maps to",[(strokes,)])
+        return None


### PR DESCRIPTION
I have made a few changes to the program mainly for my personal use, but I feel like it's time to share them now. There is now a "Regex Search" checkbox on the lookup window that allows regular expression search of the loaded dictionaries rather than just exact match w/ prefixes and suffixes:

![image](https://user-images.githubusercontent.com/39717492/43353434-f73fa1d4-91fe-11e8-945e-be4ff126686c.png)

Even without using regex symbols, this search can handle partial word searches, which has been a requested feature. The main thing I was worried about was the computational power required to filter() 80,000 dictionary keys using a regular expression. The performance doesn't seem too bad on my computer, but mine is rather fast and may not be a good benchmark. It's also possible that Python has built-in optimizations for this sort of thing, which would be great, but I just don't know for sure. If it does perform well, it could eventually be a good replacement for the normal search (with regex special characters escaped).

Also, if you enter a raw steno stroke pattern in the lookup window (i.e. STROEBG), it will return what it maps to. Not a huge change, but it does help to identify strokes that produce something other than readable text.