### PR TITLE
Update Arch Linux PKGBUILD

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -27,11 +27,6 @@ url="http://www.openstenoproject.org/plover/"
 source=(https://github.com/openstenoproject/plover/archive/v$pkgver.tar.gz)
 sha1sums=(803bb68068feef3772e34e1b1ab34e7fa25375ae)
 
-prepare() {
-  cd "$pkgname-$pkgver"
-  sed -i '/^\s*PyQt5\b.*/d' setup.cfg
-}
-
 build() {
   cd "$pkgname-$pkgver"
   python setup.py build

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -32,6 +32,11 @@ prepare() {
   sed -i '/^\s*PyQt5\b.*/d' setup.cfg
 }
 
+build() {
+  cd "$pkgname-$pkgver"
+  python setup.py build
+}
+
 check() {
   cd "$pkgname-$pkgver"
   python setup.py test


### PR DESCRIPTION
No need to patch out the PyQt5 dependency anymore: the latest python-pyqt5 package now has the proper Python distribution metadata.