### PR TITLE
switch distributions to Python 3.8 and update requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.6' 'ubuntu-16.04'
+        run: setup_cache_name '3.8' 'ubuntu-16.04'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.6' 'macos-10.15'
+        run: setup_cache_name '3.8' 'macos-10.15'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -84,7 +84,7 @@ jobs:
 
       # To support older macOS versions, setup Python from an official installer.
       - name: Setup Python
-        run: setup_osx_python '3.6'
+        run: setup_osx_python '3.8'
 
       - name: Setup Python environment
         run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/test.txt
@@ -114,11 +114,54 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
+          python-version: 3.8
+
+      - name: Set cache name
+        id: set_cache
+        run: setup_cache_name '3.8' 'windows-2019'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: .cache
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
+
+      - name: Setup pip options
+        run: setup_pip_options
+
+      - name: Setup Python environment
+        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/test.txt
+      # Test {{{
+
+      - name: Run tests
+        run: run_tests
+
+      # }}}
+
+      - name: List cache contents
+        run: list_cache
+  # }}}
+
+  # Job: Test (Python 3.6) {{{
+  test_python_36:
+
+    name: Test (Python 3.6)
+    runs-on: ubuntu-latest
+    needs: []
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
           python-version: 3.6
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.6' 'windows-2019'
+        run: setup_cache_name '3.6' 'ubuntu-latest'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -162,49 +205,6 @@ jobs:
       - name: Set cache name
         id: set_cache
         run: setup_cache_name '3.7' 'ubuntu-latest'
-
-      - name: Setup cache
-        uses: actions/cache@v2
-        with:
-          path: .cache
-          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
-
-      - name: Setup pip options
-        run: setup_pip_options
-
-      - name: Setup Python environment
-        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/test.txt
-      # Test {{{
-
-      - name: Run tests
-        run: run_tests
-
-      # }}}
-
-      - name: List cache contents
-        run: list_cache
-  # }}}
-
-  # Job: Test (Python 3.8) {{{
-  test_python_38:
-
-    name: Test (Python 3.8)
-    runs-on: ubuntu-latest
-    needs: []
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Set cache name
-        id: set_cache
-        run: setup_cache_name '3.8' 'ubuntu-latest'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -352,11 +352,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.6' 'ubuntu-16.04'
+        run: setup_cache_name '3.8' 'ubuntu-16.04'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -409,7 +409,7 @@ jobs:
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.6' 'macos-10.15'
+        run: setup_cache_name '3.8' 'macos-10.15'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -422,7 +422,7 @@ jobs:
 
       # To support older macOS versions, setup Python from an official installer.
       - name: Setup Python
-        run: setup_osx_python '3.6'
+        run: setup_osx_python '3.8'
 
       - name: Setup Python environment
         run: setup_python_env -c reqs/constraints.txt -r reqs/build.txt -r reqs/setup.txt
@@ -464,11 +464,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.6' 'windows-2019'
+        run: setup_cache_name '3.8' 'windows-2019'
 
       - name: Setup cache
         uses: actions/cache@v2
@@ -516,7 +516,7 @@ jobs:
     name: Release
     environment: release
     runs-on: ubuntu-latest
-    needs: [test_linux, test_macos, test_windows, test_python_37, test_python_38, test_python_39, test_packaging, build_linux, build_macos, build_windows]
+    needs: [test_linux, test_macos, test_windows, test_python_36, test_python_37, test_python_39, test_packaging, build_linux, build_macos, build_windows]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     steps:

--- a/.github/workflows/ci/workflow_context.yml
+++ b/.github/workflows/ci/workflow_context.yml
@@ -11,19 +11,19 @@ action_download_artifact: actions/download-artifact@v2
 vars:
   - &dist_linux
     variant: Linux
-    python: '3.6'
+    python: '3.8'
     os: Linux
     platform: ubuntu-16.04
 
   - &dist_macos
     variant: macOS
-    python: '3.6'
+    python: '3.8'
     os: macOS
     platform: macos-10.15
 
   - &dist_win
     variant: Windows
-    python: '3.6'
+    python: '3.8'
     os: Windows
     platform: windows-2019
 
@@ -48,11 +48,11 @@ jobs:
   - &python_test
     <<: *test
     <<: *dist_other
+    variant: Python 3.6
+    python: '3.6'
+  - <<: *python_test
     variant: Python 3.7
     python: '3.7'
-  - <<: *python_test
-    variant: Python 3.8
-    python: '3.8'
   - <<: *python_test
     variant: Python 3.9
     python: '3.9'

--- a/osx/deps.sh
+++ b/osx/deps.sh
@@ -1,5 +1,5 @@
-py_installer_version="3.6.8"
-py_installer_macos="10.6"
-py_installer_sha1="269ef6a91949455b9c98b08f6e84bb933026f1c5"
-reloc_py_url='https://github.com/gregneagle/relocatable-python/archive/f4c4110f36ac1cb60b8253c2e04eaf34804f7303.zip'
-reloc_py_sha1='cc5078733760dfa747ea24bd4b36a62f9d0f0b7e'
+py_installer_version="3.8.8"
+py_installer_macos="10.9"
+py_installer_sha1="04d5f5b48ba232f5b98c534200962dd736109cc3"
+reloc_py_url='https://github.com/benoit-pierre/relocatable-python/archive/35dc4a641e28eeacb709c015540c85749af9cd8d.zip'
+reloc_py_sha1='2191ea43d3e2e6535ccd2c64b32f241bd8f9f4a4'

--- a/plover/main.py
+++ b/plover/main.py
@@ -61,6 +61,10 @@ def main():
     log.info('Plover %s', __version__)
     log.info('configuration directory: %s', CONFIG_DIR)
 
+    if sys.platform == 'darwin':
+        # Fixes PyQt issue on macOS Big Sur.
+        os.environ['QT_MAC_WANTS_LAYER'] = '1'
+
     registry.update()
 
     if args.gui is None:

--- a/plover_build_utils/functions.sh
+++ b/plover_build_utils/functions.sh
@@ -174,8 +174,8 @@ osx_standalone_python()
   run "$python" "$reloc_py_dir/make_relocatable_python_framework.py" \
     --baseurl="file://$PWD/$downloads_cache/%s/../python-%s-macosx%s.pkg" \
     --python-version="$py_version" --os-version="$py_macos" \
-    --pip-requirements=/dev/null \
     --destination="$dest" \
+    --without-pip \
     ;
   run ln -s 'python3' "$py_framework_dir/Versions/Current/bin/python"
   run rm -rf "$reloc_py_dir"

--- a/plover_build_utils/get_pip.py
+++ b/plover_build_utils/get_pip.py
@@ -9,8 +9,8 @@ from .download import download
 from .install_wheels import WHEELS_CACHE, install_wheels
 
 
-PIP_VERSION = '20.0.2'
-PIP_WHEEL_URL = 'https://files.pythonhosted.org/packages/54/0c/d01aa759fdc501a58f431eb594a17495f15b88da142ce14b5845662c13f3/pip-20.0.2-py2.py3-none-any.whl'
+PIP_VERSION = '21.0.1'
+PIP_WHEEL_URL = 'https://files.pythonhosted.org/packages/fe/ef/60d7ba03b5c442309ef42e7d69959f73aacccd0d86008362a681c4698e83/pip-21.0.1-py3-none-any.whl'
 PIP_INSTALL = os.path.join('.cache', 'pip', PIP_VERSION)
 
 

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -9,7 +9,7 @@ chardet==3.0.4
 check-manifest==0.41
 click==7.1.2
 click-default-group==1.2.2
-cmarkgfm==0.4.2
+cmarkgfm==0.5.3
 colorama==0.4.4
 cryptography==3.4.7; "linux" in sys_platform
 dbus-python==1.2.16; "linux" in sys_platform

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -1,12 +1,13 @@
-appdirs==1.4.3
-appnope==0.1.0; "darwin" in sys_platform
+appdirs==1.4.4
+appnope==0.1.2; "darwin" in sys_platform
 attrs==20.3.0
-Babel==2.7.0
-bleach==3.1.4
-certifi==2019.11.28
-cffi==1.14.0
+Babel==2.9.0
+bleach==3.3.0
+build==0.3.1.post1
+certifi==2020.12.5
+cffi==1.14.5
 chardet==3.0.4
-check-manifest==0.41
+check-manifest==0.46
 click==7.1.2
 click-default-group==1.2.2
 cmarkgfm==0.5.3
@@ -16,10 +17,11 @@ dbus-python==1.2.16; "linux" in sys_platform
 dmgbuild==1.4.2; "darwin" in sys_platform
 docutils==0.16
 ds_store==1.3.0; "darwin" in sys_platform
-hidapi==0.9.0.post2
+hidapi==0.10.0.post1
 idna==2.10
 importlib-metadata==3.10.0
 incremental==21.3.0
+iniconfig==1.1.1
 jeepney==0.6.0; "linux" in sys_platform
 Jinja2==2.11.3
 keyring==23.0.1
@@ -28,43 +30,43 @@ MarkupSafe==1.1.1
 more-itertools==8.7.0
 packaging==20.9
 pep517==0.10.0
-pip==20.0.2
-pkginfo==1.5.0.1
-plover-plugins-manager==0.5.15
+pip==21.0.1
+pkginfo==1.7.0
+plover-plugins-manager==0.5.16
 plover-treal==1.0.1
 pluggy==0.13.1
-plyer==1.4.3; "win32" in sys_platform
+plyer==2.0.0; "win32" in sys_platform
 py==1.10.0
 pycparser==2.20
-Pygments==2.6.1
-pyobjc-core==6.2; "darwin" in sys_platform
-pyobjc-framework-Cocoa==6.2; "darwin" in sys_platform
-pyobjc-framework-Quartz==6.2; "darwin" in sys_platform
+Pygments==2.8.1
+pyobjc-core==7.1; "darwin" in sys_platform
+pyobjc-framework-Cocoa==7.1; "darwin" in sys_platform
+pyobjc-framework-Quartz==7.1; "darwin" in sys_platform
 pyparsing==2.4.7
-PyQt5==5.14.2
-PyQt5-sip==12.7.2
-pyserial==3.4
-pytest==5.4.1
+PyQt5==5.15.0
+PyQt5-sip==12.8.1
+pyserial==3.5
+pytest==6.2.2
 python-xlib==0.29; "linux" in sys_platform
 pytz==2021.1
-readme-renderer==25.0
-requests==2.23.0
+readme-renderer==29.0
+requests==2.25.1
 requests-cache==0.5.2
 requests-futures==1.0.0
 requests-toolbelt==0.9.1
 rfc3986==1.4.0
 SecretStorage==3.3.1; "linux" in sys_platform
-setuptools==46.1.3
-setuptools-scm==3.5.0
-six==1.14.0
+setuptools==54.2.0
+setuptools-scm==6.0.1
+six==1.15.0
 toml==0.10.2
 towncrier==21.3.0rc1
 tqdm==4.59.0
 twine==3.4.1
-urllib3==1.25.11
-wcwidth==0.1.9
+urllib3==1.26.4
+wcwidth==0.2.5
 webencodings==0.5.1
-wheel==0.34.2
+wheel==0.36.2
 zipp==3.4.1
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ classifiers =
         Programming Language :: Python :: 3
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
         License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
         Development Status :: 5 - Production/Stable
         Environment :: X11 Applications

--- a/windows/dist_deps.sh
+++ b/windows/dist_deps.sh
@@ -1,2 +1,2 @@
-py_embed_version='3.6.8'
-py_embed_sha1='f9d16a818e06ce2552076a9839039dbabb8baf1c'
+py_embed_version='3.8.8'
+py_embed_sha1='678fcb3e998437ffbe7473a824632a7b34cefd03'


### PR DESCRIPTION
Note: I updated `hidapi` to `0.10.0.post1` and not `0.10.1` because the later breaks the AppImage build (it looks like linuxdeploy does not like the `manylinux2014` wheel).
