### PR TITLE
Update plugins, development and distributions requirements, and the distributions' Python version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,9 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
+      PYTHON_ARCH: "64"
 
 cache:
   - .cache

--- a/ci/circle.sh
+++ b/ci/circle.sh
@@ -38,7 +38,7 @@ setup()
 {
   mkdir -p "$CIRCLE_ARTIFACTS"
   # Install Python.
-  download 'python36.pkg' 'https://www.python.org/ftp/python/3.6.2/python-3.6.2-macosx10.6.pkg' '86e6193fd56b1e757fc8a5a2bb6c52ba'
+  download 'python36.pkg' 'https://www.python.org/ftp/python/3.6.7/python-3.6.7-macosx10.6.pkg' '68885dffc1d13c5d24699daa0b83315f'
   run sudo installer -pkg "$downloads/python36.pkg" -target /
   # Update certifiates.
   run '/Applications/Python 3.6/Install Certificates.command'

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -74,15 +74,15 @@ build()
   run "$python" setup.py test
   # Run some packaging related sanity checks.
   run "$python" -m check_manifest
-  run "$python" setup.py check -m -r -s
+  run "$python" setup.py check -m -s
+  run "$python" setup.py bdist_wheel sdist
+  run "$python" -m twine check dist/*
   # Only generate artifacts if we're actually going to deploy them.
   # Note: if we moved this to the `before_deploy` phase, we would
   # not have to check, but we'd also lose caching; since the cache
   # is stored before the `before_install` phase...
   if is_deployment
   then
-    # Create wheel and source distribution.
-    run "$python" setup.py bdist_wheel sdist
     # Build AppImage.
     run ./linux/appimage/build.sh -c -j 2 -w dist/*.whl
     run rm -rf .cache/pip

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -54,7 +54,7 @@ run mkdir -p "$appdir" "$cachedir" "$distdir"
 # Download dependencies.
 run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImages/raw/f748bb63999e655cfbb70e88ec27e74e2b9bf8fd/functions.sh' 'a99457e22d24a61f42931b2aaafd41f2746af820' "$cachedir/functions.sh"
 run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImageKit/releases/download/9/appimagetool-x86_64.AppImage' 'ba71c5a03398b81eaa678207da1338c83189db89' "$cachedir/appimagetool"
-run "$python" -m plover_build_utils.download 'https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tar.xz' '4f92a045de9231b93dfbed50c66bb12cf03ac59a'
+run "$python" -m plover_build_utils.download 'https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tar.xz' 'dd2b0a8bf9b9617c57a0070b53065286c2142994'
 
 # Generate Plover wheel.
 if [ -z "$wheel" ]
@@ -69,10 +69,10 @@ then
  fi
 
 # Build Python.
-run tar xf "$downloads/Python-3.6.2.tar.xz" -C "$builddir"
+run tar xf "$downloads/Python-3.6.7.tar.xz" -C "$builddir"
 info '('
 (
-run cd "$builddir/Python-3.6.2"
+run cd "$builddir/Python-3.6.7"
 cmd=(
   ./configure
   --cache-file="$cachedir/python.config.cache"

--- a/osx/app_resources/dist_blacklist.txt
+++ b/osx/app_resources/dist_blacklist.txt
@@ -19,7 +19,6 @@
   **/*AxContainer*
   **/*Bluetooth*
   **/*CLucene*
-  **/*DBus*
   **/*Designer*
   **/*Location*
   **/*Nfc*

--- a/osx/make_app.sh
+++ b/osx/make_app.sh
@@ -10,7 +10,7 @@ set -e
 python='python3'
 osx_dir="$(dirname "$0")"
 plover_dir="$(dirname "$osx_dir")"
-plover_wheel="$plover_dir/dist/$1.whl"
+plover_wheel="$1"
 PACKAGE="$2"
 
 echo "Making Plover.app with Plover wheel $plover_wheel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-Babel==2.4.0
-check-manifest==0.35
-Cython==0.28.5
+Babel==2.6.0
+check-manifest==0.37
+Cython==0.29
 https://github.com/benoit-pierre/dmgbuild/archive/plover.zip; "darwin" in sys_platform
-macholib==1.8; "darwin" in sys_platform
-pip==9.0.1
-pytest==3.1.3
+macholib==1.11; "darwin" in sys_platform
+pip==18.1
+pytest==3.10.0
 readme-renderer[md]==24.0
-setuptools-scm==1.15.5
+setuptools-scm==3.1.0
 twine==1.12.1
-wheel==0.30.0
+wheel==0.32.2
 -r requirements_distribution.txt
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,12 @@ Babel==2.4.0
 check-manifest==0.35
 Cython==0.28.5
 https://github.com/benoit-pierre/dmgbuild/archive/plover.zip; "darwin" in sys_platform
-docutils==0.14
 macholib==1.8; "darwin" in sys_platform
 pip==9.0.1
 pytest==3.1.3
+readme-renderer[md]==24.0
 setuptools-scm==1.15.5
+twine==1.12.1
 wheel==0.30.0
 -r requirements_distribution.txt
 

--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -1,16 +1,17 @@
 appdirs==1.4.3
 appnope==0.1.0; "darwin" in sys_platform
-certifi==2018.1.18
+certifi==2018.10.15
 dbus-python==1.2.4; "linux" in sys_platform
 plyer==1.2.4; "win32" in sys_platform
-pyobjc-core==4.0; "darwin" in sys_platform
-pyobjc-framework-Cocoa==4.0; "darwin" in sys_platform
-pyobjc-framework-Quartz==4.0; "darwin" in sys_platform
-PyQt5==5.9.2
+pyobjc-core==5.1.1; "darwin" in sys_platform
+pyobjc-framework-Cocoa==5.1.1; "darwin" in sys_platform
+pyobjc-framework-Quartz==5.1.1; "darwin" in sys_platform
+PyQt5-sip==4.19.13
+PyQt5==5.11.3
 pyserial==3.4
 python-xlib==0.23; "linux" in sys_platform
-setuptools==38.2.4
-six==1.10.0
+setuptools==40.5.0
+six==1.11.0
 wcwidth==0.1.7
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/requirements_plugins.txt
+++ b/requirements_plugins.txt
@@ -1,9 +1,15 @@
 # plover-plugins-manager
+bleach==3.0.2
+cffi==1.11.5
+cmarkgfm==0.4.2
 docutils==0.14
-pip==9.0.1
-plover-plugins-manager==0.5.11
+pip==18.1
+plover-plugins-manager==0.5.13
+pycparser==2.19
 Pygments==2.2.0
-wheel==0.30.0
+readme-renderer==24.0
+webencodings==0.5.1
+wheel==0.32.2
 # plover-treal
 hidapi==0.7.99.post21
 plover-treal==1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,6 @@ keywords = plover
 include_package_data = True
 python_requires = >=3.4
 zip_safe = True
-setup_requires =
-	Babel
-	PyQt5>=5.8.2
 tests_require =
 	pytest
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -310,7 +310,12 @@ class BinaryDistApp(Command):
     def run(self):
         whl_cmd = self.get_finalized_command('bdist_wheel')
         whl_cmd.run()
-        wheel_path = whl_cmd.get_archive_basename()
+        for cmd, py_version, dist_path in whl_cmd.distribution.dist_files:
+            if cmd == 'bdist_wheel':
+                wheel_path = dist_path
+                break
+        else:
+            raise Exception('could not find wheel path')
         cmd = 'bash osx/make_app.sh %s %s' % (wheel_path, PACKAGE)
         log.info('running %s', cmd)
         subprocess.check_call(cmd.split())

--- a/setup.py
+++ b/setup.py
@@ -95,9 +95,9 @@ class BinaryDistWin(Command):
         # Setup embedded Python distribution.
         # Note: python36.zip is decompressed to prevent errors when 2to3
         # is used (including indirectly by setuptools `build_py` command).
-        py_embedded = download('https://www.python.org/ftp/python/3.6.3/python-3.6.3-embed-win32.zip',
-                               '3769c2129779b43f2dade3b89c783d957bff1461')
-        dist_dir = os.path.join(wheel_cmd.dist_dir, PACKAGE + '-win32')
+        py_embedded = download('https://www.python.org/ftp/python/3.6.7/python-3.6.7-embed-amd64.zip',
+                               '7a81435a25d9557581393ea6805dafb662eaf9e2')
+        dist_dir = os.path.join(wheel_cmd.dist_dir, PACKAGE + '-win64')
         dist_data = os.path.join(dist_dir, 'data')
         dist_py = os.path.join(dist_data, 'python.exe')
         dist_stdlib = os.path.join(dist_data, 'python36.zip')

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -29,11 +29,11 @@ RTF_LOAD_TESTS = (
     ''',
 
     # One translation on multiple lines.
-    lambda: pytest.mark.xfail('''
+    lambda: pytest.param('''
     {\\*\\cxs SP}\r\ntranslation
 
     'SP': 'translation'
-    '''),
+    ''', marks=pytest.mark.xfail),
 
     # Multiple translations no newlines.
     lambda: r'''
@@ -133,7 +133,7 @@ RTF_LOAD_TESTS = (
     lambda: ('', ''),
     lambda: (r'\-', '-'),
     lambda: (r'\\ ', '\\ '),
-    lambda: pytest.mark.xfail((r'\\', '\\')),
+    lambda: pytest.param((r'\\', '\\'), marks=pytest.mark.xfail),
     lambda: (r'\{', '{'),
     lambda: (r'\}', '}'),
     lambda: (r'\~', '{^ ^}'),

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -120,9 +120,10 @@ class WineEnvironment(Environment):
         super().__init__()
         self._prefix = os.path.abspath(prefix)
         self._env['WINEPREFIX'] = self._prefix
-        self._env['WINEARCH'] = 'win32'
+        self._env['WINEARCH'] = 'win64'
         self._env['WINEDEBUG'] = '-all'
         self._env['WINETRICKS_OPT_SHAREDPREFIX'] = '1'
+        self._env['WINEDLLOVERRIDES'] = 'api-ms-win-core-path-l1-1-0=d'
 
     def setup(self):
         if not os.path.exists(self._prefix):
@@ -131,7 +132,7 @@ class WineEnvironment(Environment):
                 'env DISPLAY= wineboot --init',
                 # Wait for previous command to finish.
                 'wineserver -w',
-                'winetricks --no-isolate --unattended corefonts vcrun2008',
+                'winetricks --no-isolate --unattended corefonts',
                 'winetricks win7',
             ):
                 self.run(cmd.split())
@@ -542,8 +543,8 @@ class Helper:
 class WineHelper(Helper):
 
     DEPENDENCIES = (
-        ('Python', 'https://www.python.org/ftp/python/3.6.2/python-3.6.2.exe',
-         'cd9744b142eca832f9534390676e6cfb84bf655d', None, ('PrependPath=1', '/S'), None),
+        ('Python', 'https://www.python.org/ftp/python/3.6.7/python-3.6.7-amd64.exe',
+         '4f3bd61c16ef2fbec38bd7ed53f8f4b4f2896c90', None, ('PrependPath=1', '/S'), None),
     ) + Helper.DEPENDENCIES
 
     def __init__(self):


### PR DESCRIPTION
Initially, the idea was to stay on PyQt5 5.9.x (since Qt 5.9 is supposed to be a LTS version), and only update to new point releases, but PyQt5 does not follow that, so we might as well update to the latest version.

Note: there's no QtWebEngine support with recent win32 builds of PyQt5, hence the switch to generating a 64bits distribution.

I've tested locally the new AppImage on Arch Linux and Ubuntu Trusty, and the new Windows installer/distribution on a Windows 10 VM, someone need to test the macOS image.