### PR TITLE
Add an option to only show dictionaries basename

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -7,6 +7,7 @@ from collections import ChainMap, namedtuple, OrderedDict
 import configparser
 import json
 import re
+import os
 
 from plover.exception import InvalidConfigurationError
 from plover.machine.keymap import Keymap
@@ -41,6 +42,10 @@ class DictionaryConfig(namedtuple('DictionaryConfig', 'path enabled')):
     @property
     def short_path(self):
         return shorten_path(self.path)
+
+    @property
+    def basename(self):
+        return os.path.basename(self.path)
 
     def to_dict(self):
         # Note: do not use _asdict because of
@@ -340,6 +345,7 @@ class Config:
         boolean_option('show_suggestions_display', False, 'Suggestions Display', 'show'),
         opacity_option('translation_frame_opacity', 'Translation Frame', 'opacity'),
         boolean_option('classic_dictionaries_display_order', False, 'GUI'),
+        boolean_option('show_dictionary_basename_only', False, 'GUI'),
         # Plugins.
         enabled_extensions_option(),
         # Machine.

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -288,6 +288,8 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                              _('Set the display order for dictionaries:\n'
                                '- top-down: match the search order; highest priority first\n'
                                '- bottom-up: reverse search order; lowest priority first\n')),
+                ConfigOption(_('Show dictionary base name only:'), 'show_dictionary_basename_only', BooleanOption,
+                             _('Show only the base name of the dictionaries in the dictionaries table.')),
             )),
             (_('Logging'), (
                 ConfigOption(_('Log file:'), 'log_file_name',

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -62,6 +62,7 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
         self._config_dictionaries = {}
         self._loaded_dictionaries = {}
         self._reverse_order = False
+        self._show_basename_only = False
         for action in (
             self.action_Undo,
             self.action_EditDictionaries,
@@ -107,6 +108,11 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
 
     def on_config_changed(self, config_update):
         update_kwargs = {}
+        if 'show_dictionary_basename_only' in config_update:
+            update_kwargs.update(
+                show_basename_only=config_update['show_dictionary_basename_only'],
+                record=False, save=False,
+            )
         if 'dictionaries' in config_update:
             update_kwargs.update(
                 config_dictionaries=config_update['dictionaries'],
@@ -122,13 +128,16 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
 
     def _update_dictionaries(self, config_dictionaries=None, loaded_dictionaries=None,
                              reverse_order=None, record=True, save=True,
-                             reset_undo=False, keep_selection=True):
+                             reset_undo=False, keep_selection=True, show_basename_only=None):
         if reverse_order is None:
             reverse_order = self._reverse_order
+        if show_basename_only is None:
+            show_basename_only = self._show_basename_only
         if config_dictionaries is None:
             config_dictionaries = self._config_dictionaries
         if config_dictionaries == self._config_dictionaries and \
            reverse_order == self._reverse_order and \
+           show_basename_only == self._show_basename_only and \
            loaded_dictionaries is None:
             return
         if save:
@@ -147,6 +156,7 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
         else:
             self._loaded_dictionaries = loaded_dictionaries
         self._reverse_order = reverse_order
+        self._show_basename_only = show_basename_only
         self._updating = True
         self.table.setRowCount(len(config_dictionaries))
         favorite_set = False
@@ -154,7 +164,7 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
             row = n
             if self._reverse_order:
                 row = len(config_dictionaries) - row - 1
-            item = QTableWidgetItem(dictionary.short_path)
+            item = QTableWidgetItem(dictionary.basename if show_basename_only else dictionary.short_path)
             item.setFlags((item.flags() | Qt.ItemIsUserCheckable) & ~Qt.ItemIsEditable)
             item.setCheckState(Qt.Checked if dictionary.enabled else Qt.Unchecked)
             item.setToolTip(dictionary.path)


### PR DESCRIPTION
## Summary of changes

Add an option to only show dictionaries basename.

Closes #973.

By the way: annoyingly, the default value have to be duplicated at two places. (should I fix that too?)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
