### PR TITLE
Save default machine config options, including serial ports

### DIFF
--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -435,8 +435,8 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
     def _create_option_widget(self, option):
         widget = option.widget_class()
         widget.setToolTip(option.help_text)
-        widget.setValue(self._config[option.option_name])
         widget.valueChanged.connect(partial(self.on_option_changed, option))
+        widget.setValue(self._config[option.option_name])
         return widget
 
     def keyPressEvent(self, event):

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -25,11 +25,14 @@ class SerialOption(QWidget, Ui_SerialWidget):
 
     def setValue(self, value):
         self._value = copy(value)
+        self.on_scan()
         port = value['port']
-        if port is None or port == 'None':
-            self.on_scan()
-        else:
-            self.port.setCurrentText(port)
+        if port is not None and port != 'None':
+            port_index = self.port.findText(port)
+            if port_index != -1:
+                self.port.setCurrentIndex(port_index)
+            else:
+                self.port.setCurrentText(port)
         self.baudrate.addItems(map(str, Serial.BAUDRATES))
         self.baudrate.setCurrentText(str(value['baudrate']))
         self.bytesize.addItems(map(str, Serial.BYTESIZES))


### PR DESCRIPTION
Fix #739

1. Always scan serial ports when rendering machine serial options
2. If the current value is None, set the first scanned port. That port was previously getting displayed but not saved because the "on_port_changed" method was being called before the config_window was connected. A singleShot is used to scan the ports again which will set the first port in settings.
