### PR TITLE
gui_qt/config: fix configuring extension plugins

### DIFF
--- a/news.d/bugfix/1230.ui.md
+++ b/news.d/bugfix/1230.ui.md
@@ -1,0 +1,1 @@
+Fix changes to the list of enabled extension plugins not being saved to the configuration file.

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -207,6 +207,9 @@ class MultipleChoicesOption(QTableWidget):
         self.setRowCount(0)
         if value is None:
             value = set()
+        else:
+            # Don't mutate the original value.
+            value = set(value)
         self._value = value
         row = -1
         for choice in sorted(self._reversed_choices):


### PR DESCRIPTION
## Summary of changes

Don't mutate the original configuration set, or changes won't be saved.

Closes #1180.

### Pull Request Checklist
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
