### PR TITLE
Revert "gui_qt/dictionary_editor: improve updating a translation"

### DIFF
--- a/news.d/bugfix/1219.ui.md
+++ b/news.d/bugfix/1219.ui.md
@@ -1,1 +1,0 @@
-Improve updating a translation in the dictionary editor: don't delete the key first, so extra metadata (e.g. additional columns in an Excel dictionary) is not deleted.

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -224,11 +224,10 @@ class DictionaryItemModel(QAbstractTableModel):
                     break
             if dictionary == old_item.dictionary:
                 return False
-        if (old_item.dictionary, old_item.strokes) != (dictionary, strokes):
-            try:
-                del old_item.dictionary[old_item.strokes]
-            except KeyError:
-                pass
+        try:
+            del old_item.dictionary[old_item.strokes]
+        except KeyError:
+            pass
         if not old_item.strokes and not old_item.translation:
             # Merge operations when editing a newly added row.
             if self._operations and self._operations[-1] == [(None, old_item)]:


### PR DESCRIPTION
This reverts commit 4f271959ee5cb5d59f79761175859e30b2dd3822. This use-case (only updating the translation) is not possible anymore after #1022 ([since an existing entry is deleted first](https://github.com/openstenoproject/plover/commit/d8a68ae0da40ce8f63fe60ea9400fbe5edda6156#diff-5a0d07941f5cd7ac11e809cd3dbf5d179a4249d9a63f53d52963efdba50122e6R126)), at least not without some contortions in the implementation.