### PR TITLE
Lock the display on use in KeyboardCapture for X

### DIFF
--- a/news.d/bugfix/1163.linux.rst
+++ b/news.d/bugfix/1163.linux.rst
@@ -1,0 +1,1 @@
+Fix a race condition that may freeze Plover while toggling with keyboard input machine.


### PR DESCRIPTION
## Summary of changes

Use a lock so that only one thread use the `_display` object of `KeyboardCapture` (in `plover/oslayer/xkeyboardcontrol.py`).

(there's no Python-xlib documentation about thread-safety (in fact there's hardly any documentation at all), so it's safer to assume that it isn't.)

Should close #1126 . (I toggle Plover with keyboard input machine repeatedly, and it tends to freeze without this change, and doesn't freeze so far with this change)

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
