### PR TITLE
prevent editing of still loading or readonly dictionaries

### DIFF
--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -316,8 +316,14 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
         self._update_dictionaries(dictionaries, record=False)
 
     def _edit(self, dictionaries):
-        editor = DictionaryEditor(self._engine, [d.path for d in dictionaries])
-        editor.exec_()
+        paths_to_edit = []
+        for d in dictionaries:
+            loaded_dictionary = self._loaded_dictionaries.get(d.path)
+            if loaded_dictionary and not loaded_dictionary.readonly:
+                paths_to_edit.append(d.path)
+        if paths_to_edit:
+            editor = DictionaryEditor(self._engine, paths_to_edit)
+            editor.exec_()
 
     def on_activate_cell(self, row, col):
         self._edit([self._config_dictionaries[row]])


### PR DESCRIPTION

<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
Fixes #897 
<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
Don't open the dictionary editor with dictionaries that are still loading or are readonly.