### PR TITLE
gui_qt/dictionary_editor: improve updating a translation

### DIFF
--- a/news.d/bugfix/1219.ui.md
+++ b/news.d/bugfix/1219.ui.md
@@ -1,0 +1,1 @@
+Improve updating a translation in the dictionary editor: don't delete the key first, so extra metadata (e.g. additional columns in an Excel dictionary) is not deleted.

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -224,10 +224,11 @@ class DictionaryItemModel(QAbstractTableModel):
                     break
             if dictionary == old_item.dictionary:
                 return False
-        try:
-            del old_item.dictionary[old_item.strokes]
-        except KeyError:
-            pass
+        if (old_item.dictionary, old_item.strokes) != (dictionary, strokes):
+            try:
+                del old_item.dictionary[old_item.strokes]
+            except KeyError:
+                pass
         if not old_item.strokes and not old_item.translation:
             # Merge operations when editing a newly added row.
             if self._operations and self._operations[-1] == [(None, old_item)]:


### PR DESCRIPTION
Don't delete the key first, so extra metadata (e.g. additional columns in an Excel dictionary) is not deleted.