### PR TITLE
Add set config engine command

### DIFF
--- a/news.d/feature/989.core.rst
+++ b/news.d/feature/989.core.rst
@@ -1,0 +1,6 @@
+A new ``SET_CONFIG`` command can be used to change the configuration with a stroke, e.g.::
+
+        "O*EP": "{PLOVER:SET_CONFIG:'translation_frame_opacity':100}",
+        "TR*PB": "{PLOVER:SET_CONFIG:'translation_frame_opacity':0}",
+
+to change the opacity of the "Add Translation" dialog on the fly.

--- a/plover/command/set_config.py
+++ b/plover/command/set_config.py
@@ -1,0 +1,32 @@
+import ast
+
+
+def set_config(engine, cmdline):
+    """
+    Set one or more Plover config options upon executing a stroke pattern.
+
+    Syntax:
+    {PLOVER:SET_CONFIG:option:value}
+    {PLOVER:SET_CONFIG:option1:value1,option2:value2,...}
+
+    Example usage:
+    "O*EP":   "{PLOVER:SET_CONFIG:'translation_frame_opacity':100}",
+    "STA*RT": "{PLOVER:SET_CONFIG:'start_attached':True,'start_capitalized':True}",
+
+    Be careful with nested quotes. Plover's JSON dictionaries use double quotes
+    by default, so use single quotes for config option names and other strings.
+    """
+    # Each config setting can be processed as a key:value pair in a dict.
+    # The engine.config property setter will update all settings at once.
+    engine.config = _cmdline_to_dict(cmdline)
+
+
+def _cmdline_to_dict(cmdline):
+    """ Add braces and parse the entire command line as a Python dict literal. """
+    try:
+        opt_dict = ast.literal_eval('{'+cmdline+'}')
+        assert isinstance(opt_dict, dict)
+        return opt_dict
+    except (AssertionError, SyntaxError, ValueError) as e:
+        raise ValueError('Bad command string "%s" for PLOVER:SET_CONFIG.\n' % cmdline
+                         + 'See for reference:\n\n' + set_config.__doc__) from e

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
 	wcwidth
 packages =
 	plover
+	plover.command
 	plover.dictionary
 	plover.gui_none
 	plover.gui_qt
@@ -57,6 +58,8 @@ gui_qt =
 [options.entry_points]
 console_scripts =
 	plover = plover.main:main
+plover.command =
+	set_config = plover.command.set_config:set_config
 plover.dictionary =
 	json = plover.dictionary.json_dict:JsonDictionary
 	rtf  = plover.dictionary.rtfcre_dict:RtfDictionary

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,7 +1,6 @@
 """ Unit tests for built-in engine command plugins. """
 
 import ast
-import io
 
 import pytest
 
@@ -9,9 +8,12 @@ from plover.command.set_config import set_config
 from plover.config import Config, DictionaryConfig
 from test.test_config import DEFAULTS, DEFAULT_KEYMAP
 
+from . import parametrize
 
-class _CFGFakeEngine:
-    """ The plugin sets the engine.config property, which unpacks a dict as keywords into config.update. """
+
+class FakeEngine:
+    """ The plugin sets the engine.config property, which unpacks a dict as
+    keywords into config.update. """
     def __init__(self):
         self._cfg = Config()
     @property
@@ -20,55 +22,58 @@ class _CFGFakeEngine:
     @config.setter
     def config(self, options):
         self._cfg.update(**options)
-    def cfg_to_bytes(self):
-        stream = io.BytesIO()
-        self._cfg.save(stream)
-        return stream.getvalue()
 
 
-def test_set_config():
+SET_CONFIG_TESTS = (
+    lambda: ('"space_placement":"After Output"',               "After Output"),
+    lambda: ('"start_attached":True',                          True),
+    lambda: ('"undo_levels":10',                               10),
+    lambda: ('"log_file_name":"c:/whatever/morestrokes.log"',  "c:/whatever/morestrokes.log"),
+    lambda: ('"enabled_extensions":[]',                        set()),
+    lambda: ('"machine_type":"Keyboard"',                      "Keyboard"),
+    lambda: ('"machine_specific_options":{"arpeggiate":True}', {"arpeggiate": True}),
+    lambda: ('"system_keymap":'+str(DEFAULT_KEYMAP),           DEFAULT_KEYMAP),
+    lambda: ('"dictionaries":("user.json","main.json")',       list(map(DictionaryConfig, ("user.json", "main.json")))),
+)
+
+@parametrize(SET_CONFIG_TESTS)
+def test_set_config(cmdline, expected):
     """ Unit tests for set_config command. Test at least one of each valid data type. """
     # Config values are sometimes converted and stored as different types than the input,
     # so the expected output config values may not always be strictly equal to the input.
-    valid_tests = [
-        ('"space_placement":"After Output"',               "After Output"),
-        ('"start_attached":True',                          True),
-        ('"undo_levels":10',                               10),
-        ('"log_file_name":"c:/whatever/morestrokes.log"',  "c:/whatever/morestrokes.log"),
-        ('"enabled_extensions":[]',                        set()),
-        ('"machine_type":"Keyboard"',                      "Keyboard"),
-        ('"machine_specific_options":{"arpeggiate":True}', {"arpeggiate": True}),
-        ('"system_keymap":'+str(DEFAULT_KEYMAP),           DEFAULT_KEYMAP),
-        ('"dictionaries":("user.json","main.json")',       list(map(DictionaryConfig, ("user.json", "main.json")))),
-    ]
-    engine = _CFGFakeEngine()
+    engine = FakeEngine()
     engine.config = DEFAULTS
-    # For each valid command, make sure the value made it in and back out acceptably.
-    for (cmdline, expected) in valid_tests:
-        set_config(engine, cmdline)
-        key, value = ast.literal_eval("{"+cmdline+"}").popitem()
-        assert engine.config[key] == expected
-    # Save the modified config file to a bytes object for reference.
-    file_individual = engine.cfg_to_bytes()
-    # Multiple options can be set with one command if separated by commas.
-    # Try setting every test option from scratch with a single command
-    # and make sure the saved results are the same as before.
+    set_config(engine, cmdline)
+    key = ast.literal_eval("{"+cmdline+"}").popitem()[0]
+    assert engine.config[key] == expected
+
+def test_set_config_multiple_options():
+    """ Multiple options can be set with one command if separated by commas.
+    Try setting every test option from scratch with a single command. """
+    engine = FakeEngine()
     engine.config = DEFAULTS
-    compound_cmdline = ",".join(t[0] for t in valid_tests)
+    individual_tests = [t() for t in SET_CONFIG_TESTS]
+    compound_cmdline = ",".join([t[0] for t in individual_tests])
     set_config(engine, compound_cmdline)
-    file_compound = engine.cfg_to_bytes()
-    assert file_individual == file_compound
+    for cmdline, expected in individual_tests:
+        key = ast.literal_eval("{"+cmdline+"}").popitem()[0]
+        assert engine.config[key] == expected
 
 
-def test_set_config_exceptions():
+SET_CONFIG_INVALID_TESTS = (
+    # No delimiter in command.
+    lambda: '"undo_levels"10',
+    # Wrong value type.
+    lambda: '"undo_levels":"does a string work?"',
+    # Unsupported value.
+    lambda: '"machine_type":"Telepathy"',
+    # Bad format for dict literal.
+    lambda: '"machine_specific_options":{"closing_brace":False',
+)
+
+@parametrize(SET_CONFIG_INVALID_TESTS, arity=1)
+def test_set_config_invalid(invalid_cmdline):
     """ Unit tests for set_config exception handling. """
-    invalid_tests = [
-        '"undo_levels"10',                                    # No delimiter in command.
-        '"undo_levels":"does a string work?"',                # Wrong value type.
-        '"machine_type":"Telepathy"',                         # Unsupported value.
-        '"machine_specific_options":{"closing_brace":False',  # Bad format for dict literal.
-    ]
-    engine = _CFGFakeEngine()
-    for cmdline in invalid_tests:
-        with pytest.raises(ValueError):
-            set_config(engine, cmdline)
+    engine = FakeEngine()
+    with pytest.raises(ValueError):
+        set_config(engine, invalid_cmdline)

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,0 +1,74 @@
+""" Unit tests for built-in engine command plugins. """
+
+import ast
+import io
+
+import pytest
+
+from plover.command.set_config import set_config
+from plover.config import Config, DictionaryConfig
+from test.test_config import DEFAULTS, DEFAULT_KEYMAP
+
+
+class _CFGFakeEngine:
+    """ The plugin sets the engine.config property, which unpacks a dict as keywords into config.update. """
+    def __init__(self):
+        self._cfg = Config()
+    @property
+    def config(self):
+        return self._cfg.as_dict()
+    @config.setter
+    def config(self, options):
+        self._cfg.update(**options)
+    def cfg_to_bytes(self):
+        stream = io.BytesIO()
+        self._cfg.save(stream)
+        return stream.getvalue()
+
+
+def test_set_config():
+    """ Unit tests for set_config command. Test at least one of each valid data type. """
+    # Config values are sometimes converted and stored as different types than the input,
+    # so the expected output config values may not always be strictly equal to the input.
+    valid_tests = [
+        ('"space_placement":"After Output"',               "After Output"),
+        ('"start_attached":True',                          True),
+        ('"undo_levels":10',                               10),
+        ('"log_file_name":"c:/whatever/morestrokes.log"',  "c:/whatever/morestrokes.log"),
+        ('"enabled_extensions":[]',                        set()),
+        ('"machine_type":"Keyboard"',                      "Keyboard"),
+        ('"machine_specific_options":{"arpeggiate":True}', {"arpeggiate": True}),
+        ('"system_keymap":'+str(DEFAULT_KEYMAP),           DEFAULT_KEYMAP),
+        ('"dictionaries":("user.json","main.json")',       list(map(DictionaryConfig, ("user.json", "main.json")))),
+    ]
+    engine = _CFGFakeEngine()
+    engine.config = DEFAULTS
+    # For each valid command, make sure the value made it in and back out acceptably.
+    for (cmdline, expected) in valid_tests:
+        set_config(engine, cmdline)
+        key, value = ast.literal_eval("{"+cmdline+"}").popitem()
+        assert engine.config[key] == expected
+    # Save the modified config file to a bytes object for reference.
+    file_individual = engine.cfg_to_bytes()
+    # Multiple options can be set with one command if separated by commas.
+    # Try setting every test option from scratch with a single command
+    # and make sure the saved results are the same as before.
+    engine.config = DEFAULTS
+    compound_cmdline = ",".join(t[0] for t in valid_tests)
+    set_config(engine, compound_cmdline)
+    file_compound = engine.cfg_to_bytes()
+    assert file_individual == file_compound
+
+
+def test_set_config_exceptions():
+    """ Unit tests for set_config exception handling. """
+    invalid_tests = [
+        '"undo_levels"10',                                    # No delimiter in command.
+        '"undo_levels":"does a string work?"',                # Wrong value type.
+        '"machine_type":"Telepathy"',                         # Unsupported value.
+        '"machine_specific_options":{"closing_brace":False',  # Bad format for dict literal.
+    ]
+    engine = _CFGFakeEngine()
+    for cmdline in invalid_tests:
+        with pytest.raises(ValueError):
+            set_config(engine, cmdline)


### PR DESCRIPTION
Fixes #983.
 
I've added an engine command: SET_CONFIG, which allows you to set a Plover config setting using a stroke. Mirabai asked for a command that would change the add-translation window opacity, and this does that among other things. Adding entries like this into your dictionary will allow you to set values in the global configuration:

``"O*EP": "{PLOVER:SET_CONFIG:translation_frame_opacity,100}",``
``"TR*PB": "{PLOVER:SET_CONFIG:translation_frame_opacity,0}"``

Those change the add translation window opacity, but it should work for any config setting with a value that is type-castable from a string. With a little further work I could make it usable for the more complex config settings, possibly allowing you to do things like switch out dictionaries using this command.