### PR TITLE
focus the input field when the lookup window is activated

### DIFF
--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -43,3 +43,9 @@ class LookupDialog(Tool, Ui_LookupDialog):
         translation = unescape_translation(pattern.strip())
         suggestion_list = self._engine.get_suggestions(translation)
         self._update_suggestions(suggestion_list)
+
+    def changeEvent(self, event):
+        super().changeEvent(event)
+        if event.type() == QEvent.ActivationChange and self.isActiveWindow():
+            self.pattern.setFocus()
+            self.pattern.selectAll()


### PR DESCRIPTION
Automatically focus the input field and pre-select the previous input when the lookup window is activated.

Fixes #976
