### PR TITLE
setup: use PEP 518 support for build dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ include plover/gui_qt/resources/*.png
 include plover/gui_qt/resources/*.qrc
 include plover/gui_qt/resources/*.svg
 include plover_build_utils/*.sh
+include pyproject.toml
 include requirements*.txt
 include rpm/*.spec
 include test.bat

--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -158,34 +158,3 @@ class BuildPy(build_py):
         build_py.run(self)
 
 # }}}
-
-
-def ensure_setup_requires(setuptools_spec, dependency_links=None, setup_requires=None):
-    if 'PYTHONPATH' in os.environ:
-        py_path = os.environ['PYTHONPATH'].split(os.pathsep)
-    else:
-        py_path = []
-    # First, ensure the correct version of setuptools is active.
-    setuptools_req = next(pkg_resources.parse_requirements('setuptools' + setuptools_spec))
-    setuptools_dist = pkg_resources.get_distribution('setuptools')
-    if setuptools_dist not in setuptools_req:
-        setuptools_dist = setuptools.Distribution().fetch_build_eggs(str(setuptools_req))[0]
-        py_path.insert(0, setuptools_dist.location)
-        os.environ['PYTHONPATH'] = os.pathsep.join(py_path)
-        args = [sys.executable] + sys.argv
-        os.execv(args[0], args)
-    # Second, install other setup requirements.
-    setup_attrs = {}
-    if dependency_links is not None:
-        setup_attrs['dependency_links'] = dependency_links
-    if setup_requires is not None:
-        setup_attrs['setup_requires'] = setup_requires
-    setup_dist = setuptools.Distribution(setup_attrs)
-    setup_dist.parse_config_files(ignore_option_errors=True)
-    if not setup_dist.setup_requires:
-        return
-    eggs_dir = setup_dist.get_egg_cache_dir()
-    for dist in setup_dist.fetch_build_eggs(setup_dist.setup_requires):
-        if dist.location.startswith(os.path.abspath(eggs_dir) + os.sep):
-            py_path.insert(0, dist.location)
-    os.environ['PYTHONPATH'] = os.pathsep.join(py_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+	"Babel",
+	"PyQt5>=5.8.2",
+	"setuptools>=38.2.4",
+	"wheel",
+]

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,8 @@ from plover import (
 
 from plover_build_utils.setup import (
     BuildPy, BuildUi, Command, Test,
-    ensure_setup_requires,
 )
 
-
-ensure_setup_requires('>=38.2.4')
 
 BuildPy.build_dependencies.append('build_ui')
 cmdclass = {


### PR DESCRIPTION
Now that [PEP 518](https://www.python.org/dev/peps/pep-0518/) is supported by pip (`>=18.0`), we can use it for declaring build dependencies.