### PR TITLE
Fix duplicate Ctrl+N shortcut on main window

### DIFF
--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -13,7 +13,6 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
     TITLE = _('Add Translation')
     ICON = ':/translation_add.svg'
     ROLE = 'add_translation'
-    SHORTCUT = 'Ctrl+N'
 
     def __init__(self, engine, dictionary_path=None):
         super().__init__(engine)


### PR DESCRIPTION
## Summary of changes

Initially, there are two buttons with shortcut control+N on the main window -- the add translation button on the toolbar, and the one in the dictionary editor (which adds the translation on the **selected** dictionary; if there's no selected dictionary it has the same behavior as the other button.

I think that's more useful, so I remove the shortcut for the button; otherwise to remove the other shortcut do this

```diff
--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -143,9 +143,6 @@
    <property name="toolTip">
     <string>Add a new translation</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+N</string>
-   </property>
   </action>
   <action name="action_MoveDictionariesUp">
    <property name="icon">
```


Closes #1215 .

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
