### PR TITLE
circleci: update xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ variables:
 
   macos: &macos
     macos:
-      xcode: "9.3.1"
+      xcode: "9.4.1"
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci/artifacts
 

--- a/news.d/feature/1156.osx.rst
+++ b/news.d/feature/1156.osx.rst
@@ -1,0 +1,1 @@
+The minimum version supported by the macOS bundle is now 10.13 (High Sierra).


### PR DESCRIPTION
The oldest supported XCode version is now 9.4.1.

Fix #1155.