### PR TITLE
Update PyQt5 dependencies

### DIFF
--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -6,8 +6,8 @@ plyer==1.2.4; "win32" in sys_platform
 pyobjc-core==5.1.1; "darwin" in sys_platform
 pyobjc-framework-Cocoa==5.1.1; "darwin" in sys_platform
 pyobjc-framework-Quartz==5.1.1; "darwin" in sys_platform
-PyQt5-sip==4.19.13
-PyQt5==5.11.3
+PyQt5-sip==4.19.17
+PyQt5==5.12.2
 pyserial==3.4
 python-xlib==0.23; "linux" in sys_platform
 setuptools==40.5.0


### PR DESCRIPTION
**1. The issues or a description of the problem this PR fixes**

Fixes dark mode visuals on macOS. The screenshot below shows the behavior on `master`, and the screenshot below on the right shows the behavior with this patch:

![image](https://user-images.githubusercontent.com/2949688/59556118-2ddcce80-8f72-11e9-9dfb-3267a6ba0251.png)

**2. Describe what you did, and if this PR has any open questions or requires more testing.**

Just bumped some dep versions. Seemed harmless enough, but please let me know if this introduces any regressions. The same tests are failing on this branch as compared to `master`.