### PR TITLE
formatting & translations: add support for prefix strokes

### DIFF
--- a/news.d/feature/1157.core.md
+++ b/news.d/feature/1157.core.md
@@ -1,0 +1,1 @@
+Add prefix strokes (syntax `/STROKE`) that will only translate if they are at the beginning of a word. Word endings can be specified with `{:word_end}` or `{$}`.

--- a/news.d/feature/1157.core.rst
+++ b/news.d/feature/1157.core.rst
@@ -1,0 +1,1 @@
+Add prefix strokes (syntax ``/STROKE``) that will only translate if they are at the beginning of a word. Word endings can be specified with ``{:word_end}`` or ``{$}``.

--- a/news.d/feature/1157.core.rst
+++ b/news.d/feature/1157.core.rst
@@ -1,1 +1,0 @@
-Add prefix strokes (syntax ``/STROKE``) that will only translate if they are at the beginning of a word. Word endings can be specified with ``{:word_end}`` or ``{$}``.

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -580,7 +580,7 @@ class _Action:
 
         word_is_finished -- True if word is finished.
 
-        othography -- True if orthography rules should be applies when adding
+        orthography -- True if orthography rules should be applies when adding
                       a suffix to this action.
 
         space_char -- this character will replace spaces after all other

--- a/plover/formatting.py
+++ b/plover/formatting.py
@@ -101,6 +101,8 @@ _parse_meta = _build_metas_parser((
     (r'\*-\|', 'retro_case', Case.CAP_FIRST_WORD.value  ),
     (r'\*>'  , 'retro_case', Case.LOWER_FIRST_CHAR.value),
     (r'\*<'  , 'retro_case', Case.UPPER_FIRST_WORD.value),
+    # Explicit word end.
+    (r'(\$)', 'word_end', 0),
     # Mode.
     (r'MODE:(.*)', 'mode', 0),
     # Currency.
@@ -554,7 +556,7 @@ class _Action:
                  # Current.
                  glue=False, word=None, orthography=True, space_char=' ',
                  upper_carry=False, case=None, text=None, trailing_space='',
-                 combo=None, command=None,
+                 word_is_finished=None, combo=None, command=None,
                  # Next.
                  next_attach=False, next_case=None
                 ):
@@ -575,6 +577,8 @@ class _Action:
                 suffixes.
 
         upper_carry -- True if we are uppercasing the current word.
+
+        word_is_finished -- True if word is finished.
 
         othography -- True if orthography rules should be applies when adding
                       a suffix to this action.
@@ -609,6 +613,10 @@ class _Action:
         self.orthography = orthography
         self.next_attach = next_attach
         self.next_case = next_case
+        if word_is_finished is None:
+            self.word_is_finished = not self.next_attach
+        else:
+            self.word_is_finished = word_is_finished
         # Persistent state variables
         self.space_char = space_char
         self.case = case
@@ -628,6 +636,7 @@ class _Action:
             case=self.case, glue=self.glue, orthography=self.orthography,
             space_char=self.space_char, upper_carry=self.upper_carry,
             word=self.word, trailing_space=self.trailing_space,
+            word_is_finished=self.word_is_finished,
             # Next.
             next_attach=self.next_attach, next_case=self.next_case,
         )

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -173,10 +173,13 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
         self._focus = None
 
     def _strokes(self):
-        strokes = self.strokes.text().replace('/', ' ').split()
-        if not strokes:
-            return ()
-        return normalize_steno('/'.join(strokes))
+        strokes = self.strokes.text().strip()
+        has_prefix = strokes.startswith('/')
+        strokes = '/'.join(strokes.replace('/', ' ').split())
+        if has_prefix:
+            strokes = '/' + strokes
+        strokes = normalize_steno(strokes)
+        return strokes
 
     def _translation(self):
         translation = self.translation.text().strip()

--- a/plover/meta/attach.py
+++ b/plover/meta/attach.py
@@ -24,6 +24,7 @@ def meta_attach(ctx, meta):
     if end:
         meta = meta[:-len(META_ATTACH_FLAG)]
         action.next_attach = True
+        action.word_is_finished = False
     last_word = ctx.last_action.word or ''
     if not meta:
         # We use an empty connection to indicate a "break" in the
@@ -62,6 +63,7 @@ def meta_carry_capitalize(ctx, meta):
     if end:
         meta = meta[:-len(META_ATTACH_FLAG)]
         action.next_attach = True
+        action.word_is_finished = False
     if meta or begin or end:
         action.text = meta
     return action

--- a/plover/meta/word_end.py
+++ b/plover/meta/word_end.py
@@ -1,0 +1,4 @@
+def meta_word_end(ctx, meta):
+    action = ctx.copy_last_action()
+    action.word_is_finished = True
+    return action

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -75,6 +75,10 @@ class Stroke:
         # Remove duplicate keys and save local versions of the input 
         # parameters.
         steno_keys_set = set(steno_keys)
+        if not steno_keys_set:
+            self.steno_keys = []
+            self.rtfcre = ''
+            return
         # Order the steno keys so comparisons can be made.
         steno_keys = list(sort_steno_keys(steno_keys_set))
 

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -40,6 +40,8 @@ def normalize_stroke(stroke):
 
 def normalize_steno(strokes_string):
     """Convert steno strings to one common form."""
+    if not strokes_string:
+        return ()
     return tuple(normalize_stroke(stroke) for stroke
                  in strokes_string.split(STROKE_DELIMITER))
 

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -101,6 +101,9 @@ class Stroke:
         # Determine if this stroke is a correction stroke.
         self.is_correction = (self.rtfcre == system.UNDO_STROKE_STENO)
 
+    def __hash__(self):
+        return hash(self.rtfcre)
+
     def __str__(self):
         if self.is_correction:
             prefix = '*'

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,6 +101,7 @@ plover.meta =
 	retro_case       = plover.meta.case:meta_retro_case
 	retro_currency   = plover.meta.currency:meta_retro_currency
 	stop             = plover.meta.punctuation:meta_stop
+	word_end         = plover.meta.word_end:meta_word_end
 plover.system =
 	English Stenotype = plover.system.english_stenotype
 setuptools.installation =

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1592,3 +1592,12 @@ class TestsBlackbox:
 
         TEFT/AT/TEFT  ' testattach test'
         '''
+
+    def test_prefix_strokes(self):
+        r'''
+        "/S": "{prefix^}",
+        "S": "{^suffix}",
+        "O": "{O'^}{$}",
+
+        S/S/O/S/S  " prefixsuffix O'prefixsuffix"
+        '''


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Prefix strokes only match at the beginning of a word: this is useful for orthographic theories with explicit spacing (like Melani). 

Needed for #987.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
