### PR TITLE
Lookup/suggestions implementation overhaul

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -112,12 +112,14 @@ def json_option(name, default, section, option, validate):
 def int_option(name, default, minimum, maximum, section, option=None):
     option = option or name
     def getter(config, key):
-        return config._config[section].getint(option)
+        return config._config[section][option]
     def setter(config, key, value):
         config._set(section, option, str(value))
     def validate(config, key, value):
-        if not isinstance(value, int):
-            raise InvalidConfigOption(value, default)
+        try:
+            value = int(value)
+        except ValueError as e:
+            raise InvalidConfigOption(value, default) from e
         if (minimum is not None and value < minimum) or \
            (maximum is not None and value > maximum):
             message = '%s not in [%s, %s]' % (value, minimum or '-∞', maximum or '∞')

--- a/plover/config.py
+++ b/plover/config.py
@@ -32,6 +32,11 @@ OUTPUT_CONFIG_SECTION = 'Output Configuration'
 DEFAULT_UNDO_LEVELS = 100
 MINIMUM_UNDO_LEVELS = 1
 
+DEFAULT_SEARCH_WORD_LIMIT = 5
+MINIMUM_SEARCH_WORD_LIMIT = 1
+DEFAULT_SEARCH_STROKE_LIMIT = 10
+MINIMUM_SEARCH_STROKE_LIMIT = 1
+
 DEFAULT_SYSTEM_NAME = 'English Stenotype'
 
 SYSTEM_CONFIG_SECTION = 'System: %s'
@@ -342,6 +347,10 @@ class Config:
         boolean_option('start_minimized', False, 'Startup', 'Start Minimized'),
         boolean_option('show_stroke_display', False, 'Stroke Display', 'show'),
         boolean_option('show_suggestions_display', False, 'Suggestions Display', 'show'),
+        int_option('search_word_limit', DEFAULT_SEARCH_WORD_LIMIT, MINIMUM_SEARCH_WORD_LIMIT, None,
+                   'Lookup Display', 'max_word_results'),
+        int_option('search_stroke_limit', DEFAULT_SEARCH_STROKE_LIMIT, MINIMUM_SEARCH_STROKE_LIMIT, None,
+                   'Lookup Display', 'max_stroke_results'),
         opacity_option('translation_frame_opacity', 'Translation Frame', 'opacity'),
         boolean_option('classic_dictionaries_display_order', False, 'GUI'),
         # Plugins.

--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -8,7 +8,10 @@
 """Common elements to all dictionary formats."""
 
 from os.path import splitext
+from bisect import bisect_left
 import functools
+import itertools
+import operator
 import threading
 
 from plover.registry import registry
@@ -62,3 +65,135 @@ def load_dictionary(resource, threaded_save=True):
     if not d.readonly and threaded_save:
         d.save = _threaded(_locked(d.save))
     return d
+
+
+class SimilarSearchDict(dict):
+    """
+    A special hybrid dictionary implementation using a sorted key list along with the usual hash map. This allows
+    lookups for keys that are "similar" to a given key in O(log n) time as well as exact O(1) hash lookups, at the
+    cost of extra memory to store transformed keys and increased time for individual item insertion and deletion.
+    It is most useful for large dictionaries that are mutated rarely after initialization, and which have a need
+    to compare and sort their keys by some measure other than their natural sorting order (if they have one).
+
+    The "similarity function" returns a measure of how close two keys are to one another. This function should take a
+    single key as input, and the return values should compare equal for keys that are deemed to be "similar". Even if
+    they are not equal, keys with return values that are close will be close together in the list and may appear
+    together in a search where equality is not required (i.e filter_keys with no filter). All implemented
+    functionality other than similarity search is equivalent to that of a regular dictionary.
+
+    The keys must be of a type that is immutable, hashable, and totally orderable (i.e. it is possible to rank all
+    the keys from least to greatest using comparisons) both before and after applying the given similarity function.
+    Inside the list, keys are stored in sorted order as tuples of (simkey, rawkey), which means they are ordered first
+    by the value computed by the similarity function, and if those are equal, then by their natural value.
+
+    The average-case time complexity for common operations are as follows:
+
+    +-------------------+-------------------+------+
+    |     Operation     | SimilarSearchDict | dict |
+    +-------------------+-------------------+------+
+    | Initialize        | O(n log n)        | O(n) |
+    | Lookup (exact)    | O(1)              | O(1) |
+    | Lookup (inexact)  | O(log n)          | O(n) |
+    | Insert Item       | O(n)              | O(1) |
+    | Delete Item       | O(n)              | O(1) |
+    | Iteration         | O(n)              | O(n) |
+    +-------------------+-------------------+------+
+    """
+
+    def __init__(self, simfn=None, *args, **kwargs):
+        """ Initialize the dict and list to empty and set up the similarity function (identity if not provided).
+            If other arguments were given, treat them as containing initial items to add as with dict.update(). """
+        super().__init__()
+        self._list = []
+        if simfn is None:
+            simfn = lambda x: x
+        self._simfn = simfn
+        if args or kwargs:
+            self.update(*args, **kwargs)
+
+    def clear(self):
+        super().clear()
+        self._list.clear()
+
+    def __setitem__(self, k, v):
+        """ Set an item in the dict. If the key didn't exist before, find where it goes in the list and insert it. """
+        if k not in self:
+            idx = self._index_exact(k)
+            self._list.insert(idx, (self._simfn(k), k))
+        super().__setitem__(k, v)
+
+    def __delitem__(self, k):
+        """ Delete an item from the dict and list (if it exists). This will not affect sort order. """
+        if k in self:
+            idx = self._index_exact(k)
+            del self._list[idx]
+            super().__delitem__(k)
+
+    def update(self, *args, **kwargs):
+        """ Update the dict and list using items from the given arguments. Because this is typically used
+            to fill dictionaries with large amounts of items, a fast path is included if this one is empty. """
+        if not self:
+            super().update(*args, **kwargs)
+            self._list = list(zip(map(self._simfn, self), self))
+            self._list.sort()
+        else:
+            for (k, v) in dict(*args, **kwargs).items():
+                self[k] = v
+
+    def filter_keys(self, k, count=None, filterfn=None):
+        """
+        Starting from the leftmost position in the list where <k> could be, return keys in order until:
+        1. (if <filterfn> is not None): the filter function returns False. The filter function is
+           a T/F comparison between <k> and each list key when altered by the similarity function.
+        2. (if <count> is not None): a maximum of <count> keys have been returned.
+        Either condition will terminate the loop, as will reaching the end of the list.
+        """
+        simkey = self._simfn(k)
+        idx_start = self._index_left(k)
+        # Creating a list iterator and manually setting the index is much faster than islice
+        # or subscripting for the case where an indefinite iterator over a long list is needed.
+        list_iter = iter(self._list)
+        list_iter.__setstate__(idx_start)
+        keys = []
+        keys_append = keys.append
+        for (sk, rk) in list_iter:
+            if filterfn is not None and not filterfn(sk, simkey):
+                break
+            keys_append(rk)
+            if count is not None and len(keys) >= count:
+                break
+        return keys
+
+    def get_similar_keys(self, k, count=None):
+        """ Return a list of at most <count> keys that compare equal to <k> under the similarity function. """
+        return self.filter_keys(k, count=count, filterfn=operator.eq)
+
+    def prefix_search(self, prefix):
+        """ Return a generator producing all possible raw keys that could contain <prefix>. """
+        sim_prefix = self._simfn(prefix)
+        # If the prefix is empty after transformation, it could possibly match anything in the list.
+        if not sim_prefix:
+            return map(operator.itemgetter(1), self._list)
+        # All possibilities will be found in the sort order between the prefix itself (inclusive) and
+        # the prefix with one added to the numerical value of its final character (exclusive).
+        idx_start = self._index_left(sim_prefix, already_transformed=True)
+        marker_end = sim_prefix[:-1] + chr(ord(sim_prefix[-1]) + 1)
+        idx_end = self._index_left(marker_end, already_transformed=True)
+        # If the range is empty, return a blank list instead of a generator so that it compares False.
+        if idx_start == idx_end:
+            return []
+        return map(operator.itemgetter(1), self._list[idx_start:idx_end])
+
+    def _index_left(self, k, already_transformed=False):
+        """ Find the leftmost list index of the key <k> (or the place it should be) using bisection search. """
+        # Out of all tuples with an equal first value, the 1-tuple with this value compares less than any 2-tuple.
+        return bisect_left(self._list, (k if already_transformed else self._simfn(k),))
+
+    def _index_exact(self, k):
+        """ Find the exact list index of the key <k>  using bisection search (if it exists). """
+        return bisect_left(self._list, (self._simfn(k), k))
+
+    # Unimplemented methods from the base class that can mutate the object are unsafe. Make them return errors.
+    def _UNSAFE_METHOD(self, *args, **kwargs): return NotImplementedError
+    setdefault = pop = popitem = _UNSAFE_METHOD
+

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -472,8 +472,8 @@ class StenoEngine:
         self._dictionaries.remove_filter(dictionary_filter)
 
     @with_lock
-    def get_suggestions(self, translation):
-        return Suggestions(self._dictionaries).find(translation)
+    def get_suggestions(self, translation, **kwargs):
+        return Suggestions(self._dictionaries).find(translation, **kwargs)
 
     @property
     @with_lock

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -25,7 +25,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from plover.config import MINIMUM_UNDO_LEVELS
+from plover.config import MINIMUM_UNDO_LEVELS, MINIMUM_SEARCH_WORD_LIMIT, MINIMUM_SEARCH_STROKE_LIMIT
 from plover.misc import expand_path, shorten_path
 from plover.registry import registry
 
@@ -282,6 +282,12 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                              _('Open the paper tape on startup.')),
                 ConfigOption(_('Show suggestions:'), 'show_suggestions_display', BooleanOption,
                              _('Open the suggestions dialog on startup.')),
+                ConfigOption(_('Maximum search results:'), 'search_word_limit',
+                             partial(IntOption, maximum=100, minimum=MINIMUM_SEARCH_WORD_LIMIT),
+                             _('Maximum number of search results to display in the lookup window.')),
+                ConfigOption(_('Maximum suggested strokes:'), 'search_stroke_limit',
+                             partial(IntOption, maximum=100, minimum=MINIMUM_SEARCH_STROKE_LIMIT),
+                             _('Maximum number of stroke patterns to display in the lookup window for any word.')),
                 ConfigOption(_('Add translation dialog opacity:'), 'translation_frame_opacity',
                              partial(IntOption, maximum=100, minimum=0),
                              _('Set the translation dialog opacity:\n'

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -50,6 +50,14 @@ class LookupDialog(Tool, Ui_LookupDialog):
         self.suggestions.append(suggestion_list, keep_position=True)
 
     def on_lookup(self, pattern):
+        # Wherever a character is typed or a checkbox is changed, refresh the lookup results.
+        # TODO: preserve the state of search mode checkboxes?
         translation = unescape_translation(pattern.strip())
-        suggestion_list = self._engine.get_suggestions(translation)
+        suggestion_list = self._engine.get_suggestions(translation,
+                                                       count=self._word_limit,
+                                                       partial=self.partialCheck.isChecked(),
+                                                       regex=self.regexCheck.isChecked())
         self._update_suggestions(suggestion_list)
+
+    def on_mode_change(self, state):
+        self.on_lookup(self.pattern.text())

--- a/plover/gui_qt/lookup_dialog.ui
+++ b/plover/gui_qt/lookup_dialog.ui
@@ -23,13 +23,13 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::NoButton</set>
+   <item row="1" column="0">
+    <widget class="SuggestionsWidget" name="suggestions" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>
@@ -43,15 +43,53 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="SuggestionsWidget" name="suggestions" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="4" column="0">
+    <layout class="QHBoxLayout" name="optionsLayout">
+     <property name="spacing">
+      <number>0</number>
      </property>
-    </widget>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+      <widget class="QCheckBox" name="partialCheck">
+       <property name="toolTip">
+        <string>Search for extensions of the input text (i.e. entering &quot;chair&quot; could also show results for &quot;chairman&quot;).</string>
+       </property>
+       <property name="text">
+        <string>Autocomplete</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+      <widget class="QCheckBox" name="regexCheck">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Search using the input text as a regular expression.</string>
+       </property>
+       <property name="text">
+        <string>Regex Search</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -65,38 +103,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>LookupDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>LookupDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>pattern</sender>
    <signal>textEdited(QString)</signal>
@@ -113,8 +119,41 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>regexCheck</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>LookupDialog</receiver>
+   <slot>on_mode_change(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>259</x>
+     <y>259</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>136</x>
+     <y>135</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>partialCheck</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>LookupDialog</receiver>
+   <slot>on_mode_change(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>71</x>
+     <y>253</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>136</x>
+     <y>135</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>on_lookup(QString)</slot>
+  <slot>on_mode_change(int)</slot>
  </slots>
 </ui>

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -197,35 +197,30 @@ class StenoDictionaryCollection:
             d.add_longest_key_listener(self._longest_key_listener)
         self._longest_key_listener()
 
-    def _lookup(self, key, dicts=None, filters=()):
-        if dicts is None:
-            dicts = self.dicts
-        key_len = len(key)
-        if key_len > self.longest_key:
-            return None
-        for d in dicts:
-            if not d.enabled:
-                continue
-            if key_len > d.longest_key:
-                continue
-            value = d.get(key)
-            if value:
-                for f in filters:
+    def lookup(self, key):
+        """ Perform a lookup on each enabled dictionary in priority order.
+            Return the value of the first entry that matches the key, or None if the key isn't found anywhere.
+            Immediately return None if a matching key-value pair is caught by one of the filters. """
+        for d in self.dicts:
+            if d.enabled and key in d:
+                value = d[key]
+                for f in self.filters:
                     if f(key, value):
                         return None
                 return value
+
+    def raw_lookup(self, key):
+        """ Perform a simple lookup on each enabled dictionary in priority order with no filters.
+            Return the value of the first entry that matches the key, or None if the key isn't found anywhere. """
+        for d in self.dicts:
+            if d.enabled and key in d:
+                return d[key]
 
     def __str__(self):
         return 'StenoDictionaryCollection' + repr(tuple(self.dicts))
 
     def __repr__(self):
         return str(self)
-
-    def lookup(self, key):
-        return self._lookup(key, filters=self.filters)
-
-    def raw_lookup(self, key):
-        return self._lookup(key)
 
     def reverse_lookup(self, value):
         """ Return a set of keys that can exactly produce the given value under the current dictionary precedence. """

--- a/plover/suggestions.py
+++ b/plover/suggestions.py
@@ -1,52 +1,43 @@
 import collections
+import re
 
 from plover.steno import sort_steno_strokes
 
 
 Suggestion = collections.namedtuple('Suggestion', 'text steno_list')
 
+# Hard limit on results returned by search (to avoid slowdown on overly broad searches such as regex .*)
+MATCH_LIMIT = 100
+
 
 class Suggestions:
     def __init__(self, dictionary):
         self.dictionary = dictionary
 
-    def find(self, translation):
+    def find(self, translation, count=MATCH_LIMIT, partial=False, regex=False):
+        """ Find translations that are equal or similar (different case, prefixes, suffixes, etc.) to the given one.
+            Special search types such as partial words and regular expressions are also available.
+            Return a list of suggestion tuples with these translations along with the strokes that can produce them. """
         suggestions = []
-
-        mods = [
-            '%s',  # Same
-            '{^%s}',  # Prefix
-            '{^}%s',
-            '{^%s^}',  # Infix
-            '{^}%s{^}',
-            '{%s^}',  # Suffix
-            '%s{^}',
-            '{&%s}',  # Fingerspell
-            '{#%s}',  # Command
-        ]
-
-        possible_translations = {translation}
-
-        # Only strip spaces, so patterns with \n or \t are correctly handled.
-        stripped_translation = translation.strip(' ')
-        if stripped_translation and stripped_translation != translation:
-            possible_translations.add(stripped_translation)
-
-        lowercase_translation = translation.lower()
-        if lowercase_translation != translation:
-            possible_translations.add(lowercase_translation)
-
-        similar_words = self.dictionary.casereverse_lookup(translation.lower())
-        if similar_words:
-            possible_translations |= set(similar_words)
-
-        for t in possible_translations:
-            for modded_translation in [mod % t for mod in mods]:
-                strokes_list = self.dictionary.reverse_lookup(modded_translation)
-                if not strokes_list:
-                    continue
-                strokes_list = sort_steno_strokes(strokes_list)
-                suggestion = Suggestion(modded_translation, strokes_list)
-                suggestions.append(suggestion)
-
+        # Don't bother looking for suggestions on empty strings or whitespace.
+        if translation and not translation.isspace():
+            # Perform the requested type of lookup. The results should be sorted correctly when received.
+            max_matches = min(count, MATCH_LIMIT)
+            if regex:
+                try:
+                    items = self.dictionary.find_regex(translation, max_matches)
+                except re.error as e:
+                    return [Suggestion("Invalid regular expression", [(e.msg,)])]
+            elif partial:
+                items = self.dictionary.find_partial(translation, max_matches)
+            else:
+                items = self.dictionary.find_similar(translation)[:max_matches]
+            # Package the lookup results into namedtuples for display.
+            for (t, kl) in items:
+                s = Suggestion(t, sort_steno_strokes(kl))
+                # If we got an exact match, put it at the top of the list, otherwise append the results in order.
+                if t == translation:
+                    suggestions.insert(0, s)
+                else:
+                    suggestions.append(s)
         return suggestions

--- a/test/test_dictionary.py
+++ b/test/test_dictionary.py
@@ -1,0 +1,101 @@
+""" Unit tests for base dictionary package (dictionary/base.py) """
+
+from plover.dictionary.base import SimilarSearchDict
+
+
+def test_searchdict():
+    """ Basic unit tests for init, getitem, setitem, delitem, len, and contains on SimilarSearchDict. """
+    d = SimilarSearchDict(None, {1: "a", 2: "b", 3: "c"})
+    assert 1 in d
+    assert 2 in d
+    assert 5 not in d
+    assert len(d) == 3
+    del d[1]
+    assert 1 not in d
+    assert len(d) == 2
+    d[1] = "x"
+    assert d[1] == "x"
+    assert len(d) == 3
+    d[1] = "y"
+    assert len(d) == 3
+    del d["key not here"]
+    assert len(d) == 3
+
+
+def test_searchdict_similar():
+    """
+    For these tests, the similarity function will remove everything but a's in the string.
+    This means strings with equal numbers of a's will compare as "similar".
+    In the key lists, they are sorted by this measure, then standard string sort order applies second
+    """
+    def just_a(key):
+        return "".join(c for c in key if c is "a")
+
+    # Keys are restricted to whatever type the similarity function takes, so just use strings for now
+    # The values don't matter right now; just have them be the number of a's for reference.
+    data = {"a": 1, "Canada": 3, "a man!?": 2, "^hates^": 1, "lots\nof\nlines": 0,
+            "": 0,  "A's don't count, just a's": 1, "AaaAaa, Ʊnićodə!": 4}
+    d = SimilarSearchDict(simfn=just_a, **data)
+
+    # "Similar keys", should be all keys with the same number of a's as the input
+    assert d.get_similar_keys("a") == ["A's don't count, just a's", "^hates^", "a"]
+    assert d.get_similar_keys("none in here") == ["", "lots\nof\nlines"]
+    assert d.get_similar_keys("Havana") == ["Canada"]
+    assert d.get_similar_keys("lalalalala") == []
+
+    # Restrict the number of returned values
+    assert d.get_similar_keys("add", 2) == ["A's don't count, just a's", "^hates^"]
+    assert d.get_similar_keys("still none of the first English letter", 1) == [""]
+
+    # Using a filter function, return anything with three or more a's
+    assert d.filter_keys("aaa", None, str.startswith) == ["Canada", "AaaAaa, Ʊnićodə!"]
+
+    # Without a filter function, return everything in order including/after the given key until count.
+    assert d.filter_keys("AAAAaAAAA", 2) == ["A's don't count, just a's", "^hates^"]
+    assert d.filter_keys("#%*&!?", 4) == ["", "lots\nof\nlines", "A's don't count, just a's", "^hates^"]
+    assert d.filter_keys("a", 5) == ["A's don't count, just a's", "^hates^", "a", "a man!?", "Canada"]
+    assert d.filter_keys("aaaaaaaaaa", 100) == []
+
+    # Add/delete/mutate individual items and make sure order is maintained for search.
+    del d["^hates^"]
+    assert d.get_similar_keys("a") == ["A's don't count, just a's", "a"]
+    d["----I shall be first!---"] = 1
+    assert d.get_similar_keys("a") == ["----I shall be first!---", "A's don't count, just a's", "a"]
+    d["^hates^"] = 1
+    assert d.get_similar_keys("a") == ["----I shall be first!---", "A's don't count, just a's", "^hates^", "a"]
+
+
+def test_searchdict_iter():
+    # The iterators should treat this as an ordinary dictionary, independent of the search capabilities.
+    d = SimilarSearchDict(None, {1: "a", 2: "b", 3: "c"})
+    for (k, v, item) in zip(d.keys(), d.values(), d.items()):
+        assert any(k_iter == k for k_iter in d)
+        assert (k, v) == item
+
+
+def test_searchdict_update():
+    # Make a blank dict, add new stuff from (k, v) tuples and keywords, and test it
+    d = SimilarSearchDict()
+    d.update([("a list", "yes"), ("of tuples", "okay")], but="add", some="keywords")
+    assert d
+    assert len(d) == 4
+    assert d["a list"] == "yes"
+    assert d["some"] == "keywords"
+    # Add more items (some overwriting others) and see if it behaves correctly, then clear it.
+    d.update([("a list", "still yes"), ("of sets", "nope")])
+    assert len(d) == 5
+    assert d["a list"] == "still yes"
+    d.clear()
+    assert not d
+    assert len(d) == 0
+
+
+def test_searchdict_values():
+    # Strange values shouldn't break anything.
+    d = SimilarSearchDict(None, {"x" * i: i for i in range(10)})
+    d["func"] = len
+    assert d["func"](d) == 11
+    d["tuple"] = (("UNWRAP ME!",),)
+    assert d["tuple"][0][0] == "UNWRAP ME!"
+    d["recurse me!"] = d
+    assert d["recurse me!"]["recurse me!"]["recurse me!"] is d

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -19,29 +19,41 @@ def test_dictionary():
 
     d = StenoDictionary()
     assert d.longest_key == 0
+    assert len(d) == 0
+    assert not d
 
     d.add_longest_key_listener(listener)
     d[('S',)] = 'a'
     assert d.longest_key == 1
+    assert ('S',) in d
     assert notifications == [1]
+    assert len(d) == 1
+    assert d
     d[('S', 'S', 'S', 'S')] = 'b'
     assert d.longest_key == 4
     assert notifications == [1, 4]
+    assert len(d) == 2
     d[('S', 'S')] = 'c'
     assert d.longest_key == 4
     assert d[('S', 'S')] == 'c'
     assert notifications == [1, 4]
+    assert len(d) == 3
     del d[('S', 'S', 'S', 'S')]
     assert d.longest_key == 2
     assert notifications == [1, 4, 2]
+    assert len(d) == 2
     del d[('S',)]
     assert d.longest_key == 2
+    assert ('S',) not in d
     assert notifications == [1, 4, 2]
+    assert len(d) == 1
     assert d.reverse_lookup('c') == [('S', 'S')]
     assert d.casereverse_lookup('c') == ['c']
     d.clear()
     assert d.longest_key == 0
     assert notifications == [1, 4, 2, 0]
+    assert len(d) == 0
+    assert not d
     assert d.reverse_lookup('c') == []
     assert d.casereverse_lookup('c') == []
 
@@ -49,6 +61,25 @@ def test_dictionary():
     d[('S', 'S')] = 'c'
     assert d.longest_key == 2
     assert notifications == [1, 4, 2, 0]
+
+
+def test_dictionary_update():
+    d = StenoDictionary()
+    d.update([(('S-G',),'something'), (('SPH-G',), 'something'), (('TPHOG',), 'nothing')])
+    assert d[('S-G',)] == 'something'
+    assert d[('SPH-G',)] == 'something'
+    assert d[('TPHOG',)] == 'nothing'
+    assert d.reverse_lookup('something') == [('S-G',), ('SPH-G',)]
+    assert d.reverse_lookup('nothing') == [('TPHOG',)]
+    d.update([(('S-G',), 'string')])
+    assert d[('S-G',)] == 'string'
+    assert d.reverse_lookup('something') == [('SPH-G',)]
+    assert d.reverse_lookup('string') == [('S-G',)]
+    d.clear()
+    d.update([(('EFG',), 'everything'), (('EFG',), 'everything???')])
+    assert d[('EFG',)] == 'everything???'
+    assert d.reverse_lookup('everything') == []
+    assert d.reverse_lookup('everything???') == [('EFG',)]
 
 
 def test_dictionary_collection():

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -101,14 +101,14 @@ def test_dictionary_collection():
     assert dc.raw_lookup(('S',)) == 'c'
     assert dc.lookup(('W',)) == 'd'
     assert dc.lookup(('T',)) == 'b'
-    assert dc.reverse_lookup('c') == [('S',)]
+    assert dc.reverse_lookup('c') == {('S',)}
 
     dc.remove_filter(f)
     assert dc.lookup(('S',)) == 'c'
     assert dc.lookup(('W',)) == 'd'
     assert dc.lookup(('T',)) == 'b'
 
-    assert dc.reverse_lookup('c') == [('S',)]
+    assert dc.reverse_lookup('c') == {('S',)}
 
     dc.set(('S',), 'e')
     assert dc.lookup(('S',)) == 'e'
@@ -208,21 +208,21 @@ def test_reverse_lookup():
 
     # Simple test.
     dc.set_dicts([d1])
-    assert dc.reverse_lookup('beautiful') == [('PWAOUFL',), ('WAOUFL',)]
+    assert dc.reverse_lookup('beautiful') == {('PWAOUFL',), ('WAOUFL',)}
 
     # No duplicates.
     d2_copy = StenoDictionary()
     d2_copy.update(d2)
     dc.set_dicts([d2_copy, d2])
-    assert dc.reverse_lookup('beautiful') == [('PW-FL',)]
+    assert dc.reverse_lookup('beautiful') == {('PW-FL',)}
 
     # Don't stop at the first dictionary with matches.
     dc.set_dicts([d2, d1])
-    assert dc.reverse_lookup('beautiful') == [('PW-FL',), ('PWAOUFL',), ('WAOUFL',)]
+    assert dc.reverse_lookup('beautiful') == {('PW-FL',), ('PWAOUFL',), ('WAOUFL',)}
 
     # Ignore keys overridden by a higher precedence dictionary.
     dc.set_dicts([d3, d2, d1])
-    assert dc.reverse_lookup('beautiful') == [('PW-FL',), ('PWAOUFL',)]
+    assert dc.reverse_lookup('beautiful') == {('PW-FL',), ('PWAOUFL',)}
 
 
 def test_dictionary_enabled():
@@ -239,17 +239,17 @@ def test_dictionary_enabled():
     assert dc.lookup(('TEFT',)) == 'test2'
     assert dc.raw_lookup(('TEFT',)) == 'test2'
     assert dc.casereverse_lookup('testing') == ['Testing']
-    assert dc.reverse_lookup('Testing') == [('TEFT', '-G'), ('TEFGT',)]
+    assert dc.reverse_lookup('Testing') == {('TEFT', '-G'), ('TEFGT',)}
     d2.enabled = False
     assert dc.lookup(('TEFT',)) == 'test1'
     assert dc.raw_lookup(('TEFT',)) == 'test1'
     assert dc.casereverse_lookup('testing') == ['Testing']
-    assert dc.reverse_lookup('Testing') == [('TEFGT',)]
+    assert dc.reverse_lookup('Testing') == {('TEFGT',)}
     d1.enabled = False
     assert dc.lookup(('TEST',)) is None
     assert dc.raw_lookup(('TEFT',)) is None
-    assert dc.casereverse_lookup('testing') is None
-    assert dc.reverse_lookup('Testing') == []
+    assert dc.casereverse_lookup('testing') == []
+    assert dc.reverse_lookup('Testing') == set()
 
 
 def test_dictionary_readonly():


### PR DESCRIPTION
Fixes: #917, #950, and a big step toward #943

This is it: I've finally overhauled the inner workings of the reverse dict and search system to work much better. The main improvements are:

- Standard lookup/suggestions search is now fully case-insensitive and finds more entries with special characters than it did before.
- Search is about twice as fast on average.
- Plover uses 15 MB less memory overall.
- Initial dictionary loading times are up to 30% faster.
- No plugins or other external features should break; the only API change so far is that multi-dict reverse lookup returns sets instead of lists (which it probably should have anyway since it was never strictly ordered in the first place)
- Partial word matching (like autocomplete, i.e. "mas" returns "mash" "mask", and "mass") and search using regular expressions are now available using checkboxes in the lookup window.

Anyone wants to try it out, feel free. It passes all the tests at every commit stage, and current benchmarks are here: [search_benchmark.txt](https://github.com/openstenoproject/plover/files/2408448/search_benchmark.txt)

8/20: And with the latest change, #917 is fixed. The search feature will find more things that have meta commands.

8/28: Everything except possible config options (for controlling things like the maximum number of returned results) is done. I realize this is a rather large change from somebody who hasn't been a part of Github or in fact any collaborative editing platform for very long, but people have been asking for these types of search features for a while and I do believe this is a very worthwhile addition to Plover. I tried to stay away from anything related to the actual input->translation->output part of the engine, so there shouldn't be much chance of breaking anything crucial to Plover's core operation.

9/23: Config option is in. Also ran new benchmarks that should be more reliable (i.e. not as dependent on how lucky you get with the test data).