### PR TITLE
Disable tabKeyNavigation for all tables

### DIFF
--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -149,6 +149,7 @@ class KeymapOption(QTableWidget):
         self.horizontalHeader().setStretchLastSection(True)
         self.verticalHeader().hide()
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setTabKeyNavigation(False)
         self.cellChanged.connect(self._on_cell_changed)
 
     def setValue(self, value):
@@ -215,6 +216,7 @@ class MultipleChoicesOption(QTableWidget):
         self.horizontalHeader().setStretchLastSection(True)
         self.verticalHeader().hide()
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setTabKeyNavigation(False)
         self.cellChanged.connect(self._on_cell_changed)
 
     def setValue(self, value):

--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -37,6 +37,9 @@
      <property name="frameShape">
       <enum>QFrame::Box</enum>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="showDropIndicator" stdset="0">
       <bool>true</bool>
      </property>

--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -80,6 +80,9 @@
      <property name="frameShape">
       <enum>QFrame::Box</enum>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="showDropIndicator" stdset="0">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Title.

**Note**: pull request only opened for running GitHub CI. It isn't clear whether this is the best option.

An alternative behavior would be

* Tab will jump to the next row, or the next component if the current row is the last.
* Shift+tab will jump to the previous row, or the previous component if the current row is the first.

However this requires more than toggling a simple flag.

Note: even with this, shift+tab cannot cycle through all components in the main interface -- might need more investigation.


### Pull Request Checklist
- [ ] Changes have tests *(GUI only, cannot test)*
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
