### PR TITLE
automatically set machine state to error upon disconnect of writer

### DIFF
--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -147,7 +147,7 @@ class _ThreadedStenotypeThread(threading.Thread):
             self.machine.run()
         except Exception:
             if not self.machine.finished.isSet():
-                log.error(self.machine.name + ' got disconnected.')
+                log.error('%s disconnected', self.machine.name)
                 self.machine._error()
 
 class ThreadedStenotypeBase(StenotypeBase):
@@ -156,7 +156,7 @@ class ThreadedStenotypeBase(StenotypeBase):
     Subclasses should override run.
     """
     def __init__(self):
-        self.name = self.__class__.__name__ + '-machine'
+        self.name = self.__class__.__name__
         StenotypeBase.__init__(self)
         self.finished = threading.Event()
         self._machine_thread = _ThreadedStenotypeThread(self)


### PR DESCRIPTION
Most of the implementations of the run method of the ThreadedStenotypeBase
do not catch exceptions. This causes the thread to silently die (the
exception is only logged to the console).

Now an exception in the run method is reported as an error to the system
and additionally the SerialStenotypeBase class does close the com port on
error.

Otherwise the com port resource might still be taken by plover upon
reconnect of the writer, and a different com port might be taken by the OS
and plover might not be able to reconnect to that machine.

This is a first part to solving issue #596. In addition there must be some
mechanism to retry connecting when the state is error.
