### PR TITLE
Enable CircleCI pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,3 +85,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
+
+experimental:
+  pipelines: true
+


### PR DESCRIPTION
CircleCI is rolling out a new UI and requires either a configuration update to v2.1 or to add a flag in the config. This PR adds the flag to the config.