### PR TITLE
Add trailing newline when writing JSON dictionary

### DIFF
--- a/plover/dictionary/json_dict.py
+++ b/plover/dictionary/json_dict.py
@@ -39,3 +39,4 @@ class JsonDictionary(StenoDictionary):
             json.dump({'/'.join(k): v for k, v in self.items()},
                       writer, ensure_ascii=False, sort_keys=True,
                       indent=0, separators=(',', ': '))
+            writer.write('\n')

--- a/test/test_json_dict.py
+++ b/test/test_json_dict.py
@@ -47,19 +47,19 @@ def test_load_dictionary(contents, expected):
 SAVE_TESTS = (
     # Simple test.
     lambda: ({('S', ): 'a'},
-             '{\n"S": "a"\n}'),
+             '{\n"S": "a"\n}\n'),
     # Check strokes format: '/' separated.
     lambda: ({('SAPL', '-PL'): 'sample'},
-             '{\n"SAPL/-PL": "sample"\n}'),
+             '{\n"SAPL/-PL": "sample"\n}\n'),
     # Contents should be saved as UTF-8, no escaping.
     lambda: ({('S', ): 'café'},
-             '{\n"S": "café"\n}'),
+             '{\n"S": "café"\n}\n'),
     # Check escaping of special characters.
     lambda: ({('S', ): '{^"\n\t"^}'},
-             '{\n"S": "' + r'{^\"\n\t\"^}' + '"\n}'),
+             '{\n"S": "' + r'{^\"\n\t\"^}' + '"\n}\n'),
     # Keys are sorted on save.
     lambda: ({('B', ): 'bravo', ('A', ): 'alpha', ('C', ): 'charlie'},
-             '{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}'),
+             '{\n"A": "alpha",\n"B": "bravo",\n"C": "charlie"\n}\n'),
 )
 
 @parametrize(SAVE_TESTS)


### PR DESCRIPTION
The POSIX definition of a text file requires that it end with a newline
character.  The JSON files created through e.g. the ADD_TRANSLATION
command do not conform to this definition; this commit fixes that.

<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->

<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
