### PR TITLE
Fix #991: add keyup events for Unicode characters on Windows

### DIFF
--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -389,7 +389,7 @@ class KeyboardEmulation:
     # Keyboard input type to send key input
     @staticmethod
     def _keyboard_input(code, flags):
-        if flags == KEYEVENTF_UNICODE:
+        if flags & KEYEVENTF_UNICODE:
             # special handling of Unicode characters
             return KEYBDINPUT(0, code, flags, 0, None)
         return KEYBDINPUT(code, 0, flags, 0, None)
@@ -424,7 +424,9 @@ class KeyboardEmulation:
 
     def _key_unicode(self, char):
         pairs = to_surrogate_pair(char)
-        inputs = [self._keyboard(code, KEYEVENTF_UNICODE)
+        # Send press events for all codes, then release events for all codes.
+        inputs = [self._keyboard(code, KEYEVENTF_UNICODE | direction)
+                  for direction in (0, KEYEVENTF_KEYUP)
                   for code in pairs]
         self._send_input(*inputs)
 

--- a/plover_build_utils/get_pip.py
+++ b/plover_build_utils/get_pip.py
@@ -11,7 +11,7 @@ from .install_wheels import WHEELS_CACHE, install_wheels
 def get_pip(args=None):
     # Download `get-pip.py`.
     script = download('https://bootstrap.pypa.io/get-pip.py',
-                      'b3a10e59d8bd6e500df798313e0b88b10993bfe2')
+                      'a883be89e37dbaaabe6a5d8dfa871d3dfa8b2f9e')
     # Make sure wheels cache directory exists to avoid warning.
     if not os.path.exists(WHEELS_CACHE):
         os.makedirs(WHEELS_CACHE)


### PR DESCRIPTION
Fix #991 and possibly others relating to Unicode.

I finally tracked down the main issue with Unicode output being corrupted in certain Windows GUIs (including Plover's). When sending Windows messages for keyboard input, the code branches based on whether the character has a standard keycode or needs the special Unicode flag. For standard keycodes, it makes sure to send messages for each key without the KEYUP flag, then send each one with it to release them. For Unicode, however, it only sent the keydown messages.

This one was hard to track down because it only affected certain windows. Depending how the receiving framework handled the messages, it might either work fine, or it might cause the first Unicode character to get "stuck" down. Since the "normal" keycode sent with Unicode characters is 0 (the real code is sent in a different field), it would look like the same key to some conditional checks, and so subsequent messages would appear to be an autorepeat of that character until the input handler was closed/restarted (usually by closing the window or application).

At least that's my theory. The fix is just to send KEYUP events after the KEYDOWN events just like the regular keys do.