### PR TITLE
Update appimage build

### DIFF
--- a/linux/appimage/apprun.sh
+++ b/linux/appimage/apprun.sh
@@ -2,10 +2,10 @@
 
 appimage_setenv()
 {
-  export LD_LIBRARY_PATH="${APPDIR}/usr/local/lib:${APPDIR}/usr/lib:${APPDIR}/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
+  export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
   export PATH="${APPDIR}/usr/bin:${PATH}"
   # Patch LDFLAGS so installing some Python packages from source can work.
-  export LDFLAGS="-L${APPDIR}/usr/lib/x86_64-linux-gnu -L${APPDIR}/usr/lib"
+  export LDFLAGS="-L${APPDIR}/usr/lib"
 }
 
 appimage_install()
@@ -57,9 +57,14 @@ appimage_uninstall()
   gtk-update-icon-cache -q -f -t "$prefix/share/icons/hicolor"
 }
 
+appimage_python()
+{
+  exec "${APPDIR}/usr/bin/python" "$@"
+}
+
 appimage_launch()
 {
-  exec "${APPDIR}/usr/bin/python" -s -m plover.dist_main "$@"
+  appimage_python -s -m plover.dist_main "$@"
 }
 
 set -e
@@ -77,4 +82,13 @@ appimage_setenv
     ;;
 esac
 
-appimage_launch "$@"
+# Handle custom launcher options.
+case "$1" in
+  --python)
+    shift 1
+    appimage_python "$@"
+    ;;
+  *)
+    appimage_launch "$@"
+    ;;
+esac

--- a/linux/appimage/blacklist.txt
+++ b/linux/appimage/blacklist.txt
@@ -8,19 +8,8 @@
 
 # Python.
 :usr/bin
-  2to3*
-  easy_install*
-  idle*
-  miniterm.py
-  pip*
-  pydoc*
-  python3
-  python3-config
-  python${pyversion}-config
-  python${pyversion}m
-  python${pyversion}m-config
-  pyvenv*
-  wheel
+  !python
+  *
 :usr/lib/python${pyversion}
   config-${pyversion}m*/libpython${pyversion}m.a
   ctypes/test

--- a/linux/appimage/blacklist.txt
+++ b/linux/appimage/blacklist.txt
@@ -53,19 +53,24 @@
   pyuic5
 :usr/lib/python${pyversion}/site-packages/PyQt5
   **/*Designer*
-  **/*Help*
+  **/*[Hh]elp*
+  **/*[Qq]ml*
+  **/*[Qq]uick*
   **/*Test*
-  Qt/plugins/PyQt5/libpyqt5qmlplugin.so
+  **/*[Ww]ayland*
+  **/*[Ww]eb[Ee]ngine*
+  bindings
   Qt/plugins/egldeviceintegrations
   Qt/plugins/platforms/libqeglfs.so
   Qt/plugins/platforms/libqlinuxfb.so
   Qt/plugins/platforms/libqminimal.so
   Qt/plugins/platforms/libqminimalegl.so
+  Qt/plugins/platforms/libqoffscreen.so
   Qt/plugins/platforms/libqvnc.so
+  Qt/plugins/platforms/libqwebgl.so
+  Qt/plugins/geoservices
   Qt/plugins/sceneparsers
-  Qt/qml
-  Qt/resources/qtwebengine_devtools_resources.pak
-  Qt/translations/qt_help_*
+  Qt/plugins/webview
   pylupdate*
   pyrcc*
   uic

--- a/linux/appimage/blacklist.txt
+++ b/linux/appimage/blacklist.txt
@@ -22,7 +22,7 @@
   pyvenv*
   wheel
 :usr/lib/python${pyversion}
-  config-${pyversion}m/libpython${pyversion}m.a
+  config-${pyversion}m*/libpython${pyversion}m.a
   ctypes/test
   distutils/command/*.exe
   distutils/tests

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -84,7 +84,7 @@ run cp 'plover/assets/plover.png' "$appdir/plover.png"
 
 # Trim the fat.
 run cp linux/appimage/blacklist.txt "$builddir/blacklist.txt"
-run sed -e "s/\${pyversion}/$pyversion/" -i "$builddir/blacklist.txt"
+run sed -e "s/\${pyversion}/$pyversion/g" -i "$builddir/blacklist.txt"
 run "$python" -m plover_build_utils.trim "$appdir" "$builddir/blacklist.txt"
 
 # Make distribution source-less.

--- a/linux/appimage/build.sh
+++ b/linux/appimage/build.sh
@@ -31,15 +31,51 @@ do
   shift
 done
 
+# Helper to extract an AppImage so it can be used without needing fuse.
+extract_appimage()
+{(
+  appimage="$1"
+  destdir="$2"
+
+  tmpdir="$(mktemp -d "$(dirname "$destdir")/squashfs-root.XXXXXXXXXX")"
+  cd "$tmpdir"
+  chmod +x "$appimage"
+  "$appimage" --appimage-extract >/dev/null
+  mv squashfs-root "$destdir"
+  cd ..
+  rmdir "$tmpdir"
+)}
+
 version="$("$python" -c 'from plover import __version__; print(__version__)')"
 appimage="$distdir/plover-$version-x86_64.AppImage"
 
 run rm -rf "$builddir"
 run mkdir -p "$appdir" "$cachedir" "$distdir"
 
-# Download dependencies.
-run "$python" -m plover_build_utils.download 'https://github.com/AppImage/pkg2appimage/raw/ed1d385282a6aa6c9a93b52296f20555adf9bae7/functions.sh' 'e04404e00dfdf2cd869f892417befa46bbd4e24e' "$cachedir/functions.sh"
-run "$python" -m plover_build_utils.download 'https://github.com/probonopd/AppImageKit/releases/download/11/appimagetool-x86_64.AppImage' 'f3bc2b45d3a9f3c62915ace123a7f8063cfc1822' "$cachedir/appimagetool"
+# Fetch some helpers.
+# Note:
+# - extract AppImages so fuse is not needed.
+# - we start with zsync2 and do two passes
+#   so it can update itself as needed.
+while read tool url sha1;
+do
+  if [ ! -r "$cachedir/$tool" ]
+  then
+    run wget -O "$cachedir/$tool" "$url"
+  else
+    if [ -n "$zsync2" ]
+    then
+      run_eval "(cd '$cachedir' && '$zsync2' -o '$cachedir/$tool' '$url.zsync')"
+    fi
+  fi
+  run extract_appimage "$cachedir/$tool" "$builddir/$tool"
+  run_eval "$tool='$builddir/$tool/AppRun'"
+done <<\EOF
+zsync2        https://github.com/AppImage/zsync2/releases/download/continuous/zsync2-156-10e85c0-x86_64.AppImage
+zsync2        https://github.com/AppImage/zsync2/releases/download/continuous/zsync2-156-10e85c0-x86_64.AppImage
+linuxdeploy   https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+appimagetool  https://github.com/probonopd/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+EOF
 
 # Generate Plover wheel.
 if [ -z "$wheel" ]
@@ -49,38 +85,25 @@ then
 fi
 
 # Setup Python distribution.
-run_eval "$("$python" linux/appimage/pyinfo.py)"
 pydist="$appdir/usr"
+run_eval "$("$python" linux/appimage/pyinfo.py)"
 run mkdir -p "$pydist/"{bin,lib,"$pystdlib"/..,"$pyinclude"/..}
 run cp "$pyexe" "$pydist/bin/python"
-info '('
-(
-run cd "$pyprefix"
 run cp -a "$pyprefix/$pyinclude" "$pydist/$pyinclude/../"
-run cp -a lib/"$pyldlib"* lib/"$pypy3lib" "$pydist/lib/"
-run_eval "find '$pystdlib' \\( -name __pycache__ -o -path '$pypurelib' -o -path '$pyplatlib' \\) -prune -o -type f -not -name '*.py[co]' -print0 | xargs -0 cp --parents -t '$pydist'"
-)
-info ')'
+run cp -a "$pyprefix/lib/$pyldlib"* "$pyprefix/lib/$pypy3lib" "$pydist/lib/"
+run_eval "(cd '$pyprefix' && find '$pystdlib' \\( -name __pycache__ -o -path '$pypurelib' -o -path '$pyplatlib' \\) -prune -o -type f -not -name '*.py[co]' -print0 | xargs -0 cp --parents -t '$pydist')"
 run rm -f "$pydist/$pystdlib/sytecustomize.py"
 run mkdir -p "$pydist/"{"$pypurelib","$pyplatlib"}
 
-run_eval "
-appdir_python()
-{
-  env \
-    PYTHONNOUSERSITE=1 \
-    LD_LIBRARY_PATH=\"$appdir/usr/lib:$appdir/usr/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH+:\$LD_LIBRARY_PATH}\" \
-    "$appdir/usr/bin/python" \"\$@\"
-}
-"
+# Switch to AppDir python.
+run cp linux/appimage/apprun.sh "$appdir/AppRun"
+run_eval "appdir_python(){ env PYTHONNOUSERSITE=1 '$appdir/AppRun' --python \"\$@\"; }"
 python='appdir_python'
+
+"$python" --version
 
 # Install Plover and dependencies.
 bootstrap_dist "$wheel"
-
-# Add desktop integration.
-run cp 'application/plover.desktop' "$appdir/plover.desktop"
-run cp 'plover/assets/plover.png' "$appdir/plover.png"
 
 # Trim the fat.
 run cp linux/appimage/blacklist.txt "$builddir/blacklist.txt"
@@ -90,56 +113,42 @@ run "$python" -m plover_build_utils.trim "$appdir" "$builddir/blacklist.txt"
 # Make distribution source-less.
 run "$python" -m plover_build_utils.source_less "$pydist/$purelib" "$pydist/$platlib" '*/pip/_vendor/distlib/*'
 
-# Add launcher.
-# Note: don't use AppImage's AppRun because
-# it will change the working directory.
-run cp linux/appimage/apprun.sh "$appdir/AppRun"
-
-# Finalize AppDir.
-(
-run . "$cachedir/functions.sh"
-run cd "$appdir"
-# Fix missing system dependencies.
-# Note: temporarily move PyQt5 out of the way so
-# we don't try to bundle its system dependencies.
-run mv "$pydist/$pypurelib/PyQt5" "$builddir"
-run copy_deps; run copy_deps; run copy_deps
-run move_lib
-run mv "$builddir/PyQt5" "$pydist/$pypurelib/PyQt5"
-# Move usr/include out of the way to preserve usr/include/python3.7m.
-run mv usr/include usr/include.tmp
-run delete_blacklisted
-run mv usr/include.tmp usr/include
-)
+# Avoid possible permission errors.
+run chmod u+w -R "$appdir"
 
 # Strip binaries.
 strip_binaries()
 {
-  chmod u+w -R "$appdir"
   {
     printf '%s\0' "$appdir/usr/bin/python"
     find "$appdir" -type f -regex '.*\.so\(\.[0-9.]+\)?$' -print0
-  } | xargs -0 --no-run-if-empty --verbose -n1 strip
+  } | xargs -0 --no-run-if-empty strip
 }
 run strip_binaries
+
+# Finalize the AppDir.
+# Note:
+# - use a custom launcher that does not change the working directory.
+# - temporarily move PyQt5 out of the way so linuxdeploy does not try
+#   to bundle its system dependencies.
+run mv "$pydist/$pypurelib/PyQt5" "$builddir"
+run "$linuxdeploy" \
+  --desktop-file='application/plover.desktop' \
+  --icon-file='plover/assets/plover.png' \
+  --appdir="$appdir" \
+  --verbosity=2
+run mv "$builddir/PyQt5" "$pydist/$pypurelib/PyQt5"
 
 # Remove empty directories.
 remove_emptydirs()
 {
-  find "$appdir" -type d -empty -print0 | xargs -0 --no-run-if-empty rmdir -vp --ignore-fail-on-non-empty
+  find "$appdir" -type d -empty -print0 |
+  xargs -0 --no-run-if-empty rmdir -vp --ignore-fail-on-non-empty
 }
 run remove_emptydirs
 
 # Check requirements.
-run "$python" -I -m plover_build_utils.check_requirements
+run env -i "$appdir/AppRun" --python -I -m plover_build_utils.check_requirements
 
 # Create the AppImage.
-# Note: extract appimagetool so fuse is not needed.
-info '('
-(
-run cd "$builddir"
-run chmod +x "$cachedir/appimagetool"
-run "$cachedir/appimagetool" --appimage-extract
-run env VERSION="$version" ./squashfs-root/AppRun --no-appstream --verbose "$appdir" "$appimage"
-)
-info ')'
+run env VERSION="$version" "$appimagetool" --no-appstream "$appdir" "$appimage"

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -66,7 +66,7 @@ VERSION="$(./setup.py --version)"
 SDIST="$DIST_DIR/$NAME-$VERSION.tar.xz"
 
 run rm -rf "$BUILD_DIR"
-run mkdir -p "$BUILD_DIR" "$DIST_DIR" .cache
+run mkdir -p "$BUILD_DIR" "$DIST_DIR"
 
 run python setup.py -q sdist --format=xztar --dist-dir "$BUILD_DIR/"
 cmd=(env)
@@ -75,7 +75,7 @@ then
   cmd+=(NO_PULL=1)
 fi
 cmd+=(
-  BUILDDIR="$PWD/$BUILD_DIR" CACHE_DIR="$PWD/.cache"
+  BUILDDIR="$PWD/$BUILD_DIR"
   DOCKER_REPO="$REPO"
   OS="$OS" DIST="$DIST"
   PRODUCT="$NAME" VERSION="$VERSION"

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -32,7 +32,7 @@ REPO='plover/packpack'
 case "$1" in
   appimage)
     OS='appimage'
-    DIST='2'
+    DIST='xenial'
     EXT='AppImage'
     TARGET="appimage"
     ;;

--- a/plover_build_utils/trim.py
+++ b/plover_build_utils/trim.py
@@ -6,9 +6,12 @@ import sys
 import os
 
 
-def trim(directory, patterns_file, verbose=True):
+def trim(directory, patterns_file, verbose=True, dry_run=False):
+    if dry_run:
+        verbose = True
     # Build list of patterns.
     pattern_list = []
+    exclude_list = []
     subdir = directory
     with open(patterns_file) as fp:
         for line in fp:
@@ -24,12 +27,23 @@ def trim(directory, patterns_file, verbose=True):
                 subdir = os.path.join(directory, line[1:])
                 continue
             # Pattern (relative to current sub-directory).
-            pattern_list.append(os.path.join(subdir, line))
+            if line.startswith('!'):
+                exclude_list.append(os.path.join(subdir, line[1:]))
+            else:
+                pattern_list.append(os.path.join(subdir, line))
+    # Create list of files to keep based on exclusion list.
+    to_keep = set()
+    for pattern in exclude_list:
+        to_keep.update(glob.glob(pattern, recursive=True))
     # Trim directory tree.
     for pattern in pattern_list:
         for path in reversed(glob.glob(pattern, recursive=True)):
+            if path in to_keep:
+                continue
             if verbose:
                 print('removing', path)
+            if dry_run:
+                continue
             if os.path.isdir(path):
                 shutil.rmtree(path)
             else:

--- a/windows/dist_blacklist.txt
+++ b/windows/dist_blacklist.txt
@@ -3,15 +3,18 @@
 # PyQt5.
 :Lib/site-packages/PyQt5
   **/*Designer*
-  **/*Help*
+  **/*[Hh]elp*
   **/*Test*
+  **/*Qml*
+  **/*[Qq]uick*
+  **/*[Ww]eb[Ee]ngine*
+  bindings
   Qt/bin/libeay32.dll
   Qt/bin/ssleay32.dll
   Qt/plugins/platforms/qminimal.dll
+  Qt/plugins/platforms/qoffscreen.dll
+  Qt/plugins/platforms/qwebgl.dll
   Qt/plugins/sceneparsers
-  Qt/qml
-  Qt/resources/qtwebengine_devtools_resources.pak
-  Qt/translations/qt_help_*
   pylupdate*
   pyrcc*
   uic


### PR DESCRIPTION
* use the new Xenial image when using packpack
* switch to using linuxdeploy for AppDir creation
* trim some more unnecessary PyQt5 stuff, most notably the plugin manager does not use WebEngine anymore (which itself is provided as a separate wheel for recent PyQt5 releases)
