### PR TITLE
Fix wrong assertion to allow enabling/disabling extension plugins not on the first row

### DIFF
--- a/news.d/bugfix/1171.ui.rst
+++ b/news.d/bugfix/1171.ui.rst
@@ -1,0 +1,1 @@
+Fix an exception caused by an incorrect assertion that would prevent enabling and disabling extension plugins if they weren't on the first row.

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -226,7 +226,7 @@ class MultipleChoicesOption(QTableWidget):
     def _on_cell_changed(self, row, column):
         if self._updating:
             return
-        assert (row, column) == (0, 1)
+        assert column == 1
         choice = self._reversed_choices[self.item(row, 0).data(Qt.DisplayRole)]
         if self.item(row, 1).checkState():
             self._value.add(choice)


### PR DESCRIPTION
## Summary of changes

(see title.)

The bug only occur if the user installs more than one plugin and tries to enable/disable the one not on the first row.

### Pull Request Checklist
- [ ] Changes have tests (*This is a GUI change, and I don't think it's possible to test GUI with the current framework.*)
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details
