### PR TITLE
Simplify default dictionary tests

### DIFF
--- a/test/test_default_dict.py
+++ b/test/test_default_dict.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2013 Hesky Fisher
 # See LICENSE.txt for details.
 
-import io
 import json
 from collections import defaultdict
 
@@ -18,14 +17,11 @@ DICT_PATH = 'plover/assets/'
 
 def test_no_duplicates_categorized_files():
     d = defaultdict(list)
-    dictionary = None
-    def read_key_pairs(pairs):
+    for dictionary in DICT_NAMES:
+        with open(DICT_PATH + dictionary, encoding='utf-8') as fp:
+            pairs = json.load(fp, object_pairs_hook=lambda x: x)
         for key, value in pairs:
             d[key].append((value, dictionary))
-        return d
-    for dictionary in map(lambda x: DICT_PATH + x, DICT_NAMES):
-        with io.open(dictionary, encoding='utf-8') as fp:
-            json.load(fp, object_pairs_hook=read_key_pairs)
     msg_list = []
     has_duplicate = False
     for key, value_list in d.items():
@@ -40,6 +36,9 @@ def test_no_duplicates_categorized_files():
 
 @pytest.mark.parametrize('dictionary', DICT_NAMES)
 def test_entries_are_valid(dictionary):
-    with io.open(DICT_PATH + dictionary, encoding='utf-8') as fp:
-        for k, v in json.load(fp).items():
-            [steno_to_stroke(s) for s in k.split('/')]
+    all_strokes = []
+    with open(DICT_PATH + dictionary, encoding='utf-8') as fp:
+        for k in json.load(fp):
+            all_strokes += k.split('/')
+    for s in set(all_strokes):
+        steno_to_stroke(s)


### PR DESCRIPTION
The built-in dictionary tests currently account for the majority of the total test time, most of which is spent making sure each dictionary key is a valid series of strokes. There's no need to re-test identical strings, so packing them all into a set first speeds up *the entire test suite* by almost 50% on my machine.

I also flattened the closure in the other test which relied on some non-obvious scoping rules with a loop variable. 'object_pairs_hook=lambda x: x' makes json.load return the key/value pairs directly.

## Summary of changes

- no need for io import since open() is a builtin
- flatten function 'test_no_duplicates_categorized_files'
- optimize function 'test_entries_are_valid'