### PR TITLE
Update keymap on keymap change

### DIFF
--- a/news.d/bugfix/1163.linux.rst
+++ b/news.d/bugfix/1163.linux.rst
@@ -1,0 +1,1 @@
+Fix a race condition that may freeze Plover while toggling with keyboard input machine.


### PR DESCRIPTION
## Summary of changes

Listens for `XMappingEvent`s and call `_update_keymap` whenever the keymap changes.

Closes #967.

Relies on the other pull request for `self._display_lock`.

Problem: for some reason, it refreshes the key map every time I use a different keyboard (in case I have more than one keyboard plugged in the machine -- which is usually the case with the built-in keyboard and a steno keyboard)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
