### PR TITLE
formatting: look ahead support

### DIFF
--- a/news.d/feature/1158.core.md
+++ b/news.d/feature/1158.core.md
@@ -1,0 +1,1 @@
+Add support for conditional formatting (based on the text following a translation): `{=REGEXP/TRANSLATION_IF_FOLLOWING_TEXT_MATCH/TRANSLATION_IF_NOT}` or `{:if_next_matches:REGEXP/TRANSLATION_IF_FOLLOWING_TEXT_MATCH/TRANSLATION_IF_NOT}`.

--- a/plover/meta/conditional.py
+++ b/plover/meta/conditional.py
@@ -1,0 +1,20 @@
+import re
+
+from plover.formatting import _LookAheadAction
+
+
+IF_NEXT_META_RX = re.compile(r'((?:[^\\/]|\\\\|\\/)*)/?')
+IF_NEXT_ESCAPE_RX = re.compile(r'\\([\\/])')
+
+
+def meta_if_next_matches(ctx, meta):
+    pattern, result1, result2 = [
+        IF_NEXT_ESCAPE_RX.sub(r'\1', s)
+        for s in filter(None, IF_NEXT_META_RX.split(meta, 2))
+    ]
+    action_list = []
+    for alternative in result1, result2:
+        action = ctx.new_action()
+        action.text = alternative
+        action_list.append(action)
+    return _LookAheadAction(pattern, *action_list)

--- a/plover_build_utils/testing.py
+++ b/plover_build_utils/testing.py
@@ -71,6 +71,9 @@ def steno_to_stroke(steno):
 steno_to_stroke.system = None
 
 
+BLACKBOX_OUTPUT_RX = re.compile("r?['\"]")
+
+
 def blackbox_setup(blackbox):
     blackbox.output = CaptureOutput()
     blackbox.formatter = Formatter()
@@ -117,7 +120,7 @@ def blackbox_replay(blackbox, name, test):
             '\n'.join(('> ' if n == lnum else '  ') + l
                       for n, l in enumerate(lines)) + '\n'
         )
-        if output.startswith("'") or output.startswith('"'):
+        if BLACKBOX_OUTPUT_RX.match(output):
             # Replay strokes.
             list(map(blackbox.translator.translate, steno))
             # Check output.

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ plover.meta =
 	comma            = plover.meta.punctuation:meta_comma
 	command          = plover.meta.command:meta_command
 	glue             = plover.meta.glue:meta_glue
+	if_next_matches  = plover.meta.conditional:meta_if_next_matches
 	key_combo        = plover.meta.key_combo:meta_key_combo
 	mode             = plover.meta.mode:meta_mode
 	retro_case       = plover.meta.case:meta_retro_case

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -1646,3 +1646,91 @@ class TestsBlackbox:
         system.setup('Melani', system_mod=Melani, system_dict=system_dict)
         for k, v in system_dict.items():
             monkeypatch.setattr(system, k, v)
+
+    def test_conditionals_1(self):
+        r'''
+        "*": "=undo",
+        "S-": "{=(?i)t/true/false}",
+        "TP-": "FALSE",
+        "T-": "TRUE",
+
+        S-   ' false'
+        TP-  ' false FALSE'
+        *    ' false'
+        T-   ' true TRUE'
+        *    ' false'
+        S-   ' false false'
+        TP-  ' false false FALSE'
+        *    ' false false'
+        T-   ' true true TRUE'
+        '''
+
+    def test_conditionals_2(self):
+        r'''
+        "1": "{=(?i)([8aeiouxy]|11|dei|gn|ps|s[bcdfglmnpqrtv]|z)/agli/ai}",
+        "2": "oc{^}chi",
+        "3": "dei",
+        "4": "sti{^}vali",
+
+        1  ' ai'
+        2  ' agli occhi'
+        1  ' agli occhi ai'
+        3  ' agli occhi agli dei'
+        1  ' agli occhi agli dei ai'
+        4  ' agli occhi agli dei agli stivali'
+        '''
+
+    def test_conditionals_3(self):
+        r'''
+        "1": "{:if_next_matches:(?i)([8aeiouxy]|11|dei|gn|ps|s[bcdfglmnpqrtv]|z)/agli/ai}",
+        "2": "chi",
+        "3": "oc{^}chi",
+        "4": "dei",
+        "5": "sti{^}vali",
+
+        :spaces_after
+        2  'chi '
+        1  'chi ai '
+        3  'chi agli occhi '
+        1  'chi agli occhi ai '
+        4  'chi agli occhi agli dei '
+        1  'chi agli occhi agli dei ai '
+        5  'chi agli occhi agli dei agli stivali '
+        '''
+
+    def test_conditionals_4(self):
+        r'''
+        "1": "{=(?i)([8aeiouxy]|11|dei|gn|ps|s[bcdfglmnpqrtv]|z)/agli/ai}",
+        "2": "{=(?i)([8aeiouxy]|11|dei|gn|ps|s[bcdfglmnpqrtv]|z)/cogli/coi}",
+        "3": "ci",
+
+        1/2/1/3  ' ai cogli ai ci'
+        '''
+
+    def test_conditionals_5(self):
+        r'''
+        "1": "{=(?i)([8aeiouxy]|11|dei|gn|ps|s[bcdfglmnpqrtv]|z)/agli/ai}",
+        "2": "{=(?i)([8aeiouxy]|11|dei|gn|ps|s[bcdfglmnpqrtv]|z)/cogli/coi}",
+        "3": "ci",
+
+        :spaces_after
+        1/2/1/3  'ai cogli ai ci '
+        '''
+
+    def test_conditionals_6(self):
+        r'''
+        "*": "=undo",
+        "S-": r'{=(?i)tr\/ue/tr\/ue/fa\\lse}',
+        "TP-": r'FA\LSE',
+        "T-": 'TR/UE',
+
+        S-   r' fa\lse'
+        TP-  r' fa\lse FA\LSE'
+        *    r' fa\lse'
+        T-   r' tr/ue TR/UE'
+        *    r' fa\lse'
+        S-   r' fa\lse fa\lse'
+        TP-  r' fa\lse fa\lse FA\LSE'
+        *    r' fa\lse fa\lse'
+        T-   r' tr/ue tr/ue TR/UE'
+        '''


### PR DESCRIPTION
#351  Summary of changes

Another change needed for full Melani support: conditional output, based on the text following a translation. The new syntax is `{=REGEXP/TRANSLATION_IF_FOLLOWING_TEXT_MATCH/TRANSLATION_IF_NOT}`. See blackbox tests for examples.

Needed for #987.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
