### PR TITLE
osx: use custom version of dmgbuild

### DIFF
--- a/reqs/build.txt
+++ b/reqs/build.txt
@@ -1,3 +1,4 @@
+-f https://github.com/benoit-pierre/dmgbuild/releases/tag/v1.4.2%2B1.gd79dc1e
 dmgbuild; "darwin" in sys_platform
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -14,7 +14,7 @@ cmarkgfm==0.5.3
 colorama==0.4.4
 cryptography==3.4.7; "linux" in sys_platform
 dbus-python==1.2.16; "linux" in sys_platform
-dmgbuild==1.4.2; "darwin" in sys_platform
+dmgbuild==1.4.2+1.gd79dc1e; "darwin" in sys_platform
 docutils==0.16
 ds_store==1.3.0; "darwin" in sys_platform
 hidapi==0.10.0.post1


### PR DESCRIPTION
With a workaround for the dreaded slowdowns when detaching:
```
hdiutil: detach: timeout for DiskArbitration expired
hdiutil: detach: drive not detached
```

I'd like more testing on this before making a PR to the dmgbuild project.