### PR TITLE
Argument for custom command plugins should not be forced lowercase

### DIFF
--- a/news.d/bugfix/1139.core.rst
+++ b/news.d/bugfix/1139.core.rst
@@ -1,0 +1,1 @@
+Fix forced lowercasing of all engine command arguments.

--- a/plover/command/set_config.py
+++ b/plover/command/set_config.py
@@ -23,6 +23,7 @@ def set_config(engine, cmdline):
 
 def _cmdline_to_dict(cmdline):
     """ Add braces and parse the entire command line as a Python dict literal. """
+    cmdline = cmdline.lower()
     try:
         opt_dict = ast.literal_eval('{'+cmdline+'}')
         assert isinstance(opt_dict, dict)

--- a/plover/command/set_config.py
+++ b/plover/command/set_config.py
@@ -23,7 +23,6 @@ def set_config(engine, cmdline):
 
 def _cmdline_to_dict(cmdline):
     """ Add braces and parse the entire command line as a Python dict literal. """
-    cmdline = cmdline.lower()
     try:
         opt_dict = ast.literal_eval('{'+cmdline+'}')
         assert isinstance(opt_dict, dict)

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -347,7 +347,7 @@ class StenoEngine:
             self._trigger_hook('lookup')
         else:
             command_fn = registry.get_plugin('command', command_name).obj
-            command_fn(self, command_args[0] if command_args else "")
+            command_fn(self, command_args[0] if command_args else '')
         return False
 
     def _on_stroked(self, steno_keys):

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -321,6 +321,7 @@ class StenoEngine:
 
     def _consume_engine_command(self, command):
         # The first commands can be used whether plover has output enabled or not.
+        original_command = command
         command = command.lower()
         if command == 'resume':
             self._set_output(True)
@@ -347,7 +348,7 @@ class StenoEngine:
         else:
             command_args = command.split(':', 1)
             command_fn = registry.get_plugin('command', command_args[0]).obj
-            command_fn(self, command_args[1] if len(command_args) == 2 else '')
+            command_fn(self, original_command[len(command_args[0])+1:])
         return False
 
     def _on_stroked(self, steno_keys):

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -321,34 +321,33 @@ class StenoEngine:
 
     def _consume_engine_command(self, command):
         # The first commands can be used whether plover has output enabled or not.
-        original_command = command
-        command = command.lower()
-        if command == 'resume':
+        command_name, *command_args = command.split(':', 1)
+        command_name = command_name.lower()
+        if command_name == 'resume':
             self._set_output(True)
             return True
-        elif command == 'toggle':
+        elif command_name == 'toggle':
             self._toggle_output()
             return True
-        elif command == 'quit':
+        elif command_name == 'quit':
             self.quit()
             return True
         if not self._is_running:
             return False
         # These commands can only be run when plover has output enabled.
-        if command == 'suspend':
+        if command_name == 'suspend':
             self._set_output(False)
-        elif command == 'configure':
+        elif command_name == 'configure':
             self._trigger_hook('configure')
-        elif command == 'focus':
+        elif command_name == 'focus':
             self._trigger_hook('focus')
-        elif command == 'add_translation':
+        elif command_name == 'add_translation':
             self._trigger_hook('add_translation')
-        elif command == 'lookup':
+        elif command_name == 'lookup':
             self._trigger_hook('lookup')
         else:
-            command_args = command.split(':', 1)
-            command_fn = registry.get_plugin('command', command_args[0]).obj
-            command_fn(self, original_command[len(command_args[0])+1:])
+            command_fn = registry.get_plugin('command', command_name).obj
+            command_fn(self, command_args[0] if command_args else "")
         return False
 
     def _on_stroked(self, steno_keys):


### PR DESCRIPTION
## Summary of changes

The argument received by command plugins is no longer converted to lower case.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
