### PR TITLE
setup: update `python-xlib` requirement

### DIFF
--- a/requirements_distribution.txt
+++ b/requirements_distribution.txt
@@ -9,7 +9,7 @@ pyobjc-framework-Quartz==6.2; "darwin" in sys_platform
 PyQt5-sip==12.7.2
 PyQt5==5.14.2
 pyserial==3.4
-python-xlib==0.26; "linux" in sys_platform
+python-xlib==0.29; "linux" in sys_platform
 six==1.14.0
 wcwidth==0.1.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,8 @@ install_requires =
 	pyobjc-framework-Cocoa>=4.0; "darwin" in sys_platform
 	pyobjc-framework-Quartz>=4.0; "darwin" in sys_platform
 	pyserial>=2.7
-	python-xlib>=0.16; "linux" in sys_platform
+	python-xlib>=0.16; "linux" in sys_platform and python_version < "3.9"
+	python-xlib>=0.29; "linux" in sys_platform and python_version >= "3.9"
 	setuptools
 	wcwidth
 packages =


### PR DESCRIPTION
For proper Python 3.9 support.

(Yes, I got the branch name wrong ¯\\_(ツ)_/¯).