### PR TITLE
target macOS 10.13 (High Sierra) or later

### DIFF
--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -64,8 +64,8 @@ setup_osx_python()
   fi
   # Update PATH.
   run_eval "echo \"\$PWD/$python_dir/Python.framework/Versions/Current/bin\" >>\$GITHUB_PATH"
-  # Target Mavericks.
-  run_eval "echo MACOSX_DEPLOYMENT_TARGET=10.9 >>\$GITHUB_ENV"
+  # Target High Sierra.
+  run_eval "echo MACOSX_DEPLOYMENT_TARGET=10.13 >>\$GITHUB_ENV"
   # Fix SSL certificates so plover_build_utils.download works.
   SSL_CERT_FILE="$("$python" -m pip._vendor.certifi)" || die
   run_eval "echo SSL_CERT_FILE='$SSL_CERT_FILE' >>\$GITHUB_ENV"

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -43,7 +43,7 @@ pyobjc-core==7.1; "darwin" in sys_platform
 pyobjc-framework-Cocoa==7.1; "darwin" in sys_platform
 pyobjc-framework-Quartz==7.1; "darwin" in sys_platform
 pyparsing==2.4.7
-PyQt5==5.15.0
+PyQt5==5.15.4
 PyQt5-sip==12.8.1
 pyserial==3.5
 pytest==6.2.2


### PR DESCRIPTION
Let's not pretend we support older versions, like PyQt5 does... and we might as well update to the latest version of PyQt5.