### PR TITLE
Fix Mac CI

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -6,7 +6,7 @@ You need Python 3.6 installed with pip support.
 
 Some of the dependencies cannot be installed with pip:
 
-* system libraries needed to build python-hidapi and dbus-python
+* system libraries are needed to build `python-hidapi` and `dbus-python`
 
 For the other dependencies, you can use:
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -6,7 +6,11 @@ You need Python 3.6 installed with pip support.
 
 For installing all the required dependencies, you can use:
 
-`pip3 install --user -r requirements.txt`
+`python -m pip install -r requirements.txt`
+
+To install the standard plugins, you can use:
+
+`python -m pip install --user -e . -r requirements_plugins.txt`
 
 ## Development helpers
 

--- a/osx/dmg_resources/settings.py
+++ b/osx/dmg_resources/settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import biplist
+import plistlib
 import os.path
 
 application = defines.get('app', './dist/Plover.app')
@@ -9,7 +9,8 @@ appname = os.path.basename(application)
 
 def icon_from_app(app_path):
     plist_path = os.path.join(app_path, 'Contents', 'Info.plist')
-    plist = biplist.readPlist(plist_path)
+    with open(plist_path, 'rb') as plist_file:
+        plist = plistlib.load(plist_file)
     icon_name = plist['CFBundleIconFile']
     icon_root, icon_ext = os.path.splitext(icon_name)
     if not icon_ext:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Babel==2.7.0
 check-manifest==0.41
 Cython==0.29.16
-dmgbuild==1.3.3; "darwin" in sys_platform
+dmgbuild==1.4.1; "darwin" in sys_platform
 macholib==1.14; "darwin" in sys_platform
 pip==20.0.2
 pytest==5.4.1

--- a/windows/README.md
+++ b/windows/README.md
@@ -2,7 +2,7 @@
 
 ## Environment setup
 
-You need Python 3.6 (32 bits) installed with pip support.
+You need Python 3.6 (64 bit) installed with pip support.
 
 For installing all the required dependencies, you can use:
 
@@ -10,7 +10,7 @@ For installing all the required dependencies, you can use:
 
 To install the standard plugins, you can use:
 
-`pip3 install --user -e . -r requirements_plugins.txt`
+`python -m pip install --user -e . -r requirements_plugins.txt`
 
 ## Development helpers
 


### PR DESCRIPTION
## Summary of changes

Update dmgbuild and our own script to replace usage of biplist with plistlib to fix CI build.

No need for release notes or additional tests.

+ Very slight documentation update to make sure all platforms align on installing dependencies.