### PR TITLE
archlinux: add missing `qt5-svg` dependency

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -15,6 +15,7 @@ depends=(
   'python-setuptools'
   'python-wcwidth'
   'python-xlib'
+  'qt5-svg'
 )
 makedepends=(
   'python-babel'


### PR DESCRIPTION
Fix #1045.
