### PR TITLE
Improve pep517 support and packaging checks

### DIFF
--- a/plover_build_utils/functions.sh
+++ b/plover_build_utils/functions.sh
@@ -183,16 +183,12 @@ osx_standalone_python()
 
 packaging_checks()
 {
-  # setup check
-  run "$python" setup.py -q check -m -s
   run rm -rf dist
-  run "$python" -m pip --disable-pip-version-check wheel -w dist --no-deps .
-  run "$python" -m twine check --strict dist/*.whl
-  # sdist bdist_wheel check
-  run rm -rf dist
-  run "$python" setup.py -q sdist bdist_wheel
+  # Check PEP 517/518 support.
+  run "$python" -m build --sdist --wheel .
+  # Validate distributions.
   run "$python" -m twine check --strict dist/*
-  # manifest check
+  # Check manifest.
   run "$python" -m check_manifest -v
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
 	"setuptools>=38.2.4",
 	"wheel",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
 package = "plover"

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -57,7 +57,6 @@ requests-toolbelt==0.9.1
 rfc3986==1.4.0
 SecretStorage==3.3.1; "linux" in sys_platform
 setuptools==54.2.0
-setuptools-scm==6.0.1
 six==1.15.0
 toml==0.10.2
 towncrier==21.3.0rc1

--- a/reqs/packaging.txt
+++ b/reqs/packaging.txt
@@ -1,6 +1,6 @@
+build
 check-manifest
 readme-renderer[md]
-setuptools-scm
 twine
 
 # vim: ft=cfg commentstring=#\ %s list


### PR DESCRIPTION
Explicitly set the build-backend, so we don't use the legacy setuptools' backend, and more tools (e.g. `check-manifest`) use PEP 517 support.

Improve packaging checks:

- use `build` to check PEP 517/518 support, building sdist and wheel
- don't run `setup.py check`: `twine check` already covers everything (including checking the description if `readme-renderer` is installed)
- drop the setuptools-scm dependency (not used, by us or `check_manifest`)