### PR TITLE
Update distributions to Python 3.6.8

### DIFF
--- a/ci/circle.sh
+++ b/ci/circle.sh
@@ -38,7 +38,7 @@ setup()
 {
   mkdir -p "$CIRCLE_ARTIFACTS"
   # Install Python.
-  download 'python36.pkg' 'https://www.python.org/ftp/python/3.6.7/python-3.6.7-macosx10.6.pkg' '68885dffc1d13c5d24699daa0b83315f'
+  download 'python36.pkg' 'https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.6.pkg' 'eb1a23d762946329c2aa3448d256d421'
   run sudo installer -pkg "$downloads/python36.pkg" -target /
   # Update certifiates.
   run '/Applications/Python 3.6/Install Certificates.command'

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -32,34 +32,6 @@ setup()
     libudev-dev
     libusb-1.0-0-dev
   )
-  if is_deployment
-  then
-    builddeps+=(
-      # AppImage:
-      libfuse2
-      # Python:
-      libbz2-dev
-      libgdbm-dev
-      liblzma-dev
-      libncurses5-dev
-      libreadline-dev
-      libsqlite3-dev
-      libssl-dev
-      zlib1g-dev
-      # PyQt5:
-      libasound2
-      libegl1-mesa
-      libfontconfig1
-      libgl1-mesa-glx
-      libnss3
-      libxcomposite1
-      libxcursor1
-      libxi6
-      libxrandr2
-      libxss1
-      libxtst6
-    )
-  fi
   run sudo apt-get install -qq "${builddeps[@]}"
   # Setup development environment.
   bootstrap_dev --user
@@ -84,7 +56,9 @@ build()
   if is_deployment
   then
     # Build AppImage.
-    run ./linux/appimage/build.sh -c -j 2 -w dist/*.whl
+    run git clone --depth=1 https://github.com/packpack/packpack.git
+    run_eval "export PATH=\"$PWD/packpack:\$PATH\""
+    run ./linux/packpack.sh appimage
     run rm -rf .cache/pip
   else
     # Otherwise, install plugins, and check requirements.

--- a/linux/appimage/apprun.sh
+++ b/linux/appimage/apprun.sh
@@ -2,7 +2,7 @@
 
 appimage_setenv()
 {
-  export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
+  export LD_LIBRARY_PATH="${APPDIR}/usr/local/lib:${APPDIR}/usr/lib:${APPDIR}/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
   export PATH="${APPDIR}/usr/bin:${PATH}"
   # Patch LDFLAGS so installing some Python packages from source can work.
   export LDFLAGS="-L${APPDIR}/usr/lib/x86_64-linux-gnu -L${APPDIR}/usr/lib"
@@ -59,7 +59,7 @@ appimage_uninstall()
 
 appimage_launch()
 {
-  exec "${APPDIR}/usr/bin/python3.6" -s -m plover.dist_main "$@"
+  exec "${APPDIR}/usr/bin/python" -s -m plover.dist_main "$@"
 }
 
 set -e

--- a/linux/appimage/blacklist.txt
+++ b/linux/appimage/blacklist.txt
@@ -16,13 +16,13 @@
   pydoc*
   python3
   python3-config
-  python3.6-config
-  python3.6m
-  python3.6m-config
+  python${pyversion}-config
+  python${pyversion}m
+  python${pyversion}m-config
   pyvenv*
   wheel
-:usr/lib/python3.6
-  config-3.6m/libpython3.6m.a
+:usr/lib/python${pyversion}
+  config-${pyversion}m/libpython${pyversion}m.a
   ctypes/test
   distutils/command/*.exe
   distutils/tests
@@ -35,12 +35,12 @@
   tkinter
   turtle*
   unittest/test
-:usr/lib/python3.6/site-packages
+:usr/lib/python${pyversion}/site-packages
   pip/_vendor/distlib/*.exe
   setuptools/*.exe
 
 # Plover.
-:usr/lib/python3.6/site-packages/plover
+:usr/lib/python${pyversion}/site-packages/plover
   gui_qt/*.ui
   gui_qt/messages/**/*.po
   gui_qt/messages/plover.pot
@@ -51,7 +51,7 @@
   pylupdate5
   pyrcc5
   pyuic5
-:usr/lib/python3.6/site-packages/PyQt5
+:usr/lib/python${pyversion}/site-packages/PyQt5
   **/*Designer*
   **/*Help*
   **/*Test*

--- a/linux/appimage/pyinfo.py
+++ b/linux/appimage/pyinfo.py
@@ -1,0 +1,14 @@
+from distutils import sysconfig
+import sys
+
+print("; ".join("py%s=%r" % (k, v) for k, v in sorted({
+    'exe'    : sys.executable,
+    'prefix' : sys.prefix,
+    'version': sysconfig.get_python_version(),
+    'include': sysconfig.get_python_inc(prefix=''),
+    'ldlib'  : sysconfig.get_config_var('LDLIBRARY'),
+    'py3lib' : sysconfig.get_config_var('PY3LIBRARY'),
+    'stdlib' : sysconfig.get_python_lib(standard_lib=1, prefix=''),
+    'purelib': sysconfig.get_python_lib(plat_specific=0, prefix=''),
+    'platlib': sysconfig.get_python_lib(plat_specific=1, prefix=''),
+}.items())))

--- a/linux/packpack.mk
+++ b/linux/packpack.mk
@@ -3,10 +3,10 @@ PACKAGE := $(PRODUCT)-$(VERSION)
 .PHONY: appimage
 
 appimage:
-	tar xf dist/$(PACKAGE).tar.xz -C /build
+	tar xf /build/$(PACKAGE).tar.xz -C /build
 	cd /build/$(PACKAGE) && \
 		ln -s /cache .cache && \
-		env MAKEFLAGS='' ./linux/appimage/build.sh -w /source/dist/$(PACKAGE)-py3-none-any.whl -c -j 2 && \
+		python3 setup.py bdist_appimage && \
 		mv dist/*.AppImage ..
 
 .PHONY: makepkg

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -68,13 +68,7 @@ SDIST="$DIST_DIR/$NAME-$VERSION.tar.xz"
 run rm -rf "$BUILD_DIR"
 run mkdir -p "$BUILD_DIR" "$DIST_DIR" .cache
 
-setup_cmd=(./setup.py -q sdist --format=xztar)
-if [ "$TARGET" = 'appimage' ]
-then
-  setup_cmd+=(bdist_wheel)
-fi
-run "${setup_cmd[@]}"
-run cp "$SDIST" "$BUILD_DIR/"
+run python setup.py -q sdist --format=xztar --dist-dir "$BUILD_DIR/"
 cmd=(env)
 if [ $opt_no_pull -ne 0 ]
 then

--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -36,6 +36,15 @@ class Command(setuptools.Command):
             sys.modules.update(old_modules)
             pkg_resources.working_set.__init__()
 
+    def bdist_wheel(self):
+        '''Run bdist_wheel and return resulting wheel file path.'''
+        whl_cmd = self.get_finalized_command('bdist_wheel')
+        whl_cmd.run()
+        for cmd, py_version, dist_path in whl_cmd.distribution.dist_files:
+            if cmd == 'bdist_wheel':
+                return dist_path
+        raise Exception('could not find wheel path')
+
 # `test` command. {{{
 
 class Test(Command):

--- a/setup.py
+++ b/setup.py
@@ -89,17 +89,13 @@ class BinaryDistWin(Command):
         # Download helper.
         from plover_build_utils.download import download
         # First things first: create Plover wheel.
-        wheel_cmd = self.get_finalized_command('bdist_wheel')
-        wheel_cmd.run()
-        plover_wheel = glob.glob(os.path.join(wheel_cmd.dist_dir,
-                                              wheel_cmd.wheel_dist_name)
-                                 + '*.whl')[0]
+        plover_wheel = self.bdist_wheel()
         # Setup embedded Python distribution.
         # Note: python36.zip is decompressed to prevent errors when 2to3
         # is used (including indirectly by setuptools `build_py` command).
         py_embedded = download('https://www.python.org/ftp/python/3.6.7/python-3.6.7-embed-amd64.zip',
                                '7a81435a25d9557581393ea6805dafb662eaf9e2')
-        dist_dir = os.path.join(wheel_cmd.dist_dir, PACKAGE + '-win64')
+        dist_dir = os.path.join(os.path.dirname(plover_wheel), PACKAGE + '-win64')
         dist_data = os.path.join(dist_dir, 'data')
         dist_py = os.path.join(dist_data, 'python.exe')
         dist_stdlib = os.path.join(dist_data, 'python36.zip')
@@ -136,7 +132,7 @@ class BinaryDistWin(Command):
         # Run command helper.
         def run(*args):
             if self.verbose:
-                log.info('running %s', ' '.join(a for a in args))
+                log.info('running %s', ' '.join(args))
             subprocess.check_call(args)
         def pyrun(*args):
             run(dist_py, '-E', '-s', *args)
@@ -310,16 +306,8 @@ class BinaryDistApp(Command):
         pass
 
     def run(self):
-        whl_cmd = self.get_finalized_command('bdist_wheel')
-        whl_cmd.run()
-        for cmd, py_version, dist_path in whl_cmd.distribution.dist_files:
-            if cmd == 'bdist_wheel':
-                wheel_path = dist_path
-                break
-        else:
-            raise Exception('could not find wheel path')
-        cmd = 'bash osx/make_app.sh %s %s' % (wheel_path, PACKAGE)
-        log.info('running %s', cmd)
+        cmd = 'bash osx/make_app.sh %s %s' % (self.bdist_wheel(), PACKAGE)
+        log.info('running %s', ' '.join(cmd))
         subprocess.check_call(cmd.split())
 
 class BinaryDistDmg(Command):

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,8 @@ class BinaryDistWin(Command):
         # Setup embedded Python distribution.
         # Note: python36.zip is decompressed to prevent errors when 2to3
         # is used (including indirectly by setuptools `build_py` command).
-        py_embedded = download('https://www.python.org/ftp/python/3.6.7/python-3.6.7-embed-amd64.zip',
-                               '7a81435a25d9557581393ea6805dafb662eaf9e2')
+        py_embedded = download('https://www.python.org/ftp/python/3.6.8/python-3.6.8-embed-amd64.zip',
+                               'f9d16a818e06ce2552076a9839039dbabb8baf1c')
         dist_dir = os.path.join(os.path.dirname(plover_wheel), PACKAGE + '-win64')
         dist_data = os.path.join(dist_dir, 'data')
         dist_py = os.path.join(dist_data, 'python.exe')
@@ -126,8 +126,8 @@ class BinaryDistWin(Command):
                 '''
             ).lstrip())
         # Use standard site.py so user site packages are enabled.
-        site_py = download('https://github.com/python/cpython/raw/v3.6.3/Lib/site.py',
-                           '5b5a92032c666e0e30c0b2665b8acffe2a624641')
+        site_py = download('https://github.com/python/cpython/raw/v3.6.8/Lib/site.py',
+                           '46d88612c34b1ed0098f1fbf655454b46afde049')
         shutil.copyfile(site_py, os.path.join(dist_site_packages, 'site.py'))
         # Run command helper.
         def run(*args):

--- a/setup.py
+++ b/setup.py
@@ -343,6 +343,31 @@ if sys.platform.startswith('darwin'):
 
 # }}}
 
+# `bdist_appimage` command. {{{
+
+class BinaryDistAppImage(Command):
+
+    description = 'create AppImage distribution for Linux'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        cmd = ['./linux/appimage/build.sh',
+               '--python', sys.executable,
+               '--wheel', self.bdist_wheel()]
+        log.info('running %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
+
+if sys.platform.startswith('linux'):
+    cmdclass['bdist_appimage'] = BinaryDistAppImage
+
+# }}}
+
 # Translations support. {{{
 
 from babel.messages import frontend as babel

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -543,8 +543,8 @@ class Helper:
 class WineHelper(Helper):
 
     DEPENDENCIES = (
-        ('Python', 'https://www.python.org/ftp/python/3.6.7/python-3.6.7-amd64.exe',
-         '4f3bd61c16ef2fbec38bd7ed53f8f4b4f2896c90', None, ('PrependPath=1', '/S'), None),
+        ('Python', 'https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe',
+         '0c80bc4e3ea98e1415264b29f3290fb7195a8bc3', None, ('PrependPath=1', '/S'), None),
     ) + Helper.DEPENDENCIES
 
     def __init__(self):


### PR DESCRIPTION
This include the following change to the AppImage creation: Python is no longer built, instead the available version of `python3` is used. This way the compilation can be moved to the Docker image creation, for both faster AppImage build times and a faster interpreter (built with optimizations).

This rely on https://github.com/openstenoproject/plover-docker-images/pull/2 being merged.

AppImage timings: `16.586s` -> `14.826s` when loading `german_palantype.json` (58.29 MiB, 1466824 entries).