### PR TITLE
setup: fix inclusion of translations

### DIFF
--- a/news.d/bugfix/1248.ui.md
+++ b/news.d/bugfix/1248.ui.md
@@ -1,0 +1,1 @@
+Fix missing translations.

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,4 +97,8 @@ plover.system =
 setuptools.installation =
 	eggsecutable = plover.main:main
 
+[options.package_data]
+plover.gui_qt =
+	messages/*/LC_MESSAGES/*.mo
+
 # vim: commentstring=#\ %s list


### PR DESCRIPTION
## Summary of changes

We don't want to include the generated catalogs in the source distribution, but we do need to include them in the wheel so they are part of the binary distributions.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
