### PR TITLE
add towncrier support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,12 @@
-<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->
+<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst! -->
+<!-- Remove sections if not applicable -->
 
-<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
+## Summary of changes
+
+<!-- Summary goes here -->
+
+Closes <!-- issue number here -->
+
+### Pull Request Checklist
+- [ ] Changes have tests
+- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 # and not already automatically included by setuptools.
 include CONTRIBUTING.md
 include LICENSE.txt
+include NEWS.rst
 include application/*
 include archlinux/*
 include debian/*
@@ -11,6 +12,10 @@ include launch.bat
 include launch.sh
 include linux/*
 include linux/appimage/*
+include news.d/api/*
+include news.d/bugfix/*
+include news.d/feature/*
+include news.d/template.rst
 include osx/*
 include osx/app_resources/*
 include osx/dmg_resources/*

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,0 +1,40 @@
+v4.0.0.dev8+66.g685bd33 (2018-07-02)
+====================================
+
+
+Features
+--------
+
+Dictionaries
+~~~~~~~~~~~~
+
+- Use ``AOE`` instead of ``E`` for prefix "e". (#951)
+- Quality of Life changes/additions to the dictionaries. (#959, #960)
+
+
+User Interface
+~~~~~~~~~~~~~~
+
+- Add tooltips to dictionary status icons. (#962)
+
+
+Bugfixes
+--------
+
+Core
+~~~~
+
+- Fix issues when output is set to "Spaces After". (#965)
+
+
+macOS
+~~~~~
+
+- Fix portable mode. (#932)
+
+
+Windows
+~~~~~~~
+
+- Add missing C++ redistributable DLL to the installer. (#957)
+- Fix emoji output. (#942)

--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -1,0 +1,43 @@
+---------------------
+Making a pull request
+---------------------
+
+When making a pull request, please include a short summary of the changes
+and a reference to any issue tickets that the PR is intended to solve.
+All PRs with code changes should include tests. All changes should include a
+changelog entry.
+
+Plover uses `towncrier <https://pypi.org/project/towncrier/>`_
+for changelog management, so when making a PR, please add a news fragment in
+the ``news.d/`` folder. Changelog files are written in reStructuredText and
+should be a 1 or 2 sentence description of the substantive changes in the PR.
+They should be named ``<section>/<pr_number>.<category>.rst``, where the
+sections / categories are:
+
+* ``feature``: New features:
+
+  - ``core``: Core changes.
+  - ``dict``: Updates to the default dictionaries.
+  - ``ui``: Changes to the user interface.
+  - ``linux``: Linux specific changes.
+  - ``osx``: macOS specific changes.
+  - ``windows``: Windows specific changes.
+
+* ``bugfix``: For bugfixes, support the same categories as for ``feature``.
+
+* ``api``: For documenting changes to the public/plugins API:
+
+  - ``break``: For breaking (backward incompatible) changes.
+  - ``dnr``: For deprecations of an existing feature or behavior.
+  - ``new``: For other (backward compatible) changes, like new APIs.
+
+A pull request may have more than one of these components, for example a code
+change may introduce a new feature that deprecates an old feature, in which
+case two fragments should be added. It is not necessary to make a separate
+documentation fragment for documentation changes accompanying the relevant
+code changes. See the following for an example news fragment:
+
+.. code-block:: bash
+
+    $ cat news.d/bugfix/1041.ui.rst
+    Fix possible crash when changing machine parameters in the configuration dialog.

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -1,0 +1,19 @@
+===============
+Release Process
+===============
+
+Version numbers:
+
+- official release: ``{major}.{minor}.{patch}`` (e.g. ``2.2.1``, ``3.1.0``, ``4.0.0``...)
+- pre-release: ``{major}.{minor}.{patch}.{dev|rc}{devel}`` (e.g. ``4.0.0.dev7``, ``4.0.0rc1``, ...)
+
+
+Steps to cut a new release (from a clean checkout of ``master``):
+
+1. Update version in ``plover/__init__.py``, and stage the change ``git add plover/__init__.py``.
+2. Install towncrier (``pip install towncrier``) and update ``NEWS.rst``: ``towncrier``.
+3. Review the stagged changes, check all news fragments in ``news.d`` were properly handled
+   (merged into ``NEWS.rst`` and removed by towncrier).
+4. Commit: ``git commit -m "release $(./setup.py --version)"``
+5. Tag the release: ``git tag -m "$(git log -1 --pretty='format:%B')" "v$(./setup.py --version)"``
+6. Push to Github: ``git push --follow-tags origin``

--- a/news.d/api/1066.break.rst
+++ b/news.d/api/1066.break.rst
@@ -1,0 +1,1 @@
+``StenoDictionaryCollection.casereverse_lookup`` now returns a ``set`` (instead of a ``list``).

--- a/news.d/bugfix/1022.core.rst
+++ b/news.d/bugfix/1022.core.rst
@@ -1,0 +1,1 @@
+Fix updating a dictionary mapping: ensure reverse lookups data stays consistent.

--- a/news.d/bugfix/1027.windows.rst
+++ b/news.d/bugfix/1027.windows.rst
@@ -1,0 +1,1 @@
+Fix installer's icon.

--- a/news.d/bugfix/1038.dict.rst
+++ b/news.d/bugfix/1038.dict.rst
@@ -1,0 +1,1 @@
+Fix a number of invalid entries in the main dictionary.

--- a/news.d/bugfix/1041.ui.rst
+++ b/news.d/bugfix/1041.ui.rst
@@ -1,0 +1,1 @@
+Fix possible crash when changing machine parameters in the configuration dialog.

--- a/news.d/bugfix/1061.ui.rst
+++ b/news.d/bugfix/1061.ui.rst
@@ -1,0 +1,1 @@
+Fix internationalization of machine types in the configuration dialog.

--- a/news.d/bugfix/1062.ui.rst
+++ b/news.d/bugfix/1062.ui.rst
@@ -1,0 +1,1 @@
+Fix tools shortcuts.

--- a/news.d/bugfix/1065.core.rst
+++ b/news.d/bugfix/1065.core.rst
@@ -1,0 +1,1 @@
+Fix keymap validation: properly fallback to default keymap when invalid.

--- a/news.d/bugfix/1066.core.rst
+++ b/news.d/bugfix/1066.core.rst
@@ -1,0 +1,1 @@
+Fix lookups by translation: do not ignore lower priority dictionaries when a match is found in a higher priority one.

--- a/news.d/bugfix/1096.dict.rst
+++ b/news.d/bugfix/1096.dict.rst
@@ -1,0 +1,1 @@
+Tweak orthographic rules so "reduce/{^ability}" result in "reducibility" instead of "reducability".

--- a/news.d/bugfix/897.ui.rst
+++ b/news.d/bugfix/897.ui.rst
@@ -1,0 +1,1 @@
+Fix a possible crash on close when opening a read-only dictionary in the editor.

--- a/news.d/bugfix/991.windows.rst
+++ b/news.d/bugfix/991.windows.rst
@@ -1,0 +1,1 @@
+Fix Unicode characters output.

--- a/news.d/bugfix/995.core.rst
+++ b/news.d/bugfix/995.core.rst
@@ -1,0 +1,1 @@
+Fix retrospective insert space macro when the previous translation involved suffix keys.

--- a/news.d/feature/1009.ui.rst
+++ b/news.d/feature/1009.ui.rst
@@ -1,0 +1,1 @@
+Automatically focus the input field and pre-select the previous input when the lookup window is activated.

--- a/news.d/feature/1022.core.rst
+++ b/news.d/feature/1022.core.rst
@@ -1,0 +1,1 @@
+Speed up loading dictionaries.

--- a/news.d/feature/1023.windows.rst
+++ b/news.d/feature/1023.windows.rst
@@ -1,0 +1,1 @@
+The distribution is now 64bits.

--- a/news.d/feature/1025.core.rst
+++ b/news.d/feature/1025.core.rst
@@ -1,0 +1,1 @@
+Be more restrictive with macro names: only accept valid identifier, so for example ``==`` is not handled like a macro anymore.

--- a/news.d/feature/1036.ui.rst
+++ b/news.d/feature/1036.ui.rst
@@ -1,0 +1,1 @@
+Improve the configuration dialog for serial machines: automatically scan available ports and default to the first one.

--- a/news.d/feature/1068.linux.rst
+++ b/news.d/feature/1068.linux.rst
@@ -1,0 +1,1 @@
+The distribution Python is now built with optimization.

--- a/news.d/feature/1082.linux.rst
+++ b/news.d/feature/1082.linux.rst
@@ -1,0 +1,1 @@
+Expand the list of supported key names in key combos to include non-US specific keys (like ``ISO_Level3_Shift``).

--- a/news.d/feature/981.ui.rst
+++ b/news.d/feature/981.ui.rst
@@ -1,0 +1,1 @@
+Add menu entry for opening the configuration directory ("File" => "Open config folder").

--- a/news.d/template.rst
+++ b/news.d/template.rst
@@ -1,0 +1,33 @@
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }} ({{ values|join(', ') }})
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,69 @@ requires = [
 	"setuptools>=38.2.4",
 	"wheel",
 ]
+
+[tool.towncrier]
+package = "plover"
+filename = "NEWS.rst"
+directory = "news.d"
+template = "news.d/template.rst"
+title_format = "v{version} ({project_date})"
+
+[[tool.towncrier.section]]
+path = "feature"
+name = "Features"
+
+[[tool.towncrier.section]]
+path = "bugfix"
+name = "Bugfixes"
+
+[[tool.towncrier.type]]
+directory = "core"
+name = "Core"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dict"
+name = "Dictionaries"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "ui"
+name = "User Interface"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "linux"
+name = "Linux"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "osx"
+name = "macOS"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "windows"
+name = "Windows"
+showcontent = true
+
+[[tool.towncrier.section]]
+path = "api"
+name = "API"
+
+[[tool.towncrier.type]]
+directory = "break"
+name = "Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dnr"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "new"
+name = "New"
+showcontent = true
+
+# vim: ft=cfg


### PR DESCRIPTION
Add [towncrier](https://pypi.org/project/towncrier/) support: avoid the need to go spelunking through the log to create release notes. See the newly added documentation for usage.

I also added some news fragments for existing changes since the latest weekly, here is how those would be rendered (`towncrier --draft`):

```rst
v4.0.0.dev8+162.gf92ded2f (2019-12-16)
======================================

Features
--------

Core
~~~~

- Speed up loading dictionaries. (#1022)
- Be more restrictive with macro names: only accept valid identifier, so for example ``==`` is not handled like a macro anymore. (#1025)


User Interface
~~~~~~~~~~~~~~

- Add menu entry for opening the configuration directory ("File" => "Open config folder"). (#981)
- Automatically focus the input field and pre-select the previous input when the lookup window is activated. (#1009)
- Improve the configuration dialog for serial machines: automatically scan available ports and default to the first one. (#1036)


Linux
~~~~~

- The distribution Python is now built with optimization. (#1068)


Windows
~~~~~~~

- The distribution is now 64bits. (#1023)


Bugfixes
--------

Core
~~~~

- Fix retrospective insert space macro when the previous translation involved suffix keys. (#995)
- Fix updating a dictionary mapping: ensure reverse lookups data stays consistent. (#1022)
- Fix keymap validation: properly fallback to default keymap when invalid. (#1065)
- Fix lookups by translation: do not ignore lower priority dictionaries when a match is found in a higher priority one. (#1066)


Dictionaries
~~~~~~~~~~~~

- Fix a number of invalid entries in the main dictionary. (#1038)


User Interface
~~~~~~~~~~~~~~

- Fix a possible crash on close when opening a read-only dictionary in the editor. (#897)
- Fix possible crash when changing machine parameters in the configuration dialog. (#1041)
- Fix internationalization of machine types in the configuration dialog. (#1061)
- Fix tools shortcuts. (#1062)


Windows
~~~~~~~

- Fix Unicode characters output. (#991)
- Fix installer's icon. (#1027)


API
---

Breaking Changes
~~~~~~~~~~~~~~~~

- ``StenoDictionaryCollection.casereverse_lookup`` now returns a ``set`` (instead of a ``list``). (#1066)

```