### PR TITLE
Update dmgbuild to suppress file not found errors

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -4,7 +4,7 @@
 
 You need Python 3.6 installed with pip support.
 
-If you plan on building Plover for distribution, you'll need to be using Python as distributed on [python.org](https://www.python.org/downloads/). For running from source, a brew or pyenv python should suffice.
+If you plan on building Plover for distribution, you'll need to be using Python installed from [python.org](https://www.python.org/downloads/). For running from source, a brew or pyenv python should suffice.
 
 For installing all the required dependencies, you can use:
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -4,13 +4,15 @@
 
 You need Python 3.6 installed with pip support.
 
+If you plan on building Plover for distribution, you'll need to be using Python as distributed on [python.org](https://www.python.org/downloads/). For running from source, a brew or pyenv python should suffice.
+
 For installing all the required dependencies, you can use:
 
-`python -m pip install -r requirements.txt`
+`python3 -m pip install -r requirements.txt`
 
 To install the standard plugins, you can use:
 
-`python -m pip install --user -e . -r requirements_plugins.txt`
+`python3 -m pip install --user -e . -r requirements_plugins.txt`
 
 ## Development helpers
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Babel==2.7.0
 check-manifest==0.41
 Cython==0.29.16
-dmgbuild==1.4.1; "darwin" in sys_platform
+dmgbuild==1.4.2; "darwin" in sys_platform
 macholib==1.14; "darwin" in sys_platform
 pip==20.0.2
 pytest==5.4.1

--- a/windows/README.md
+++ b/windows/README.md
@@ -6,11 +6,11 @@ You need Python 3.6 (64 bit) installed with pip support.
 
 For installing all the required dependencies, you can use:
 
-`python -m pip install -r requirements.txt`
+`python3 -m pip install -r requirements.txt`
 
 To install the standard plugins, you can use:
 
-`python -m pip install --user -e . -r requirements_plugins.txt`
+`python3 -m pip install --user -e . -r requirements_plugins.txt`
 
 ## Development helpers
 


### PR DESCRIPTION
Updating to dmgbuild 1.4.1 solved the build, but introduced some new (harmless) errors. A patch was just released to address them.

Bonus: update documentation to be clear about using `python3` instead of `python` and also share that in order to build apps and dmgs, one needs python.org python.