### PR TITLE
Fix memory leak caused by defaultdict access in suggestions feature

### DIFF
--- a/news.d/bugfix/1188.core.md
+++ b/news.d/bugfix/1188.core.md
@@ -1,0 +1,1 @@
+Fix unbounded memory use in the lookup functions used by the Suggestions window.

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -157,10 +157,10 @@ class StenoDictionary:
         return self.get(key) is not None
 
     def reverse_lookup(self, value):
-        return set(self.reverse[value])
+        return set(self.reverse.get(value, ()))
 
     def casereverse_lookup(self, value):
-        return set(self.casereverse[value])
+        return set(self.casereverse.get(value, ()))
 
     @property
     def _longest_key(self):


### PR DESCRIPTION
## Summary of changes

Fixes a memory leak in the suggestions feature.

The leak only become apparent to me when I use the new console GUI. (normally I never use the suggestions window)

Remark: when I use the console GUI, I occasionally get a hang too. I guess it's caused by either dict rehash or garbage collection.

### Pull Request Checklist
- [ ] Changes have tests -> Will have later. Idea: count the number of items in the dicts after an nonexistent reverse lookup.
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.rst#making-a-pull-request) for details -> TODO
