### PR TITLE
Replace case-reverse lookup system

### DIFF
--- a/plover/engine.py
+++ b/plover/engine.py
@@ -15,7 +15,7 @@ from plover.registry import registry
 from plover.resource import ASSET_SCHEME, resource_filename
 from plover.steno import Stroke
 from plover.steno_dictionary import StenoDictionary, StenoDictionaryCollection
-from plover.suggestions import Suggestions
+from plover.suggestions import find_suggestions
 from plover.translation import Translator
 
 
@@ -468,7 +468,7 @@ class StenoEngine:
 
     @with_lock
     def get_suggestions(self, translation):
-        return Suggestions(self._dictionaries).find(translation)
+        return find_suggestions(self._dictionaries,translation)
 
     @property
     @with_lock

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -459,11 +459,6 @@ class StenoEngine:
         return [] if matches is None else matches
 
     @with_lock
-    def casereverse_lookup(self, translation):
-        matches = self._dictionaries.casereverse_lookup(translation)
-        return set() if matches is None else matches
-
-    @with_lock
     def add_dictionary_filter(self, dictionary_filter):
         self._dictionaries.add_filter(dictionary_filter)
 

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -2,48 +2,43 @@ import collections
 
 from plover.steno import sort_steno_strokes
 
-
 Suggestion = collections.namedtuple('Suggestion', 'text steno_list')
 
 
-class Suggestions:
-    def __init__(self, dictionary):
-        self.dictionary = dictionary
+def find_suggestions(dictionary, translation):
+    # List of base translations to try looking up, including stripped and case variations.
+    # Make it start out as a set so that duplicates are removed.
+    base = list({
+        translation,               # Self
+        translation.strip(' '),    # Strip spaces (patterns with \n or \t are correctly handled)
+        translation.lower(),       # All lowercase
+        translation.capitalize(),  # First letter capitalized
+        translation.upper(),       # All uppercase
+    })
 
-    def find(self, translation):
-        # List of base translations to try looking up, including stripped and case variations.
-        # Make it start out as a set so that duplicates are removed.
-        base = list({
-            translation,               # Self
-            translation.strip(' '),    # Strip spaces (patterns with \n or \t are correctly handled)
-            translation.lower(),       # All lowercase
-            translation.capitalize(),  # First letter capitalized
-            translation.upper(),       # All uppercase
-        })
+    # List of modifications to apply to each base to find prefixes, suffixes, commands etc.
+    mods = [
+        lambda s: s,               # No modification
+        lambda s: '{^%s}' % s,     # Prefix
+        lambda s: '{^}%s' % s,
+        lambda s: '{^%s^}' % s,    # Infix
+        lambda s: '{^}%s{^}' % s,
+        lambda s: '{%s^}' % s,     # Suffix
+        lambda s: '%s{^}' % s,
+        lambda s: '{&%s}' % s,     # Fingerspell
+        lambda s: '{#%s}' % s,     # Raw keystrokes
+    ]
 
-        # List of modifications to apply to each base to find prefixes, suffixes, commands etc.
-        mods = [
-            lambda s: s,               # No modification
-            lambda s: '{^%s}' % s,     # Prefix
-            lambda s: '{^}%s' % s,
-            lambda s: '{^%s^}' % s,    # Infix
-            lambda s: '{^}%s{^}' % s,
-            lambda s: '{%s^}' % s,     # Suffix
-            lambda s: '%s{^}' % s,
-            lambda s: '{&%s}' % s,     # Fingerspell
-            lambda s: '{#%s}' % s,     # Raw keystrokes
-        ]
+    # Make an iterator to run each non-empty base translation through each mod in turn.
+    possible_translations = (mod(t) for t in base if t for mod in mods)
 
-        # Make an iterator to run each non-empty base translation through each mod in turn.
-        possible_translations = (mod(t) for t in base if t for mod in mods)
-
-        # Look up every possibility and return a suggestion for each one with a non-empty result.
-        suggestions = []
-        for t in possible_translations:
-            strokes_list = self.dictionary.reverse_lookup(t)
-            if not strokes_list:
-                continue
-            strokes_list = sort_steno_strokes(strokes_list)
-            suggestion = Suggestion(t, strokes_list)
-            suggestions.append(suggestion)
-        return suggestions
+    # Look up every possibility and return a suggestion for each one with a non-empty result.
+    suggestions = []
+    for t in possible_translations:
+        strokes_list = dictionary.reverse_lookup(t)
+        if not strokes_list:
+            continue
+        strokes_list = sort_steno_strokes(strokes_list)
+        suggestion = Suggestion(t, strokes_list)
+        suggestions.append(suggestion)
+    return suggestions

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -7,14 +7,14 @@ Suggestion = collections.namedtuple('Suggestion', 'text steno_list')
 
 def find_suggestions(dictionary, translation):
     # List of base translations to try looking up, including stripped and case variations.
-    # Make it start out as a set so that duplicates are removed.
-    base = list({
+    # To remove duplicates while preserving list order, run it through an OrderedDict as a key list.
+    base = collections.OrderedDict.fromkeys([
         translation,               # Self
         translation.strip(' '),    # Strip spaces (patterns with \n or \t are correctly handled)
         translation.lower(),       # All lowercase
         translation.capitalize(),  # First letter capitalized
         translation.upper(),       # All uppercase
-    })
+    ]).keys()
 
     # List of modifications to apply to each base to find prefixes, suffixes, commands etc.
     mods = [
@@ -29,8 +29,8 @@ def find_suggestions(dictionary, translation):
         lambda s: '{#%s}' % s,     # Raw keystrokes
     ]
 
-    # Make an iterator to run each non-empty base translation through each mod in turn.
-    possible_translations = (mod(t) for t in base if t for mod in mods)
+    # Run each non-empty base translation through each mod in turn.
+    possible_translations = [mod(t) for t in base if t for mod in mods]
 
     # Look up every possibility and return a suggestion for each one with a non-empty result.
     suggestions = []

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -38,12 +38,10 @@ def test_dictionary():
     assert d.longest_key == 2
     assert notifications == [1, 4, 2]
     assert d.reverse_lookup('c') == [('S', 'S')]
-    assert d.casereverse_lookup('c') == ['c']
     d.clear()
     assert d.longest_key == 0
     assert notifications == [1, 4, 2, 0]
     assert d.reverse_lookup('c') == []
-    assert d.casereverse_lookup('c') == []
 
     d.remove_longest_key_listener(listener)
     d[('S', 'S')] = 'c'
@@ -151,17 +149,6 @@ def test_dictionary_collection_longest_key():
     assert dc.longest_key == 0
 
 
-def test_casereverse_del():
-    d = StenoDictionary()
-    d[('S-G',)] = 'something'
-    d[('SPH-G',)] = 'something'
-    assert d.casereverse_lookup('something') == ['something']
-    del d[('S-G',)]
-    assert d.casereverse_lookup('something') == ['something']
-    del d[('SPH-G',)]
-    assert d.casereverse_lookup('something') == []
-
-
 def test_reverse_lookup():
     dc = StenoDictionaryCollection()
 
@@ -207,17 +194,14 @@ def test_dictionary_enabled():
     dc.set_dicts([d2, d1])
     assert dc.lookup(('TEFT',)) == 'test2'
     assert dc.raw_lookup(('TEFT',)) == 'test2'
-    assert dc.casereverse_lookup('testing') == ['Testing']
     assert dc.reverse_lookup('Testing') == [('TEFT', '-G'), ('TEFGT',)]
     d2.enabled = False
     assert dc.lookup(('TEFT',)) == 'test1'
     assert dc.raw_lookup(('TEFT',)) == 'test1'
-    assert dc.casereverse_lookup('testing') == ['Testing']
     assert dc.reverse_lookup('Testing') == [('TEFGT',)]
     d1.enabled = False
     assert dc.lookup(('TEST',)) is None
     assert dc.raw_lookup(('TEFT',)) is None
-    assert dc.casereverse_lookup('testing') is None
     assert dc.reverse_lookup('Testing') == []
 
 


### PR DESCRIPTION
I've been breaking down my changes to the search system into pieces, and this one is probably the most drastic (it removes quite a bit of code), so I feel like it should be discussed first. Basically, when finding word suggestions, the system uses a special case-reverse dictionary to find case variants of a given word. This is a dict of Counter dicts which involves extra maintenance work from the steno dictionary class and takes up quite a bit of memory. When I looked at the Plover dictionary code for the first time, the case-reverse system confused me a bit and felt like kind of an ugly hack.

Currently, in order to find special entries such as prefixes and suffixes, the suggestions finder simply creates a list of possibilities to try and looks up each one in turn. Hash map lookups are cheap, so I thought "why not do this for case variants as well?". After all, for normal English text, case variants consist almost exclusively of three choices: lowercase, Capitalized, or UPPERCASE. Adding these to the possibilities list simplifies the lookup system a great deal and offloads a bunch of work from the dictionary class.

The bulk of the changes to the code are:

1. Changing the Suggestion finder to manually check for the most common case variants. The code is structured a little differently; hopefully I added enough comments. Basically, I took a list of base variants (regular, lowercase, uppercase, etc.) on the given search string, removed duplicates, then ran each one through the list of "mod" functions used to check for things like prefixes and suffixes. All of the possibilities are then looked up and the ones that exist are returned. I didn't really need to convert the mods list into lambdas since all of the current ones are just format strings (it happened while testing the approach of making case variants into mods themselves), but I feel like it makes the intentions clearer, and it allows variants other than simple string substitution in the future.

2. Removing all case-reverse code. The suggestion finder was the only module that used this, so it can be safely removed. This means less upkeep for the dictionaries, less test code, and one less path through the engine. On my system, this modification alone caused a 15% decrease in Plover's memory usage.

The two main downsides I can see to this approach are:
- it won't detect EXOtic CAse VARiants, or multi-word case variants such as Title Case and CamelCase.
- if there are any plugins that currently use engine.casereverse_lookup, they will break.

For the first point, an exact match will still work for looking up complicated case variants, and a future regex search (probably my next PR, I've cleaned up my existing code a bit) could do a full case-insensitive search. For the second, there could be some sort backwards compatibility code there instead, but at the moment I can't think of any current plugin that might need to use this engine function directly.