### PR TITLE
config: fix keymap validation

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -244,8 +244,8 @@ def system_keymap_option():
     def validate(config, key, value):
         try:
             return build_keymap(config, key, value)
-        except ValueError as e:
-            raise InvalidConfigOption(value, default(config, machine_type, system_name)) from e
+        except (TypeError, ValueError) as e:
+            raise InvalidConfigOption(value, default(config, key)) from e
     return ConfigOption('system_keymap', default, getter, setter, validate, full_key)
 
 def dictionaries_option():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -337,6 +337,28 @@ CONFIG_TESTS = (
      '''
     ),
 
+    ('invalid_keymap_1',
+     '''
+     [System: English Stenotype]
+     keymap[keyboard] = [["_-"]]
+     ''',
+     DEFAULTS,
+     {},
+     {},
+     None,
+    ),
+
+    ('invalid_keymap_2',
+     '''
+     [System: English Stenotype]
+     keymap[keyboard] = 42
+     ''',
+     DEFAULTS,
+     {},
+     {},
+     None,
+    ),
+
     ('invalid_options_1',
      '''
      [System]


### PR DESCRIPTION
The call to get the default value was using the wrong parameters + handle the case where the wrong type is used.