### PR TITLE
Allow higher priority dictionaries to delete entries from others

### DIFF
--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -210,8 +210,10 @@ class StenoDictionaryCollection:
             if key_len > d.longest_key:
                 continue
             value = d.get(key)
-            if value:
+            if value is not None:
                 if not any(f(key, value) for f in filters):
+                    if value.lower() == "{plover:deleted}":
+                        return None
                     return value
 
     def _lookup_from_all(self, key, dicts=None, filters=()):


### PR DESCRIPTION
## Summary of changes

If there's an entry `{plover:deleted}` in a dictionary, Plover will understand that the entry is deleted.

TODO: currently reverse-lookup still lists the deleted entry.

I've seen the POC in the linked issue, but it has a lot of merge conflicts, it's more complex (edits a lot of places in the code to special-case handle it), it doesn't work well with the add translation dialog (by default it does nothing if either field is empty) and it doesn't seem to work.

Closes #726 .

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
