### PR TITLE
Load non-us keyboard related keysyms from xkb

### DIFF
--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -37,7 +37,9 @@ from plover import log
 
 # Enable support for media keys.
 XK.load_keysym_group('xf86')
-
+# Load non-us keyboard related keysyms.
+XK.load_keysym_group('xkb')
+   
 # Create case insensitive mapping of keyname to keysym.
 KEY_TO_KEYSYM = {}
 for symbol in sorted(dir(XK)): # Sorted so XK_a is preferred over XK_A.


### PR DESCRIPTION
<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
Enables the usage of ISO level 3 shift and thus makes possible to use the AltGr-modifier key found, for example on the Finnish keyboard. The usage is {#ISO_Level3_Shift(...)}.
<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
