### PR TITLE
switch distributions to Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
     # Linux / Python 3
     - os: linux
       language: python
-      python: "3.6"
+      python: "3.7"
       dist: xenial
       sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
 
 cache:

--- a/ci/circle.sh
+++ b/ci/circle.sh
@@ -38,10 +38,10 @@ setup()
 {
   mkdir -p "$CIRCLE_ARTIFACTS"
   # Install Python.
-  download 'python36.pkg' 'https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.6.pkg' 'eb1a23d762946329c2aa3448d256d421'
-  run sudo installer -pkg "$downloads/python36.pkg" -target /
+  download 'python37.pkg' 'https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg' '4b544fc0ac8c3cffdb67dede23ddb79e'
+  run sudo installer -pkg "$downloads/python37.pkg" -target /
   # Update certifiates.
-  run '/Applications/Python 3.6/Install Certificates.command'
+  run '/Applications/Python 3.7/Install Certificates.command'
   # Setup development environment.
   bootstrap_dev --user
 }

--- a/linux/packpack.sh
+++ b/linux/packpack.sh
@@ -32,7 +32,7 @@ REPO='plover/packpack'
 case "$1" in
   appimage)
     OS='appimage'
-    DIST='xenial'
+    DIST='xenial-py37'
     EXT='AppImage'
     TARGET="appimage"
     ;;

--- a/news.d/feature/1170.linux.rst
+++ b/news.d/feature/1170.linux.rst
@@ -1,0 +1,1 @@
+The distribution now uses Python 3.7.9.

--- a/news.d/feature/1170.osx.rst
+++ b/news.d/feature/1170.osx.rst
@@ -1,0 +1,1 @@
+The distribution now uses Python 3.7.9.

--- a/news.d/feature/1170.windows.rst
+++ b/news.d/feature/1170.windows.rst
@@ -1,0 +1,1 @@
+The distribution now uses Python 3.7.9.

--- a/osx/app_resources/Info.plist
+++ b/osx/app_resources/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Plover</string>
+	<key>CFBundleExecutable</key>
+	<string>MacOS/Plover</string>
+	<key>CFBundleIconFile</key>
+	<string>plover.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.openstenoproject.plover</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Plover</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$version</string>
+	<key>CFBundleVersion</key>
+	<string>$version</string>
+	<key>NSAppSleepDisabled</key>
+	<true/>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Plover needs to control system events in order to raise and lower dialogs over other windows.</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>© $year, Open Steno Project</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/osx/app_resources/dist_blacklist.txt
+++ b/osx/app_resources/dist_blacklist.txt
@@ -1,11 +1,18 @@
 # Python.
-:Versions/$python_version
-  bin
+:
+  _CodeSignature
   share
-  bin
-  Resources
-  lib/pkgconfig
-:Versions/$python_version/lib/$target_python
+  Resources/English.lproj
+:bin
+  !python
+  *
+:lib
+  **/*.tcl
+  itcl*
+  pkgconfig
+  tcl*
+  [Tt]k*
+:lib/python$python_base_version
   pkgconfig
   tkinter
   idlelib
@@ -15,7 +22,7 @@
   **/*.exe
   */test*
 # PyQt5.
-:Versions/$python_version/lib/$target_python/site-packages/PyQt5
+:lib/python$python_base_version/site-packages/PyQt5
   **/*AxContainer*
   **/*Bluetooth*
   **/*CLucene*
@@ -51,7 +58,7 @@
   pyrcc*
   uic
 # Plover.
-:Versions/$python_version/lib/$target_python/site-packages/plover
+:lib/python$python_base_version/site-packages/plover
   gui_qt/*.ui
   gui_qt/messages/**/*.po
   gui_qt/messages/plover.pot

--- a/osx/app_resources/plover_launcher.c
+++ b/osx/app_resources/plover_launcher.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
     // Get path to the Python interpreter.
     snprintf(
       python_path, sizeof (python_path),
-      "%s/Frameworks/pythonexecutable",
+      "%s/Python.framework/Versions/Current/bin/python",
       app_dir
     );
 

--- a/osx/app_resources/sitecustomize.py
+++ b/osx/app_resources/sitecustomize.py
@@ -1,4 +1,0 @@
-import os
-import site
-
-site.addsitedir(os.path.join(os.path.dirname(__file__), 'site-packages'))

--- a/osx/make_app.sh
+++ b/osx/make_app.sh
@@ -1,125 +1,72 @@
 #!/usr/bin/env bash
 
-# Usage: ./setup.py bdist_app
-# $1: wheel name
-# $2: package name
 set -e
 
 . ./plover_build_utils/functions.sh
 
+topdir="$PWD"
+builddir="$topdir/build/osxapp"
+appdir="$builddir/Plover.app"
+distdir="$topdir/dist/Plover.app"
 python='python3'
-osx_dir="$(dirname "$0")"
-plover_dir="$(dirname "$osx_dir")"
 plover_wheel="$1"
-PACKAGE="$2"
 
-echo "Making Plover.app with Plover wheel $plover_wheel"
+echo "Making Plover.app with Plover wheel $plover_wheel."
 
-# Get Plover's version
-plover_version="$("$python" -c "from plover import __version__; print(__version__)")"
+run rm -rf "$builddir" "$distdir"
+run mkdir -p "$appdir"
 
-# Find system Python
-python3_bin_dir="$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.executable)))')"
-python3_dir="$(dirname "$python3_bin_dir")"
-py_version="$(basename "$python3_dir")" # e.g. 3.6
-echo "System python3 is found at: $python3_dir"
+# Make skeleton.
+frameworks_dir="$appdir/Contents/Frameworks"
+resources_dir="$appdir/Contents/Resources"
+macos_dir="$appdir/Contents/MacOS"
+run mkdir -p "$frameworks_dir" "$resources_dir" "$macos_dir"
 
-# App to build
-app_dir="$plover_dir/build/$PACKAGE.app"
-app_dist_dir="$plover_dir/dist/Plover.app"
-
-rm -rf "$app_dir"{,.fat} "$app_dist_dir"
-
-# E.g. python3.6 (name of python executable)
-target_python="python${py_version}"
-# Main library folder in App
-target_dir="$app_dir/Contents/Frameworks"
-
-# Make skeleton
-mkdir -p "$target_dir"
-mkdir "$app_dir/Contents/MacOS"
-mkdir "$app_dir/Contents/Resources"
-
-# Copy Python launcher
-cp "$python3_dir/Resources/Python.app/Contents/MacOS/Python" "$target_dir/${target_python}"
-
-# Copy over system dependencies for Python
-"$python" -m macholib standalone "$app_dir"
-
-# Make site-packages local
-python_home="$target_dir/Python.framework/Versions/$py_version/"
-# We want pip to install packages to $target_libs
-target_libs="$python_home/lib/$target_python"
-# Delete system site-packages
-rm -rf "$target_libs/site-packages"
-mkdir "$target_libs/site-packages"
-# Add sitecustomize.py -- adds the above site-packages to our Python's sys.path
-cp "$plover_dir/osx/app_resources/sitecustomize.py" "$target_libs/sitecustomize.py"
+# Add Python framework.
+py_reloc_version='f4c4110f36ac1cb60b8253c2e04eaf34804f7303'
+py_home="$frameworks_dir/Python.framework/Versions/Current"
+run_eval "$("$python" -c 'print("py_base_version={0}.{1}; py_version={0}.{1}.{2}".format(*__import__("sys").version_info[:3]))')"
+run "$python" -m plover_build_utils.download "https://github.com/gregneagle/relocatable-python/archive/$py_reloc_version.zip" 'cc5078733760dfa747ea24bd4b36a62f9d0f0b7e'
+run rm -rf "build/relocatable-python-$py_reloc_version"
+run unzip -d build "$downloads/f4c4110f36ac1cb60b8253c2e04eaf34804f7303.zip"
+run "$python" "build/relocatable-python-$py_reloc_version/make_relocatable_python_framework.py" --python-version="$py_version" --no-unsign --pip-requirements=/dev/null --destination="$frameworks_dir"
+run mv "$py_home/bin"/{"python$py_base_version",python}
+run ln -s "../../lib/python$py_base_version/site-packages/certifi/cacert.pem" "$py_home/etc/openssl/cert.pem"
 
 # Switch to target Python.
-python="$PWD/$target_dir/$target_python"
-unset __PYVENV_LAUNCHER__
-
-run_eval "
-appdir_python()
-{
-  env \
-    PYTHONNOUSERSITE=1 \
-    "$PWD/$target_dir/$target_python" \"\$@\"
-}
-"
+run_eval "appdir_python() { env PYTHONNOUSERSITE=1 "$py_home/bin/python" \"\$@\"; }"
 python='appdir_python'
+unset __PYVENV_LAUNCHER__
 
 # Install Plover and dependencies.
 bootstrap_dist "$plover_wheel"
 
-# Make launcher
-plover_executable=MacOS/Plover
-launcher_file="$app_dir/Contents/$plover_executable"
-sed "s/pythonexecutable/$target_python/g" "$osx_dir/app_resources/plover_launcher.c" > "$launcher_file.c"
-gcc -Wall -O2 "$launcher_file.c" -o "$launcher_file"
-rm "$launcher_file.c"
+# Create launcher.
+run gcc -Wall -O2 'osx/app_resources/plover_launcher.c' -o "$macos_dir/Plover"
 
-# Copy icon
-cp "$osx_dir/app_resources/plover.icns" "$app_dir/Contents/Resources/plover.icns"
+# Copy icon.
+run cp 'osx/app_resources/plover.icns' "$resources_dir/plover.icns"
 
-# This allows notifications from our Python binary to identify as from Plover...
-/usr/libexec/PlistBuddy -c 'Add :CFBundleIdentifier string "org.openstenoproject.plover"' "$app_dir/Contents/Frameworks/Info.plist"
+# Get Plover's version.
+plover_version="$("$python" -c 'print(__import__("plover").__version__)')"
 
-# Setup PList for Plover
-/usr/libexec/PlistBuddy -c 'Add :CFBundleDevelopmentRegion string "en"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :CFBundleIconFile string "plover.icns"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :CFBundleIdentifier string "org.openstenoproject.plover"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :CFBundleName string "Plover"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :CFBundleDisplayName string "Plover"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string \"$plover_executable\"" "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :CFBundlePackageType string "APPL"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string \"$plover_version\"" "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Add :CFBundleVersion string \"$plover_version\"" "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :CFBundleInfoDictionaryVersion string "6.0"' "$app_dir/Contents/Info.plist"
-year=$(date '+%Y')
-copyright="© $year, Open Steno Project"
-/usr/libexec/PlistBuddy -c 'Add :NSAppleEventsUsageDescription string "Plover needs to control system events in order to raise and lower dialogs over other windows."' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Add :NSHumanReadableCopyright string \"$copyright\"" "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :NSPrincipalClass string "NSApplication"' "$app_dir/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c 'Add :NSAppSleepDisabled bool true' "$app_dir/Contents/Info.plist"
+# Setup PList for Plover.
+run cp 'osx/app_resources/Info.plist' "$appdir/Contents/Info.plist"
+run sed -e "s/\$version/$plover_version/" -e "s/\$year/$(date '+%Y')/" -i '' "$appdir/Contents/Info.plist"
 
+# Trim superfluous content.
+run cp osx/app_resources/dist_blacklist.txt "$builddir/dist_blacklist.txt"
+run sed -e "s/\$python_version/$py_version/" -e "s/\$python_base_version/$py_base_version/" -i '' "$builddir/dist_blacklist.txt"
+run "$python" -m plover_build_utils.trim "$py_home" "$builddir/dist_blacklist.txt"
 
-# Remove broken symlinks
-rm "$target_dir/Python.framework/Headers"
-rm "$target_dir/Python.framework/Python"
-rm "$target_dir/Python.framework/Resources"
-# Trim superfluous content from app
-sed -e "s/\$python_version/$py_version/" -e "s/\$target_python/$target_python/" osx/app_resources/dist_blacklist.txt > build/dist_blacklist.txt
-"$python" -m plover_build_utils.trim "$target_dir/Python.framework" build/dist_blacklist.txt
-# Make distribution source-less
-"$python" -m plover_build_utils.source_less "$target_libs" "*/pip/_vendor/distlib/*"
+# Make distribution source-less.
+run "$python" -m plover_build_utils.source_less "$py_home/lib" "*/pip/_vendor/distlib/*"
 
 # Strip 32-bit support
-mv "$app_dir"{,.fat}
-ditto -v --arch x86_64 "$app_dir"{.fat,}
+run mv "$appdir"{,.fat}
+run ditto -v --arch x86_64 "$appdir"{.fat,}
 
 # Check requirements.
 run "$python" -I -m plover_build_utils.check_requirements
 
-mv "$app_dir" "$app_dist_dir"
+run mv "$appdir" "$distdir"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Babel==2.7.0
 check-manifest==0.41
 Cython==0.29.16
 dmgbuild==1.4.2; "darwin" in sys_platform
-macholib==1.14; "darwin" in sys_platform
 pip==20.0.2
 pytest==5.4.1
 readme-renderer[md]==25.0

--- a/setup.py
+++ b/setup.py
@@ -305,7 +305,7 @@ class BinaryDistApp(Command):
         pass
 
     def run(self):
-        cmd = 'bash osx/make_app.sh %s %s' % (self.bdist_wheel(), PACKAGE)
+        cmd = 'bash osx/make_app.sh %s' % self.bdist_wheel()
         log.info('running %s', ' '.join(cmd))
         subprocess.check_call(cmd.split())
 

--- a/setup.py
+++ b/setup.py
@@ -90,14 +90,14 @@ class BinaryDistWin(Command):
         # First things first: create Plover wheel.
         plover_wheel = self.bdist_wheel()
         # Setup embedded Python distribution.
-        # Note: python36.zip is decompressed to prevent errors when 2to3
+        # Note: python37.zip is decompressed to prevent errors when 2to3
         # is used (including indirectly by setuptools `build_py` command).
-        py_embedded = download('https://www.python.org/ftp/python/3.6.8/python-3.6.8-embed-amd64.zip',
-                               'f9d16a818e06ce2552076a9839039dbabb8baf1c')
+        py_embedded = download('https://www.python.org/ftp/python/3.7.9/python-3.7.9-embed-amd64.zip',
+                               '50b144212d4972bb539d0d48b49b0ad4ad2f65e0')
         dist_dir = os.path.join(os.path.dirname(plover_wheel), PACKAGE + '-win64')
         dist_data = os.path.join(dist_dir, 'data')
         dist_py = os.path.join(dist_data, 'python.exe')
-        dist_stdlib = os.path.join(dist_data, 'python36.zip')
+        dist_stdlib = os.path.join(dist_data, 'python37.zip')
         if os.path.exists(dist_dir):
             shutil.rmtree(dist_dir)
         os.makedirs(dist_data)
@@ -110,7 +110,7 @@ class BinaryDistWin(Command):
         # directory and for the current directory to be prepended
         # to `sys.path` so `plover_build_utils` can be used and
         # plugins can be installed from source.
-        dist_pth = os.path.join(dist_data, 'python36._pth')
+        dist_pth = os.path.join(dist_data, 'python37._pth')
         with open(dist_pth, 'r+') as fp:
             pth = fp.read() + 'import site\n'
             fp.seek(0)
@@ -125,8 +125,8 @@ class BinaryDistWin(Command):
                 '''
             ).lstrip())
         # Use standard site.py so user site packages are enabled.
-        site_py = download('https://github.com/python/cpython/raw/v3.6.8/Lib/site.py',
-                           '46d88612c34b1ed0098f1fbf655454b46afde049')
+        site_py = download('https://github.com/python/cpython/raw/v3.7.9/Lib/site.py',
+                           '33326741fe4ae2e3220969f753a6e5e44f415cf5')
         shutil.copyfile(site_py, os.path.join(dist_site_packages, 'site.py'))
         # Run command helper.
         def run(*args):

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -267,7 +267,7 @@ class Helper:
             if not name.startswith('cmd_'):
                 continue
             cmd = getattr(self, name)
-            argspec = inspect.getargspec(cmd)
+            argspec = inspect.getfullargspec(cmd)
             name = name[4:]
             doc = cmd.__doc__.strip().split('\n')
             help = doc[0]
@@ -516,7 +516,7 @@ class Helper:
             if not name.startswith('_')
         }
         cmd = getattr(self, 'cmd_%s' % opts._command)
-        argspec = inspect.getargspec(cmd)
+        argspec = inspect.getfullargspec(cmd)
         args = []
         assert 'self' == argspec.args[0]
         for a in argspec.args[1:]:

--- a/windows/helper.py
+++ b/windows/helper.py
@@ -130,8 +130,7 @@ class WineEnvironment(Environment):
             info('intializing Wine prefix')
             for cmd in (
                 'env DISPLAY= wineboot --init',
-                # Wait for previous command to finish.
-                'wineserver -w',
+                'wineserver -k',
                 'winetricks --no-isolate --unattended corefonts',
                 'winetricks win7',
             ):
@@ -543,8 +542,8 @@ class Helper:
 class WineHelper(Helper):
 
     DEPENDENCIES = (
-        ('Python', 'https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe',
-         '0c80bc4e3ea98e1415264b29f3290fb7195a8bc3', None, ('PrependPath=1', '/S'), None),
+        ('Python', 'https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe',
+         'f8d42a421db25a01b53f0c135a9a74ddae042643', None, ('PrependPath=1', '/S'), None),
     ) + Helper.DEPENDENCIES
 
     def __init__(self):


### PR DESCRIPTION
## Summary of changes

Updating the Linux and Windows versions was easy, but I ran into a snag with the macOS version: after the upgrade to Python 3.7, `python -m macholib standalone` does not create a working standalone version anymore; the system prefixes are not correctly set (still pointing to the original source version of Python), tripping `plover_build_utils.check_requirements`.

I ended up switching to [this script](https://github.com/gregneagle/relocatable-python) for creating a relocatable Python directly from one of the official installer package.

Hopefully someone with access to a mac can check the final result does indeed work.

### Pull Request Checklist
- [x] News fragment added in news.d.
