### PR TITLE
reqs: move certifi to the boostrap requirements

### DIFF
--- a/reqs/bootstrap.txt
+++ b/reqs/bootstrap.txt
@@ -1,3 +1,4 @@
+certifi
 pip
 setuptools
 wheel

--- a/reqs/build.txt
+++ b/reqs/build.txt
@@ -1,4 +1,3 @@
 dmgbuild; "darwin" in sys_platform
-certifi
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/reqs/dist.txt
+++ b/reqs/dist.txt
@@ -1,6 +1,5 @@
 appdirs>=1.3.0
 appnope>=0.1.0; "darwin" in sys_platform
-certifi
 pyobjc-core>=4.0; "darwin" in sys_platform
 pyobjc-framework-Cocoa>=4.0; "darwin" in sys_platform
 pyobjc-framework-Quartz>=4.0; "darwin" in sys_platform


### PR DESCRIPTION
Since we don't directly depend on it at runtime, but may need it for bootstraping the distribution. Fix [an issue](https://aur.archlinux.org/packages/plover-git/#comment-802195) with the AUR package.