### PR TITLE
force the use of the Qt GUI when running from a distribution

### DIFF
--- a/plover/dist_main.py
+++ b/plover/dist_main.py
@@ -8,7 +8,7 @@ from plover.oslayer.config import CONFIG_DIR, PLUGINS_PLATFORM
 
 def main():
     args = sys.argv[:]
-    args[0:1] = [sys.executable, '-m', 'plover.main']
+    args[0:1] = [sys.executable, '-m', 'plover.main', '--gui', 'qt']
     if '--no-user-plugins' in args[3:]:
         args.remove('--no-user-plugins')
         args.insert(1, '-s')


### PR DESCRIPTION
This is so someone does not end up with an invisible Plover running in headless mode (because that's the fallback if the Qt GUI cannot be loaded and no other one is available), possibly catching keyboard input. Note that it's still possible to override this choice using the `--gui` option.