### PR TITLE
show port description in port dropdown menu

### DIFF
--- a/news.d/feature/1254.ui.md
+++ b/news.d/feature/1254.ui.md
@@ -1,0 +1,1 @@
+Show a description next to the port in the machine port dropdown menu.

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -67,16 +67,18 @@ class SerialOption(QWidget, Ui_SerialWidget):
         self.valueChanged.emit(self._value)
 
     def on_scan(self):
-        self.port.clear()
+        self.ports.clear()
         for port in comports():
             portItem = QStandardItem(str(port))
             portItem.setData(port.device)
             self.ports.appendRow(portItem)
 
     def on_port_changed(self, value):
-        port = self.ports.item(self.port.currentIndex()).data()
-        self.port.setCurrentText(port)
-        self._update('port', port)
+        portItem = self.ports.item(self.port.currentIndex())
+        if portItem:
+            port = portItem.data()
+            self.port.setCurrentText(port)
+            self._update('port', port)
 
     def on_baudrate_changed(self, value):
         self._update('baudrate', int(value))

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -63,10 +63,12 @@ class SerialOption(QWidget, Ui_SerialWidget):
 
     def on_scan(self):
         self.port.clear()
-        self.port.addItems(sorted(x[0] for x in comports()))
+        self.port.addItems(sorted(f"{port.device} ({port.description})" for port in comports()))
 
     def on_port_changed(self, value):
-        self._update('port', value)
+        port = value.split(" ")[0]
+        self.port.setCurrentText(port)
+        self._update('port', port)
 
     def on_baudrate_changed(self, value):
         self._update('baudrate', int(value))

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -14,6 +14,7 @@ from plover.gui_qt.i18n import get_gettext
 
 _ = get_gettext()
 
+
 class SerialOption(QWidget, Ui_SerialWidget):
 
     valueChanged = pyqtSignal(QVariant)

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -69,14 +69,14 @@ class SerialOption(QWidget, Ui_SerialWidget):
     def on_scan(self):
         self.ports.clear()
         for port in comports():
-            portItem = QStandardItem(str(port))
-            portItem.setData(port.device)
-            self.ports.appendRow(portItem)
+            port_item = QStandardItem(str(port))
+            port_item.setData(port.device)
+            self.ports.appendRow(port_item)
 
     def on_port_changed(self, value):
-        portItem = self.ports.item(self.port.currentIndex())
-        if portItem:
-            port = portItem.data()
+        port_item = self.ports.item(self.port.currentIndex())
+        if port_item:
+            port = port_item.data()
             self.port.setCurrentText(port)
             self._update('port', port)
 

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -2,6 +2,7 @@ from copy import copy
 
 from PyQt5.QtCore import QVariant, pyqtSignal
 from PyQt5.QtWidgets import QWidget
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
 
 from serial import Serial
 from serial.tools.list_ports import comports
@@ -13,7 +14,6 @@ from plover.gui_qt.i18n import get_gettext
 
 _ = get_gettext()
 
-
 class SerialOption(QWidget, Ui_SerialWidget):
 
     valueChanged = pyqtSignal(QVariant)
@@ -21,6 +21,10 @@ class SerialOption(QWidget, Ui_SerialWidget):
     def __init__(self):
         super().__init__()
         self.setupUi(self)
+
+        self.ports = QStandardItemModel()
+        self.port.setModel(self.ports)
+
         self._value = {}
 
     def setValue(self, value):
@@ -63,10 +67,13 @@ class SerialOption(QWidget, Ui_SerialWidget):
 
     def on_scan(self):
         self.port.clear()
-        self.port.addItems(sorted(f"{port.device} ({port.description})" for port in comports()))
+        for port in comports():
+            portItem = QStandardItem(str(port))
+            portItem.setData(port.device)
+            self.ports.appendRow(portItem)
 
     def on_port_changed(self, value):
-        port = value.split(" ")[0]
+        port = self.ports.item(self.port.currentIndex()).data()
         self.port.setCurrentText(port)
         self._update('port', port)
 

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from PyQt5.QtCore import QVariant, pyqtSignal
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QWidget, QCompleter, QComboBox
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 
 from serial import Serial
@@ -25,6 +25,7 @@ class SerialOption(QWidget, Ui_SerialWidget):
 
         self.ports = QStandardItemModel()
         self.port.setModel(self.ports)
+        self.port.setInsertPolicy(QComboBox.NoInsert)
 
         self._value = {}
 
@@ -68,17 +69,22 @@ class SerialOption(QWidget, Ui_SerialWidget):
 
     def on_scan(self):
         self.ports.clear()
+        completion_list = []
         for port in comports():
             port_item = QStandardItem(str(port))
             port_item.setData(port.device)
             self.ports.appendRow(port_item)
+            completion_list.append(port.device)
+        self.port.setCompleter(QCompleter(completion_list))
 
     def on_port_changed(self, value):
         port_item = self.ports.item(self.port.currentIndex())
-        if port_item:
+        if port_item and value == port_item.text():
             port = port_item.data()
-            self.port.setCurrentText(port)
-            self._update('port', port)
+        else:
+            port = value
+        self.port.setCurrentText(port)
+        self._update('port', port)
 
     def on_baudrate_changed(self, value):
         self._update('baudrate', int(value))


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Add port description to the dropdown of available ports. E.g. instead of `/dev/ttyACM0` it shows `/dev/ttyACM0 - EcoSteno`.

![image](https://user-images.githubusercontent.com/3298461/150560866-f61ddf6a-f1cd-4101-94b8-d699de10993a.png)

This was mentioned briefly in #789 but doesn't address the main issue (but might be useful anyway).

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
