### PR TITLE
Add missing orthography rule alias

### DIFF
--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -73,6 +73,7 @@ ORTHOGRAPHY_RULES = [
 
 ORTHOGRAPHY_RULES_ALIASES = {
     'able': 'ible',
+    'ability': 'ibility',
 }
 
 ORTHOGRAPHY_WORDLIST = 'american_english_words.txt'


### PR DESCRIPTION
<!-- 1. the issues (e.g. Fixes #123) or a description of the problem this PR fixes -->

Stroking `RUS/-BLT` will result in "reducibility" instead of "reducability".

I know it's possible to get that word with `RUS/IBLT`, but this is for consistency with `"able": "ible"`.

<!-- 2. Describe what you did, and if this PR has any open questions or requires more testing. -->
