### PR TITLE
Disable pyqt5 auto connections

### DIFF
--- a/plover_build_utils/pyqt.py
+++ b/plover_build_utils/pyqt.py
@@ -4,15 +4,19 @@ import re
 def fix_icons(contents):
     # replace ``addPixmap(QtGui.QPixmap(":/settings.svg"),``
     # by ``addFile(":/settings.svg", QtCore.QSize(),``
-    contents = re.sub(r'\baddPixmap\(QtGui.QPixmap\(("[^"]*")\),',
-                      r'addFile(\1, QtCore.QSize(),', contents)
+    contents = re.sub(
+        r'\baddPixmap\(QtGui\.QPixmap\(("[^"]*")\),',
+        r'addFile(\1, QtCore.QSize(),',
+        contents
+    )
     return contents
 
 def gettext(contents):
     # replace ``_translate("context", `` by ``_(``
     contents = re.sub(r'_translate\(".*",\s', '_(', contents)
-    contents = contents.replace(
-        '        _translate = QtCore.QCoreApplication.translate',
-        ''
+    contents = re.sub(
+        r'\n\s+_translate = QtCore\.QCoreApplication\.translate\n',
+        '\n',
+        contents
     )
     return contents

--- a/plover_build_utils/pyqt.py
+++ b/plover_build_utils/pyqt.py
@@ -20,3 +20,12 @@ def gettext(contents):
         contents
     )
     return contents
+
+def no_autoconnection(contents):
+    # remove calls to ``QtCore.QMetaObject.connectSlotsByName``
+    contents = re.sub(
+        r'\n\s+QtCore\.QMetaObject\.connectSlotsByName\(\w+\)\n',
+        '\n',
+        contents
+    )
+    return contents

--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -103,6 +103,7 @@ class BuildUi(Command):
     hooks = '''
     plover_build_utils.pyqt:fix_icons
     plover_build_utils.pyqt:gettext
+    plover_build_utils.pyqt:no_autoconnection
     '''.split()
 
     def initialize_options(self):


### PR DESCRIPTION
Rational:
- we already explicitly set connections in UI files
- auto-connections don't always work when there are multiple prototypes for the same signal' slot since Python functions are untyped