### PR TITLE
Fix CI builds

### DIFF
--- a/plover_build_utils/get_pip.py
+++ b/plover_build_utils/get_pip.py
@@ -10,8 +10,8 @@ from .install_wheels import WHEELS_CACHE, install_wheels
 
 def get_pip(args=None):
     # Download `get-pip.py`.
-    script = download('https://github.com/pypa/get-pip/raw/c394417beced07131645c83cd0a01d1adc8c149b/get-pip.py',
-                      '19365b3d19b145dd9f94f8b55200aa2a0a3ec1cd')
+    script = download('https://github.com/pypa/get-pip/raw/69941dc3ee6a2562d873f8616a4df31ba401b2a9/get-pip.py',
+                      '29295f4181a2a3df9539dcf1cebc2079da569320')
     # Make sure wheels cache directory exists to avoid warning.
     if not os.path.exists(WHEELS_CACHE):
         os.makedirs(WHEELS_CACHE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-Babel==2.6.0
-check-manifest==0.37
-Cython==0.29
-https://github.com/benoit-pierre/dmgbuild/archive/plover.zip; "darwin" in sys_platform
-macholib==1.11; "darwin" in sys_platform
-pip==18.1
-pytest==3.10.0
-readme-renderer[md]==24.0
-setuptools-scm==3.1.0
-twine==1.12.1
-wheel==0.32.2
+Babel==2.7.0
+check-manifest==0.41
+Cython==0.29.16
+dmgbuild==1.3.3; "darwin" in sys_platform
+macholib==1.14; "darwin" in sys_platform
+pip==20.0.2
+pytest==5.4.1
+readme-renderer[md]==25.0
+setuptools-scm==3.5.0
+twine==1.15.0
+wheel==0.34.2
 -r requirements_distribution.txt
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -10,7 +10,7 @@ PyQt5-sip==4.19.13
 PyQt5==5.11.3
 pyserial==3.4
 python-xlib==0.23; "linux" in sys_platform
-setuptools==40.5.0
+setuptools==46.1.3
 six==1.11.0
 wcwidth==0.1.7
 

--- a/requirements_plugins.txt
+++ b/requirements_plugins.txt
@@ -1,15 +1,19 @@
 # plover-plugins-manager
-bleach==3.0.2
-cffi==1.11.5
+bleach==3.1.4
+cffi==1.14.0
 cmarkgfm==0.4.2
-docutils==0.14
-pip==18.1
-plover-plugins-manager==0.5.13
-pycparser==2.19
-Pygments==2.2.0
-readme-renderer==24.0
+docutils==0.16
+pip==20.0.2
+pkginfo==1.5.0.1
+plover-plugins-manager==0.5.14
+pycparser==2.20
+Pygments==2.6.1
+readme-renderer==25.0
+requests-cache==0.5.2
+requests-futures==1.0.0
+requests==2.23.0
 webencodings==0.5.1
-wheel==0.32.2
+wheel==0.34.2
 # plover-treal
 hidapi==0.7.99.post21
 plover-treal==1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ maintainer = Ted Morin
 maintainer_email = morinted@gmail.com
 classifiers =
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.4
         Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
@@ -25,7 +24,7 @@ keywords = plover
 
 [options]
 include_package_data = True
-python_requires = >=3.4
+python_requires = >=3.5
 zip_safe = True
 tests_require =
 	pytest


### PR DESCRIPTION
* setup: drop support for Python 3.4 (EOL was March 18, 2019)
* update development requirements
* utils: update get-pip to pip 20.0.2
* plugins: update plover-plugins-manager to latest version

