### PR TITLE
utils: fix blackbox tests framework to work with pytest>=4.2.0

### DIFF
--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -2,10 +2,11 @@
 
 from plover.registry import Registry
 
-from plover_build_utils.testing import BlackboxTester
+from plover_build_utils.testing import blackbox_test
 
 
-class TestsBlackbox(BlackboxTester):
+@blackbox_test
+class TestsBlackbox:
 
     def test_translator_state_handling(self):
         r'''


### PR DESCRIPTION
Starting with 4.2.0, the support for xunit-style setup functions has changed; more precisely the order in which they are called.

For some reason, this can break blackbox tests:

* patch one of the blackbox test to fail:

```diff
diff --git a/test/test_blackbox.py b/test/test_blackbox.py
@@ -985,7 +985,7 @@ def test_upper6(self):
         'P-': '{foo^}',
         '-S': '{^bar}',

-        TP*U/P-/-S  " FOOBAR"
+        TP*U/P-/-S  " FooBaR"
         '''

     def test_upper7(self):
```

* run all the blackbox tests (`./test.sh test/test_blackbox.py`): `test_upper6' fails has expected

* run only `test_upper6` (`./test.sh test/test_blackbox.py test_upper6`): the test now passes!

So change the implementation to use a decorator, which is both compatible with pytest>=4.2.0 and more pythonic.