### PR TITLE
Add config option for sleeping between key presses

### DIFF
--- a/news.d/feature/1132.ui.rst
+++ b/news.d/feature/1132.ui.rst
@@ -1,0 +1,1 @@
+Add config option which allows setting a timeout in milliseconds to be applied between all emulated key presses. This delays key events, providing a workaround for programs which drop or reorder key presses in case of too many events.

--- a/plover/config.py
+++ b/plover/config.py
@@ -26,6 +26,8 @@ LOGGING_CONFIG_SECTION = 'Logging Configuration'
 OUTPUT_CONFIG_SECTION = 'Output Configuration'
 DEFAULT_UNDO_LEVELS = 100
 MINIMUM_UNDO_LEVELS = 1
+DEFAULT_TIME_BETWEEN_KEY_PRESSES = 0
+MINIMUM_TIME_BETWEEN_KEY_PRESSES = 0
 
 DEFAULT_SYSTEM_NAME = 'English Stenotype'
 
@@ -106,6 +108,8 @@ def int_option(name, default, minimum, maximum, section, option=None):
     def setter(config, key, value):
         config._set(section, option, str(value))
     def validate(config, key, value):
+        if value is None:
+            value = default
         if not isinstance(value, int):
             raise InvalidConfigOption(value, default)
         if (minimum is not None and value < minimum) or \
@@ -330,6 +334,7 @@ class Config:
         boolean_option('start_attached', False, OUTPUT_CONFIG_SECTION),
         boolean_option('start_capitalized', False, OUTPUT_CONFIG_SECTION),
         int_option('undo_levels', DEFAULT_UNDO_LEVELS, MINIMUM_UNDO_LEVELS, None, OUTPUT_CONFIG_SECTION),
+        int_option('time_between_key_presses', DEFAULT_TIME_BETWEEN_KEY_PRESSES, MINIMUM_TIME_BETWEEN_KEY_PRESSES, None, OUTPUT_CONFIG_SECTION),
         # Logging.
         path_option('log_file_name', expand_path('strokes.log'), LOGGING_CONFIG_SECTION, 'log_file'),
         boolean_option('enable_stroke_logging', False, LOGGING_CONFIG_SECTION),

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -192,6 +192,7 @@ class StenoEngine:
         self._formatter.start_attached = config['start_attached']
         self._formatter.start_capitalized = config['start_capitalized']
         self._translator.set_min_undo_length(config['undo_levels'])
+        self._keyboard_emulation.set_time_between_key_presses(config['time_between_key_presses'])
         # Update system.
         system_name = config['system_name']
         if system.NAME != system_name:

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -334,6 +334,7 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                                'dictionaries entry with the maximum number of strokes.')),
                 ConfigOption(_('Time between key presses (ms)'), 'time_between_key_presses',
                              partial(IntOption,
+                                     maximum=100000,
                                      minimum=MINIMUM_TIME_BETWEEN_KEY_PRESSES),
                              _('Set the timeout between emulated key presses.\n'
                                '\n'

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -25,7 +25,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from plover.config import MINIMUM_UNDO_LEVELS
+from plover.config import MINIMUM_UNDO_LEVELS, MINIMUM_TIME_BETWEEN_KEY_PRESSES
 from plover.misc import expand_path, shorten_path
 from plover.registry import registry
 
@@ -332,6 +332,16 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                                '\n'
                                'Note: the effective value will take into account the\n'
                                'dictionaries entry with the maximum number of strokes.')),
+                ConfigOption(_('Time between key presses (ms)'), 'time_between_key_presses',
+                             partial(IntOption,
+                                     minimum=MINIMUM_TIME_BETWEEN_KEY_PRESSES),
+                             _('Set the timeout between emulated key presses.\n'
+                               '\n'
+                               'Some programs may drop some keys like hitting backspace\n'
+                               'not enough times, leaving some remainder characters.\n'
+                               'Increasing this number helps solve that problem.\n'
+                               'A high number negatively impacts the performance of\n'
+                               'the key stroke output.')),
             )),
             (_('Plugins'), (
                 ConfigOption(_('Extension:'), 'enabled_extensions',

--- a/plover/oslayer/osxkeyboardcontrol.py
+++ b/plover/oslayer/osxkeyboardcontrol.py
@@ -392,7 +392,7 @@ class KeyboardEmulation:
         KeyboardEmulation._set_event_string(event, c)
         CGEventPost(kCGSessionEventTap, event)
         if self._time_between_key_presses != 0:
-                sleep(self._time_between_key_presses / 1000)
+            sleep(self._time_between_key_presses / 1000)
 
     def send_key_combination(self, combo_string):
         """Emulate a sequence of key combinations.

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -18,6 +18,7 @@ import multiprocessing
 import os
 import threading
 import winreg
+from time import sleep;
 
 from ctypes import windll, wintypes
 
@@ -361,6 +362,10 @@ class KeyboardEmulation:
 
     def __init__(self):
         self.keyboard_layout = KeyboardLayout()
+        self._time_between_key_presses = 0
+
+    def set_time_between_key_presses(self, ms):
+        self._time_between_key_presses = ms
 
     # Sends input types to buffer
     @staticmethod
@@ -433,6 +438,8 @@ class KeyboardEmulation:
     def send_backspaces(self, number_of_backspaces):
         for _ in range(number_of_backspaces):
             self._key_press('\x08')
+            if self._time_between_key_presses != 0:
+                sleep(self._time_between_key_presses / 1000)
 
     def send_string(self, s):
         self._refresh_keyboard_layout()
@@ -443,6 +450,8 @@ class KeyboardEmulation:
             else:
                 # Otherwise, we send it as a Unicode string.
                 self._key_unicode(char)
+        if self._time_between_key_presses != 0:
+            sleep(self._time_between_key_presses / 1000)
 
     def send_key_combination(self, combo_string):
         """Emulate a sequence of key combinations.

--- a/plover/oslayer/winkeyboardcontrol.py
+++ b/plover/oslayer/winkeyboardcontrol.py
@@ -475,3 +475,5 @@ class KeyboardEmulation:
         # Send events...
         for keycode, pressed in key_events:
             self._key_event(keycode, pressed)
+            if self._time_between_key_presses != 0:
+                sleep(self._time_between_key_presses / 1000)

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -26,6 +26,7 @@ import os
 import string
 import select
 import threading
+from time import sleep
 
 from Xlib import X, XK, display
 from Xlib.ext import xinput, xtest
@@ -1142,6 +1143,10 @@ class KeyboardEmulation:
         """Prepare to emulate keyboard events."""
         self._display = display.Display()
         self._update_keymap()
+        self._time_between_key_presses = 0
+
+    def set_time_between_key_presses(self, ms):
+        self._time_between_key_presses = ms
 
     def _update_keymap(self):
         '''Analyse keymap, build a mapping of keysym to (keycode + modifiers),
@@ -1214,6 +1219,9 @@ class KeyboardEmulation:
         for x in range(number_of_backspaces):
             self._send_keycode(self._backspace_mapping.keycode,
                                self._backspace_mapping.modifiers)
+            if self._time_between_key_presses != 0:
+                sleep(self._time_between_key_presses / 1000)
+                self._display.sync()
         self._display.sync()
 
     def send_string(self, s):
@@ -1233,6 +1241,9 @@ class KeyboardEmulation:
                 continue
             self._send_keycode(mapping.keycode,
                                mapping.modifiers)
+            if self._time_between_key_presses != 0:
+                sleep(self._time_between_key_presses / 1000)
+                self._display.sync()
         self._display.sync()
 
     def send_key_combination(self, combo_string):

--- a/plover/oslayer/xkeyboardcontrol.py
+++ b/plover/oslayer/xkeyboardcontrol.py
@@ -1220,8 +1220,8 @@ class KeyboardEmulation:
             self._send_keycode(self._backspace_mapping.keycode,
                                self._backspace_mapping.modifiers)
             if self._time_between_key_presses != 0:
-                sleep(self._time_between_key_presses / 1000)
                 self._display.sync()
+                sleep(self._time_between_key_presses / 1000)
         self._display.sync()
 
     def send_string(self, s):
@@ -1242,8 +1242,8 @@ class KeyboardEmulation:
             self._send_keycode(mapping.keycode,
                                mapping.modifiers)
             if self._time_between_key_presses != 0:
-                sleep(self._time_between_key_presses / 1000)
                 self._display.sync()
+                sleep(self._time_between_key_presses / 1000)
         self._display.sync()
 
     def send_key_combination(self, combo_string):
@@ -1276,6 +1276,9 @@ class KeyboardEmulation:
         # Emulate the key combination by sending key events.
         for keycode, event_type in key_events:
             xtest.fake_input(self._display, event_type, keycode)
+            if self._time_between_key_presses != 0:
+                self._display.sync()
+                sleep(self._time_between_key_presses / 1000)
         self._display.sync()
 
     def _send_keycode(self, keycode, modifiers=0):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -115,6 +115,7 @@ DEFAULTS = {
     'start_attached': False,
     'start_capitalized': False,
     'undo_levels': config.DEFAULT_UNDO_LEVELS,
+    'time_between_key_presses': config.DEFAULT_TIME_BETWEEN_KEY_PRESSES,
     'log_file_name': expand_path('strokes.log'),
     'enable_stroke_logging': False,
     'enable_translation_logging': False,
@@ -150,18 +151,21 @@ CONFIG_TESTS = (
      start_attached = true
      start_capitalized = yes
      undo_levels = 42
+     time_between_key_presses = 1337
      ''',
      dict_replace(DEFAULTS, {
          'space_placement': 'After Output',
          'start_attached': True,
          'start_capitalized': True,
          'undo_levels': 42,
+         'time_between_key_presses': 1337,
      }),
      {
          'space_placement': 'Before Output',
          'start_attached': False,
          'start_capitalized': False,
          'undo_levels': 200,
+         'time_between_key_presses': 5,
      },
      None,
      '''
@@ -170,6 +174,7 @@ CONFIG_TESTS = (
      start_attached = False
      start_capitalized = False
      undo_levels = 200
+     time_between_key_presses = 5
      ''',
     ),
 
@@ -442,6 +447,16 @@ CONFIG_TESTS = (
      ''',
      DEFAULTS,
      ('undo_levels', -42),
+     config.InvalidConfigOption,
+     '''
+     '''
+    ),
+
+    ('setitem_invalid_2',
+     '''
+     ''',
+     DEFAULTS,
+     ('time_between_key_presses', -1),
      config.InvalidConfigOption,
      '''
      '''

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -43,6 +43,9 @@ class FakeMachine(StenotypeBase):
 
 class FakeKeyboardEmulation:
 
+    def set_time_between_key_presses(self, ms):
+        pass
+
     def send_backspaces(self, b):
         pass
 


### PR DESCRIPTION
## Summary of changes

On Linux (haven't tested other OS) Firefox seems to drop some key events if they are sent too quickly. One extreme example is stroking SER to get "certificate", followed by `SRER` to change it to "server". In Firefox, often times the beginning "c" or "ce" of "certificate" aren't deleted, which results in "ceserver". Sometimes a backspace key is even applied after "server" has been written, resulting in "ceserve" and similar.  
To work around that problem, I implemented a config option, which allows setting a timeout in milliseconds, which is applied between all emulated keys, delaying the key events so that Firefox processes them correctly in the correct order. For me about 5 milliseconds seems to be the optimum.

### Open Questions

- [ ] Do I need to / how should I update the .pot file?
- [ ] Is changing the `KeyboardEmulation.{send_backspaces,send_string}` functions in some os-implementations from static to non-static a breaking API change that needs to be documented for towncrier?
- [ ] To not cause config-file problems, I added an if-condition to `int_option`, which sets the `value` to the `default` if `value is None`. This results in the config option added by this PR to default to its default value. Before doing this, I got an error message during startup of plover that the config option is missing in the config file. Is this an appropriate solution, or is there a different way that I should use for config-file migration?

### Pull Request Checklist

- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
