### PR TITLE
Add Ubuntu specific instructions to Linux development readme

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -20,3 +20,28 @@ To install the standard plugins, you can use:
 
 * `./launch.sh`: run from source
 * `./test.sh`: run tests
+
+
+## Setup on Ubuntu 18.04
+Check Python3 version - version 3.6 or higher required
+`python3 -v`
+
+Install pip 
+
+`sudo apt install python3-pip`
+
+Install other required libraries
+
+`sudo apt install python-hidapi python-dbus libdbus-1-dev libdbus-glib-1-dev`
+
+Clone plover repository
+
+`git clone https://github.com/openstenoproject/plover.git`
+
+Change to plover directory
+
+`cd plover`
+
+Install plover dependencies using pip
+
+`pip3 install --user -r requirements.txt`


### PR DESCRIPTION
 Here are the steps I had to follow to get a development environment setup on a recent Ubuntu 18.04 install. I haven't tried it on a completely fresh install, so it's possible that I missed some dependencies that I already installed. 

I'm also not totally sure if `python-dbus` is required, and I assumed that versions of python newer than 3.6 would work fine. If anything looks off, I can try it on a fresh install.