### PR TITLE
Fix tooltip punctuation consistency (issue #963) and make tool tooltips localizable

### DIFF
--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -8,9 +8,9 @@ _ = get_gettext()
 
 class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
 
-    ''' Add a new translation to the dictionary. '''
 
     TITLE = _('Add Translation')
+    TOOLTIP = _('Add a new translation to the dictionary.')
     ICON = ':/translation_add.svg'
     ROLE = 'add_translation'
     SHORTCUT = 'Ctrl+N'

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -285,14 +285,14 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                 ConfigOption(_('Add translation dialog opacity:'), 'translation_frame_opacity',
                              partial(IntOption, maximum=100, minimum=0),
                              _('Set the translation dialog opacity:\n'
-                               '- 0 makes the dialog invisible\n'
-                               '- 100 is fully opaque')),
+                               '- 0 makes the dialog invisible.\n'
+                               '- 100 is fully opaque.')),
                 ConfigOption(_('Dictionaries display order:'), 'classic_dictionaries_display_order',
                              partial(BooleanAsDualChoiceOption,
                                      _('top-down'), _('bottom-up')),
                              _('Set the display order for dictionaries:\n'
-                               '- top-down: match the search order; highest priority first\n'
-                               '- bottom-up: reverse search order; lowest priority first\n')),
+                               '- top-down: Match the search order; highest priority first.\n'
+                               '- bottom-up: Reverse search order; lowest priority first.\n')),
             )),
             (_('Logging'), (
                 ConfigOption(_('Log file:'), 'log_file_name',

--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -81,7 +81,7 @@
     <string>&amp;Edit dictionaries</string>
    </property>
    <property name="toolTip">
-    <string>Edit selected dictionaries</string>
+    <string>Edit selected dictionaries.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+E</string>
@@ -96,7 +96,7 @@
     <string>&amp;Remove dictionaries</string>
    </property>
    <property name="toolTip">
-    <string>Remove selected dictionaries</string>
+    <string>Remove selected dictionaries.</string>
    </property>
    <property name="shortcut">
     <string>Del</string>
@@ -126,7 +126,7 @@
     <string>&amp;Add dictionaries</string>
    </property>
    <property name="toolTip">
-    <string>Add dictionaries</string>
+    <string>Add dictionaries.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -141,7 +141,7 @@
     <string>Add &amp;translation</string>
    </property>
    <property name="toolTip">
-    <string>Add a new translation</string>
+    <string>Add a new translation.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+N</string>

--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -155,7 +155,7 @@
     <string>&amp;New translation</string>
    </property>
    <property name="toolTip">
-    <string>Add a new translation</string>
+    <string>Add a new translation.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+N</string>

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -13,9 +13,9 @@ _ = get_gettext()
 
 class LookupDialog(Tool, Ui_LookupDialog):
 
-    ''' Search the dictionary for translations. '''
 
     TITLE = _('Lookup')
+    TOOLTIP = _('Search the dictionary for translations.')
     ICON = ':/lookup.svg'
     ROLE = 'lookup'
     SHORTCUT = 'Ctrl+L'

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -103,8 +103,8 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             for parent in (tools_menu, self.toolbar, self.toolbar_menu):
                 action = parent.addAction(*action_parameters)
                 action.setObjectName(tool_plugin.name)
-                if tool.__doc__ is not None:
-                    action.setToolTip(tool.__doc__)
+                if tool.TOOLTIP is not None:
+                    action.setToolTip(tool.TOOLTIP)
                 if tool.SHORTCUT is not None:
                     action.setShortcut(QKeySequence.fromString(tool.SHORTCUT))
                 if parent == self.toolbar_menu:

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -24,9 +24,9 @@ _ = get_gettext()
 
 class PaperTape(Tool, Ui_PaperTape):
 
-    ''' Paper tape display of strokes. '''
 
     TITLE = _('Paper Tape')
+    TOOLTIP = _('Display paper tape of strokes.')
     ICON = ':/tape.svg'
     ROLE = 'paper_tape'
     SHORTCUT = 'Ctrl+T'

--- a/plover/gui_qt/paper_tape.ui
+++ b/plover/gui_qt/paper_tape.ui
@@ -82,7 +82,7 @@
     <string>&amp;Clear</string>
    </property>
    <property name="toolTip">
-    <string>Clear paper tape</string>
+    <string>Clear paper tape.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
@@ -97,7 +97,7 @@
     <string>&amp;Save</string>
    </property>
    <property name="toolTip">
-    <string>Save paper tape to file</string>
+    <string>Save paper tape to file.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
@@ -115,7 +115,7 @@
     <string>&amp;Toggle &quot;always on top&quot;</string>
    </property>
    <property name="toolTip">
-    <string>Toggle &quot;always on top&quot;</string>
+    <string>Toggle &quot;always on top&quot;.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+T</string>
@@ -130,7 +130,7 @@
     <string>Select &amp;font</string>
    </property>
    <property name="toolTip">
-    <string>Open font selection dialog</string>
+    <string>Open font selection dialog.</string>
    </property>
   </action>
  </widget>

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -26,9 +26,9 @@ _ = get_gettext()
 
 class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
 
-    ''' Suggest possible strokes for the last written words. '''
 
     TITLE = _('Suggestions')
+    TOOLTIP = _('Suggest possible strokes for the last written words.')
     ICON = ':/lightbulb.svg'
     ROLE = 'suggestions'
     SHORTCUT = 'Ctrl+J'

--- a/plover/gui_qt/suggestions_dialog.ui
+++ b/plover/gui_qt/suggestions_dialog.ui
@@ -35,7 +35,7 @@
     <string>&amp;Clear</string>
    </property>
    <property name="toolTip">
-    <string>Clear paper tape</string>
+    <string>Clear paper tape.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
@@ -53,7 +53,7 @@
     <string>&amp;Toggle &quot;always on top&quot;</string>
    </property>
    <property name="toolTip">
-    <string>Toggle &quot;always on top&quot;</string>
+    <string>Toggle &quot;always on top&quot;.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+T</string>
@@ -68,7 +68,7 @@
     <string>Select &amp;font</string>
    </property>
    <property name="toolTip">
-    <string>Open font selection dialog</string>
+    <string>Open font selection dialog.</string>
    </property>
   </action>
  </widget>

--- a/plover/gui_qt/tool.py
+++ b/plover/gui_qt/tool.py
@@ -8,12 +8,13 @@ class Tool(QDialog, WindowState):
 
     # Used for dialog window title, menu entry text.
     TITLE = None
+    # Used in the main window
+    TOOLTIP = None
     # Optional path to icon image.
     ICON = None
     # Optional shortcut (as a string).
     SHORTCUT = None
-    # Note: the class documentation is automatically used as tooltip.
-
+    
     def __init__(self, engine):
         super().__init__()
         self._update_title()

--- a/plover/gui_qt/trayicon.py
+++ b/plover/gui_qt/trayicon.py
@@ -117,7 +117,7 @@ class TrayIcon(QObject):
             output_state = _('output is disabled')
         self._trayicon.setIcon(icon)
         self._trayicon.setToolTip(
-            'Plover:\n- %s\n- %s' % (output_state, machine_state)
+            'Plover:\n- %s\n- %s.' % (output_state, machine_state)
         )
 
     def _on_activated(self, reason):


### PR DESCRIPTION
Fix #963 by removing periods at the end of some tooltips, supporting localizable tooltips for the Tool class (which used to only fetch tooltips from class docstrings) and adding such tooltips to the built in tools.