### PR TITLE
setup: fix support for pip>=19.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ import zipfile
 
 from setuptools import setup
 
+sys.path.insert(0, os.path.dirname(__file__))
+
 from plover import (
     __name__ as __software_name__,
     __version__,


### PR DESCRIPTION
Ensure `plover`/`plover_build_utils` can be imported even when`pip>=19.0` PEP 517/518 build isolation is used.
