### PR TITLE
Exit edit mode before modifying the model

### DIFF
--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -361,6 +361,7 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
             row = self._selection[0]
         else:
             row = 0
+        self.table.reset()
         self._model.new_row(row)
         self._select(row, edit=True)
         self.action_Undo.setEnabled(self._model.has_undo)


### PR DESCRIPTION
Fixes #1040.

It appears that `QTableView` has problem when the model is modified while it's in edit state.