### PR TITLE
Fix read-only dict saving (#897)

### DIFF
--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -276,10 +276,11 @@ class StenoDictionaryCollection:
 
         If <path_list> is None, all writable dictionaries are saved'''
         if path_list is None:
-            dict_list = [d for d in self if dictionary.save is not None]
+            dict_list = [d for d in self if not d.readonly]
         else:
             dict_list = [self[path] for path in path_list]
         for d in dict_list:
+            assert not d.readonly
             d.save()
 
     def get(self, path):


### PR DESCRIPTION
Fix #897.

I came across this method during my search code revisions and my IDE always marked it with warnings. Now that I see there's an issue with the program attempting to save dictionaries marked as read-only, it's a simple fix.
