### PR TITLE
steno_dictionary: fix handling of read-only flag

### DIFF
--- a/news.d/bugfix/core.1301.md
+++ b/news.d/bugfix/core.1301.md
@@ -1,0 +1,1 @@
+Ensure a read-only dictionary implementation result in loaded dictionaries marked as read-only too.

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -62,8 +62,9 @@ class StenoDictionary:
         timestamp = resource_timestamp(filename)
         d = cls()
         d._load(filename)
-        if resource.startswith(ASSET_SCHEME) or \
-           not os.access(filename, os.W_OK):
+        if (cls.readonly or
+            resource.startswith(ASSET_SCHEME) or
+            not os.access(filename, os.W_OK)):
             d.readonly = True
         d.path = resource
         d.timestamp = timestamp

--- a/test/test_steno_dictionary.py
+++ b/test/test_steno_dictionary.py
@@ -3,10 +3,6 @@
 
 """Unit tests for steno_dictionary.py."""
 
-import os
-import stat
-import tempfile
-
 import pytest
 
 from plover.steno_dictionary import StenoDictionary, StenoDictionaryCollection
@@ -293,6 +289,15 @@ def test_dictionary_readonly_file(tmp_dict):
         # Deleting the file will fail on Windows
         # if we don't restore write permission.
         tmp_dict.chmod(0o660)
+
+def test_dictionary_readonly_class(tmp_dict):
+    # If the class implementation is marked as read-only,
+    # then loading from a writable file should still
+    # result in a read-only dictionary.
+    class ReadOnlyFakeDictionary(FakeDictionary):
+        readonly = True
+    d = ReadOnlyFakeDictionary.load(str(tmp_dict))
+    assert d.readonly
 
 def test_dictionary_readonly_asset():
     # Assets are always readonly.


### PR DESCRIPTION
## Summary of changes

If the class implementation is marked as read-only, then loading from a writable file should still result in a read-only dictionary.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
