### PR TITLE
macro: fix retrospective insert space with suffix keys

### DIFF
--- a/plover/macro/retrospective.py
+++ b/plover/macro/retrospective.py
@@ -1,6 +1,7 @@
 
 from plover.translation import Translation
 from plover.steno import Stroke
+from plover import system
 
 
 def toggle_asterisk(translator, stroke, cmdline):
@@ -49,7 +50,10 @@ def insert_space(translator, stroke, cmdline):
     english = [t.english or '/'.join(t.rtfcre)
                for t in replaced.replaced]
     if english:
-        english.append(translator.lookup([lookup_stroke]) or lookup_stroke.rtfcre)
+        english.append(
+            translator.lookup([lookup_stroke], system.SUFFIX_KEYS)
+            or lookup_stroke.rtfcre
+        )
         t = Translation([stroke], ' '.join(english))
         t.replaced = [replaced]
         t.is_retrospective_command = True

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1398,3 +1398,15 @@ class TestsBlackbox(BlackboxTester):
 
         KPA*L/TKPWAEUPL/-G/*  ' GAME'
         '''
+
+    def test_bug980(self):
+        r'''
+        "PUFRPB": "punch",
+        "HRAOEUPB": "line",
+        "PUFRPB/HRAOEUPB": "punchline",
+        "-S": "{^s}",
+        "AFPS": "{*?}",
+
+        PUFRPB/HRAOEUPBS  ' punchlines'
+        AFPS              ' punch lines'
+        '''


### PR DESCRIPTION
Fix #980.
