### PR TITLE
ci: add translations catalogs to the test jobs' skiplist

### DIFF
--- a/.github/workflows/ci/skiplist_job_test.txt
+++ b/.github/workflows/ci/skiplist_job_test.txt
@@ -7,6 +7,7 @@ MANIFEST.in
 osx/*_resources
 osx/make_app.sh
 plover/gui_*/*
+plover/messages/*
 pyproject.toml
 reqs/build.txt
 reqs/dist_*.txt


### PR DESCRIPTION
Those were previously covered by the `plover/gui_*/*` exclusion pattern.
