### PR TITLE
utils/functions: fix `release_prepare` helper

### DIFF
--- a/plover_build_utils/functions.sh
+++ b/plover_build_utils/functions.sh
@@ -253,10 +253,9 @@ git_tree_sha1()
 release_prepare()
 {
   [ $# -eq 1 ] || die 1 'expecting one argument: the new version'
-  version="$("$python" setup.py --version)"
   run "$python" setup.py patch_version "$1"
   run git add plover/__init__.py
-  run towncrier --version="$version" --yes
+  run towncrier --version="$1" --yes
 }
 
 release_finalize()


### PR DESCRIPTION
Of course we want the new changelog section to refer to the new release, not the old one...