### PR TITLE
Add dictionaries "save as..." support

### DIFF
--- a/news.d/feature/1244.ui.md
+++ b/news.d/feature/1244.ui.md
@@ -1,0 +1,4 @@
+Add support for saving dictionaries:
+- save a copy of each selected dictionary
+- merge the selected dictionaries into a new one
+- both operations support converting to another format

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -119,21 +119,21 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
         # Add menu.
         self.menu_AddDictionaries = QMenu(self.action_AddDictionaries.text())
         self.menu_AddDictionaries.setIcon(self.action_AddDictionaries.icon())
-        self.menu_AddDictionaries.addAction(_(
+        self.menu_AddDictionaries.addAction(
             _('Open dictionaries'),
-        )).triggered.connect(self._add_existing_dictionaries)
-        self.menu_AddDictionaries.addAction(_(
+        ).triggered.connect(self._add_existing_dictionaries)
+        self.menu_AddDictionaries.addAction(
             _('New dictionary'),
-        )).triggered.connect(self._create_new_dictionary)
+        ).triggered.connect(self._create_new_dictionary)
         # Save menu.
         self.menu_SaveDictionaries = QMenu(self.action_SaveDictionaries.text())
         self.menu_SaveDictionaries.setIcon(self.action_SaveDictionaries.icon())
-        self.menu_SaveDictionaries.addAction(_(
+        self.menu_SaveDictionaries.addAction(
             _('Create a copy of each dictionary'),
-        )).triggered.connect(self._save_dictionaries)
-        self.menu_SaveDictionaries.addAction(_(
+        ).triggered.connect(self._save_dictionaries)
+        self.menu_SaveDictionaries.addAction(
             _('Merge dictionaries into a new one'),
-        )).triggered.connect(functools.partial(self._save_dictionaries,
+        ).triggered.connect(functools.partial(self._save_dictionaries,
                                                merge=True))
         self.table.supportedDropActions = self._supported_drop_actions
         self.table.dragEnterEvent = self._drag_enter_event

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -22,6 +22,7 @@ from plover.config import DictionaryConfig
 from plover.dictionary.base import create_dictionary
 from plover.engine import ErroredDictionary
 from plover.misc import normalize_path
+from plover.oslayer.config import CONFIG_DIR
 from plover.registry import registry
 from plover import log
 
@@ -65,6 +66,9 @@ def _get_dictionary_save_name(parent_widget, title, default_name=None,
         default_name += '.' + next((e for e in default_extensions
                                     if e in writable_extensions),
                                    'json')
+        default_name = os.path.join(CONFIG_DIR, default_name)
+    else:
+        default_name = CONFIG_DIR
     new_filename = QFileDialog.getSaveFileName(
         parent=parent_widget, caption=title, directory=default_name,
         filter=_dictionary_filters(include_readonly=False),

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -332,15 +332,24 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
     def on_selection_changed(self):
         if self._updating:
             return
-        enabled = bool(self.table.selectedItems())
+        selection = self._get_selection()
+        has_selection = bool(selection)
         for widget in (
             self.action_RemoveDictionaries,
+            self.action_MoveDictionariesUp,
+            self.action_MoveDictionariesDown,
+        ):
+            widget.setEnabled(has_selection)
+        has_live_selection = any(
+            self._config_dictionaries[row].path in self._loaded_dictionaries
+            for row in selection
+        )
+        for widget in (
             self.action_EditDictionaries,
             self.action_SaveDictionaries,
-            self.action_MoveDictionariesDown,
             self.menu_SaveDictionaries,
         ):
-            widget.setEnabled(enabled)
+            widget.setEnabled(has_live_selection)
 
     def on_dictionary_changed(self, item):
         if self._updating:

--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -87,6 +87,21 @@
     <string>Ctrl+E</string>
    </property>
   </action>
+  <action name="action_SaveDictionaries">
+   <property name="icon">
+    <iconset resource="resources/resources.qrc">
+     <normaloff>:/save.svg</normaloff>:/save.svg</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Save dictionaries as...</string>
+   </property>
+   <property name="toolTip">
+    <string>Save the selected dictionaries: create a new copy of each dictionary, or merge them into a new dictionary.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
   <action name="action_RemoveDictionaries">
    <property name="icon">
     <iconset resource="resources/resources.qrc">

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -55,6 +55,9 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         edit_menu.addSeparator()
         edit_menu.addAction(self.dictionaries.action_MoveDictionariesUp)
         edit_menu.addAction(self.dictionaries.action_MoveDictionariesDown)
+        self.dictionaries.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.dictionaries.customContextMenuRequested.connect(
+            lambda p: edit_menu.exec_(self.dictionaries.mapToGlobal(p)))
         # Tray icon.
         self._trayicon = TrayIcon()
         self._trayicon.enable()

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -51,6 +51,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         edit_menu.addSeparator()
         edit_menu.addMenu(self.dictionaries.menu_AddDictionaries)
         edit_menu.addAction(self.dictionaries.action_EditDictionaries)
+        edit_menu.addMenu(self.dictionaries.menu_SaveDictionaries)
         edit_menu.addAction(self.dictionaries.action_RemoveDictionaries)
         edit_menu.addSeparator()
         edit_menu.addAction(self.dictionaries.action_MoveDictionariesUp)


### PR DESCRIPTION
## Summary of changes

Alternative to #1149.

See commit messages for the detail of the changes.

Rational for 8dcda12d7257432a3edfb3937521b6bbfbdc5908, and allowing to create copies when multiple dictionaries are selected: with this PR and our support for read-only `assets:` resources, I think we should consider changing the system default dictionaries definition to:
```python
DEFAULT_DICTIONARIES = (
    'user.json',
    DICTIONARIES_ROOT + '/commands.json',
    DICTIONARIES_ROOT + '/main.json',
)
```
This would result in:
- only `user.json` is (re-)created when missing
- the other 2 dictionaries are loaded read-only directly from the assets directory

This would make updating easier for users that don't change those dictionaries. And if you really want to edit those, you can always can now easily save a copy (and addressing #726 would provide an even better alternative).

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. 