### PR TITLE
Improve config handling

### DIFF
--- a/news.d/bugfix/1123.core.rst
+++ b/news.d/bugfix/1123.core.rst
@@ -1,0 +1,1 @@
+Configuration save operations are now atomic.

--- a/news.d/feature/1123.core.rst
+++ b/news.d/feature/1123.core.rst
@@ -1,0 +1,1 @@
+The configuration is now automatically saved on change, rather than on exit.

--- a/news.d/feature/1123.linux.rst
+++ b/news.d/feature/1123.linux.rst
@@ -1,0 +1,1 @@
+The default configuration directory on Linux is now ``~/.config/plover`` (``~/.local/share/plover`` is still supported for backward compatibility).

--- a/plover/config.py
+++ b/plover/config.py
@@ -12,6 +12,7 @@ import re
 from plover.exception import InvalidConfigurationError
 from plover.machine.keymap import Keymap
 from plover.registry import registry
+from plover.resource import resource_update
 from plover.oslayer.config import CONFIG_DIR
 from plover.misc import boolean, expand_path, shorten_path
 from plover import log
@@ -316,8 +317,9 @@ class Config:
         self._cache.clear()
 
     def save(self):
-        with open(self.path, mode='w', encoding='utf-8') as fp:
-            self._config.write(fp)
+        with resource_update(self.path) as temp_path:
+            with open(temp_path, mode='w', encoding='utf-8') as fp:
+                self._config.write(fp)
 
     def _set(self, section, option, value):
         if not self._config.has_section(section):

--- a/plover/config.py
+++ b/plover/config.py
@@ -13,13 +13,9 @@ from plover.exception import InvalidConfigurationError
 from plover.machine.keymap import Keymap
 from plover.registry import registry
 from plover.resource import resource_update
-from plover.oslayer.config import CONFIG_DIR
 from plover.misc import boolean, expand_path, shorten_path
 from plover import log
 
-
-# Config path.
-CONFIG_FILE = os.path.join(CONFIG_DIR, 'plover.cfg')
 
 # General configuration sections, options and defaults.
 MACHINE_CONFIG_SECTION = 'Machine Configuration'

--- a/plover/config.py
+++ b/plover/config.py
@@ -6,7 +6,6 @@
 from collections import ChainMap, namedtuple, OrderedDict
 import configparser
 import json
-import os
 import re
 
 from plover.exception import InvalidConfigurationError

--- a/plover/config.py
+++ b/plover/config.py
@@ -4,7 +4,6 @@
 """Configuration management."""
 
 from collections import ChainMap, namedtuple, OrderedDict
-import codecs
 import configparser
 import json
 import os
@@ -297,28 +296,28 @@ def dictionaries_option():
 
 class Config:
 
-    def __init__(self):
+    def __init__(self, path=None):
         self._config = None
         self._cache = {}
         # A convenient place for other code to store a file name.
-        self.target_file = None
+        self.path = path
         self.clear()
 
-    def load(self, fp):
+    def load(self):
         self.clear()
-        reader = codecs.getreader('utf8')(fp)
-        try:
-            self._config.read_file(reader)
-        except configparser.Error as e:
-            raise InvalidConfigurationError(str(e))
+        with open(self.path, encoding='utf-8') as fp:
+            try:
+                self._config.read_file(fp)
+            except configparser.Error as e:
+                raise InvalidConfigurationError(str(e))
 
     def clear(self):
         self._config = configparser.RawConfigParser()
         self._cache.clear()
 
-    def save(self, fp):
-        writer = codecs.getwriter('utf8')(fp)
-        self._config.write(writer)
+    def save(self):
+        with open(self.path, mode='w', encoding='utf-8') as fp:
+            self._config.write(fp)
 
     def _set(self, section, option, value):
         if not self._config.has_section(section):

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -423,8 +423,7 @@ class StenoEngine:
 
     def load_config(self):
         try:
-            with open(self._config.target_file, 'rb') as f:
-                self._config.load(f)
+            self._config.load()
         except Exception:
             log.error('loading configuration failed, resetting to default', exc_info=True)
             self._config.clear()

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -180,6 +180,9 @@ class StenoEngine:
                 for option, value in config.items()
                 if value != original_config[option]
             }
+            # Save config if anything changed.
+            if config_update:
+                self._config.save()
         # Update logging.
         log.set_stroke_filename(config['log_file_name'])
         log.enable_stroke_logging(config['enable_stroke_logging'])

--- a/plover/main.py
+++ b/plover/main.py
@@ -125,7 +125,6 @@ def main():
             log.setup_logfile()
             config = Config(CONFIG_FILE)
             code = gui.main(config)
-            config.save()
     except processlock.LockNotAcquiredException:
         gui.show_error('Error', 'Another instance of Plover is already running.')
         code = 1

--- a/plover/main.py
+++ b/plover/main.py
@@ -123,11 +123,9 @@ def main():
             # This must be done after calling init_config_dir, so
             # Plover's configuration directory actually exists.
             log.setup_logfile()
-            config = Config()
-            config.target_file = CONFIG_FILE
+            config = Config(CONFIG_FILE)
             code = gui.main(config)
-            with open(config.target_file, 'wb') as f:
-                config.save(f)
+            config.save()
     except processlock.LockNotAcquiredException:
         gui.show_error('Error', 'Another instance of Plover is already running.')
         code = 1

--- a/plover/main.py
+++ b/plover/main.py
@@ -17,8 +17,9 @@ import pkg_resources
 if sys.platform.startswith('darwin'):
     import appnope
 
-from plover.config import CONFIG_DIR, CONFIG_FILE, Config
+from plover.config import Config
 from plover.oslayer import processlock
+from plover.oslayer.config import CONFIG_DIR, CONFIG_FILE
 from plover.registry import registry
 from plover import log
 from plover import __name__ as __software_name__
@@ -36,8 +37,7 @@ def init_config_dir():
 
     # Create a default configuration file if one doesn't already exist.
     if not os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, 'wb') as f:
-            f.close()
+        open(CONFIG_FILE, 'wb').close()
 
 
 def main():

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -21,10 +21,21 @@ if sys.platform.startswith('darwin') and '.app/' in os.path.realpath(__file__):
 else:
     PROGRAM_DIR = os.getcwd()
 
-if os.path.isfile(os.path.join(PROGRAM_DIR, 'plover.cfg')):
+# Setup configuration directory.
+CONFIG_BASENAME = 'plover.cfg'
+if os.path.isfile(os.path.join(PROGRAM_DIR, CONFIG_BASENAME)):
     CONFIG_DIR = PROGRAM_DIR
 else:
-    CONFIG_DIR = appdirs.user_data_dir('plover', 'plover')
+    config_directories = [
+        getattr(appdirs, directory_type)('plover')
+        for directory_type in ('user_config_dir', 'user_data_dir')
+    ]
+    for CONFIG_DIR in config_directories:
+        if os.path.isfile(os.path.join(CONFIG_DIR, CONFIG_BASENAME)):
+            break
+    else:
+        CONFIG_DIR = config_directories[0]
+CONFIG_FILE = os.path.join(CONFIG_DIR, CONFIG_BASENAME)
 
 # Setup plugins directory.
 if sys.platform.startswith('darwin'):

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -1,5 +1,8 @@
 
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
 import os
+import shutil
 
 import pkg_resources
 
@@ -25,3 +28,18 @@ def resource_filename(resource_name):
 def resource_timestamp(resource_name):
     filename = resource_filename(resource_name)
     return os.path.getmtime(filename)
+
+@contextmanager
+def resource_update(resource_name):
+    filename = resource_filename(resource_name)
+    directory = os.path.dirname(filename)
+    extension = os.path.splitext(filename)[1]
+    tempfile = NamedTemporaryFile(delete=False, dir=directory,
+                                  suffix=extension or None)
+    try:
+        tempfile.close()
+        yield tempfile.name
+        shutil.move(tempfile.name, filename)
+    finally:
+        if os.path.exists(tempfile.name):
+            os.unlink(tempfile.name)

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -9,9 +9,8 @@ A steno dictionary maps sequences of steno strokes to translations.
 
 import collections
 import os
-import shutil
 
-from plover.resource import ASSET_SCHEME, resource_filename, resource_timestamp
+from plover.resource import ASSET_SCHEME, resource_filename, resource_timestamp, resource_update
 
 
 class StenoDictionary:
@@ -72,15 +71,9 @@ class StenoDictionary:
 
     def save(self):
         assert not self.readonly
-        filename = resource_filename(self.path)
-        # Write the new file to a temp location.
-        tmp = filename + '.tmp'
-        self._save(tmp)
-        timestamp = resource_timestamp(tmp)
-        # Then move the new file to the final location.
-        shutil.move(tmp, filename)
-        # And update our timestamp.
-        self.timestamp = timestamp
+        with resource_update(self.path) as temp_path:
+            self._save(temp_path)
+        self.timestamp = resource_timestamp(self.path)
 
     def _load(self, filename):
         raise NotImplementedError()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # See LICENSE.txt for details.
 
 from distutils import log
-import glob
 import os
 import re
 import shutil

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,13 +3,19 @@
 
 """Unit tests for config.py."""
 
+from ast import literal_eval
 from contextlib import ExitStack
+from pathlib import Path
+from site import USER_BASE
+from string import Template
 import inspect
 import json
 import os
+import subprocess
 import sys
 import textwrap
 
+import appdirs
 import pytest
 
 from plover import config
@@ -496,3 +502,87 @@ def test_config(original_contents, original_config,
     if resulting_contents is None:
         resulting_contents = original_contents
     assert config_file.read_text(encoding='utf-8').strip() == dedent_strip(resulting_contents)
+
+
+CONFIG_DIR_TESTS = (
+    # Default to `user_config_dir`.
+    ('''
+     $user_config_dir/foo.cfg
+     $user_data_dir/bar.cfg
+     $cwd/config.cfg
+     ''', '$user_config_dir'),
+    # Use cwd if config file is present, override other directories.
+    ('''
+     $user_config_dir/plover.cfg
+     $user_data_dir/plover.cfg
+     $cwd/plover.cfg
+     ''', '$cwd'),
+    # plover.cfg must be a file.
+    ('''
+     $user_data_dir/plover.cfg
+     $cwd/plover.cfg/config
+     ''', '$user_data_dir'),
+)
+
+if appdirs.user_data_dir() != appdirs.user_config_dir():
+    CONFIG_DIR_TESTS += (
+        # `user_config_dir` take precedence over `user_data_dir`.
+        ('''
+         $user_config_dir/plover.cfg
+         $user_data_dir/plover.cfg
+         $cwd/config.cfg
+         ''', '$user_config_dir'),
+        # But `user_data_dir` is still used when applicable.
+        ('''
+         $user_config_dir/plover.cfg/conf
+         $user_data_dir/plover.cfg
+         $cwd/config.cfg
+         ''', '$user_data_dir'),
+    )
+
+@pytest.mark.parametrize(('tree', 'expected_config_dir'), CONFIG_DIR_TESTS)
+def test_config_dir(tree, expected_config_dir, tmpdir):
+    # Create fake home/cwd directories.
+    home = tmpdir / 'home'
+    home.mkdir()
+    cwd = tmpdir / 'cwd'
+    cwd.mkdir()
+    directories = {
+        'tmpdir': str(tmpdir),
+        'home': str(home),
+        'cwd': str(cwd),
+    }
+    # Setup environment.
+    env = dict(os.environ)
+    env['HOME'] = str(home)
+    env['PYTHONUSERBASE'] = USER_BASE
+    # Helpers.
+    def pyeval(script):
+        return literal_eval(subprocess.check_output(
+            (sys.executable, '-c', script),
+            cwd=str(cwd), env=env).decode())
+    def path_expand(path):
+        return Template(path.replace('/', os.sep)).substitute(**directories)
+    # Find out user_config_dir/user_data_dir locations.
+    directories.update(pyeval(dedent_strip(
+        '''
+        import appdirs, os
+        print(repr({
+            'user_config_dir': appdirs.user_config_dir('plover'),
+            'user_data_dir': appdirs.user_data_dir('plover'),
+        }))
+        ''')))
+    # Create initial tree.
+    for filename_template in dedent_strip(tree).replace('/', os.sep).split('\n'):
+        filename = Path(path_expand(filename_template))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        filename.write_text('pouet')
+    # Check plover.oslayer.config.CONFIG_DIR is correctly set.
+    config_dir = pyeval(dedent_strip(
+        '''
+        __import__('sys').path.insert(0, %r)
+        from plover.oslayer.config import CONFIG_DIR
+        print(repr(CONFIG_DIR))
+        ''' % str(Path(config.__file__).parent.parent)))
+    expected_config_dir = path_expand(expected_config_dir)
+    assert config_dir == expected_config_dir

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -80,18 +80,17 @@ def engine(monkeypatch):
     registry.register_plugin('machine', 'Fake', FakeMachine)
     monkeypatch.setattr('plover.config.registry', registry)
     monkeypatch.setattr('plover.engine.registry', registry)
-    cfg = Config()
     kbd = FakeKeyboardEmulation()
     cfg_file = tempfile.NamedTemporaryFile(prefix='plover',
                                            suffix='config',
                                            delete=False)
     try:
-        cfg.target_file = cfg_file.name
+        cfg_file.close()
+        cfg = Config(cfg_file.name)
         cfg['dictionaries'] = []
         cfg['machine_type'] = 'Fake'
         cfg['system_keymap'] = [(k, k) for k in system.KEYS]
-        cfg.save(cfg_file)
-        cfg_file.close()
+        cfg.save()
         yield FakeEngine(cfg, kbd)
     finally:
         os.unlink(cfg_file.name)


### PR DESCRIPTION
## Summary of changes

- simplify the load/save API
- ensure save operations are atomic
- save on config changes, instead of (always) on exit
- support `~/.config/plover` on Linux (it's given priority over `~/.local/share/plover`)

Closes #674, #915, and #1097.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
