### PR TITLE
setup: add target platform to macOS DMG filename

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,8 +219,11 @@ class BinaryDistDmg(Command):
 
     def run(self):
         self.run_command('bdist_app')
+        # Encode targeted macOS plaftorm in the filename.
+        from wheel.bdist_wheel import get_platform
+        platform = get_platform('dist/Plover.app')
         args = '{out!r}, {name!r}, {settings!r}, lookForHiDPI=True'.format(
-            out='dist/%s.dmg' % PACKAGE,
+            out='dist/%s-%s.dmg' % (PACKAGE, platform),
             name=__software_name__.capitalize(),
             settings='osx/dmg_resources/settings.py',
         )


### PR DESCRIPTION
=> `plover-4.0.0.dev8+344.gfdf0c01-macosx-10.13-x86_64.dmg`

This should make the minimum supported macOS release and supported architecture clearer.