### PR TITLE
steno_dictionary: fix `StenoDictionary.__setitem` implementation

### DIFF
--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -119,9 +119,23 @@ class StenoDictionary:
         ]
         if kwargs:
             iterable_list.append(kwargs.items())
-        for iterable in iterable_list:
-            for key, value in iterable:
-                self[key] = value
+        if not self._dict:
+            reverse = self.reverse
+            casereverse = self.casereverse
+            longest_key = self._longest_key
+            assert not (reverse or casereverse or longest_key)
+            self._dict = dict(*iterable_list)
+            for key, value in self._dict.items():
+                reverse[value].append(key)
+                casereverse[value.lower()][value] += 1
+                key_len = len(key)
+                if key_len > longest_key:
+                    longest_key = key_len
+            self._longest_key = longest_key
+        else:
+            for iterable in iterable_list:
+                for key, value in iterable:
+                    self[key] = value
 
     def __setitem__(self, key, value):
         assert not self.readonly

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -113,22 +113,20 @@ class StenoDictionary:
 
     def update(self, *args, **kwargs):
         assert not self.readonly
-        longest_key = 0
-        _dict = self._dict
-        reverse = self.reverse
-        casereverse = self.casereverse
-        for iterable in args + (kwargs,):
-            if isinstance(iterable, (dict, StenoDictionary)):
-                iterable = iterable.items()
+        iterable_list = [
+            a.items() if isinstance(a, (dict, StenoDictionary))
+            else a for a in args
+        ]
+        if kwargs:
+            iterable_list.append(kwargs.items())
+        for iterable in iterable_list:
             for key, value in iterable:
-                longest_key = max(longest_key, len(key))
-                _dict[key] = value
-                reverse[value].append(key)
-                casereverse[value.lower()][value] += 1
-        self._longest_key = max(self._longest_key, longest_key)
+                self[key] = value
 
     def __setitem__(self, key, value):
         assert not self.readonly
+        if key in self:
+            del self[key]
         self._longest_key = max(self._longest_key, len(key))
         self._dict[key] = value
         self.reverse[value].append(key)


### PR DESCRIPTION
Make sure an existing previous mapping is removed before updating it (so `reverse_lookup`/`casereverse_lookup` results are not erroneous).

Also slightly speedup `StenoDictionary.update` in the common case (when the dictionary being updated being updated is empty, e.g. when loading), to avoid the slowdown brought by the fix.