### PR TITLE
Fix Python 3.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.4.0
 check-manifest==0.35
-Cython==0.25.2
+Cython==0.28.5
 https://github.com/benoit-pierre/dmgbuild/archive/plover.zip; "darwin" in sys_platform
 docutils==0.14
 macholib==1.8; "darwin" in sys_platform

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ keywords = plover
 
 [options]
 include_package_data = True
+python_requires = >=3.4
 zip_safe = True
 setup_requires =
 	Babel

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ classifiers =
         Programming Language :: Python :: 3.4
         Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
+        Programming Language :: Python :: 3.7
         License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
         Development Status :: 5 - Production/Stable
         Environment :: X11 Applications


### PR DESCRIPTION
Rational: Arch Linux just switched to Python 3.7.