### PR TITLE
Redirect indirect imports from GUI forms

### DIFF
--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -1,4 +1,6 @@
-from plover.gui_qt.add_translation_dialog_ui import _, Ui_AddTranslationDialog
+from plover import _
+
+from plover.gui_qt.add_translation_dialog_ui import Ui_AddTranslationDialog
 from plover.gui_qt.tool import Tool
 
 

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -6,6 +6,7 @@ from os.path import split as os_path_split
 from PyQt5.QtCore import QEvent, QTimer
 from PyQt5.QtWidgets import QApplication, QWidget
 
+from plover import _
 from plover.misc import shorten_path
 from plover.steno import normalize_steno, sort_steno_strokes
 from plover.engine import StartingStrokeState
@@ -13,7 +14,7 @@ from plover.translation import escape_translation, unescape_translation
 from plover.formatting import RetroFormatter
 from plover.resource import resource_filename
 
-from plover.gui_qt.add_translation_widget_ui import _, Ui_AddTranslationWidget
+from plover.gui_qt.add_translation_widget_ui import Ui_AddTranslationWidget
 
 
 class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -25,11 +25,12 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from plover import _
 from plover.config import MINIMUM_UNDO_LEVELS
 from plover.misc import expand_path, shorten_path
 from plover.registry import registry
 
-from plover.gui_qt.config_window_ui import _, Ui_ConfigWindow
+from plover.gui_qt.config_window_ui import Ui_ConfigWindow
 from plover.gui_qt.config_file_widget_ui import Ui_FileWidget
 from plover.gui_qt.utils import WindowState
 

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -18,15 +18,15 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from plover import _
 from plover.config import DictionaryConfig
 from plover.dictionary.base import create_dictionary
 from plover.engine import ErroredDictionary
 from plover.misc import normalize_path
 from plover.oslayer.config import CONFIG_DIR
 from plover.registry import registry
-from plover import log
 
-from plover.gui_qt.dictionaries_widget_ui import _, Ui_DictionariesWidget
+from plover.gui_qt.dictionaries_widget_ui import Ui_DictionariesWidget
 from plover.gui_qt.dictionary_editor import DictionaryEditor
 from plover.gui_qt.utils import ToolBar
 

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -14,11 +14,12 @@ from PyQt5.QtWidgets import (
     QStyledItemDelegate,
 )
 
+from plover import _
 from plover.translation import escape_translation, unescape_translation
 from plover.misc import expand_path, shorten_path
 from plover.steno import normalize_steno
 
-from plover.gui_qt.dictionary_editor_ui import _, Ui_DictionaryEditor
+from plover.gui_qt.dictionary_editor_ui import Ui_DictionaryEditor
 from plover.gui_qt.utils import ToolBar, WindowState
 
 

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -1,9 +1,10 @@
 
 from PyQt5.QtCore import QEvent, Qt
 
+from plover import _
 from plover.translation import unescape_translation
 
-from plover.gui_qt.lookup_dialog_ui import _, Ui_LookupDialog
+from plover.gui_qt.lookup_dialog_ui import Ui_LookupDialog
 from plover.gui_qt.tool import Tool
 
 

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -6,7 +6,9 @@ from PyQt5.QtWidgets import QWidget
 from serial import Serial
 from serial.tools.list_ports import comports
 
-from plover.gui_qt.config_keyboard_widget_ui import _, Ui_KeyboardWidget
+from plover import _
+
+from plover.gui_qt.config_keyboard_widget_ui import Ui_KeyboardWidget
 from plover.gui_qt.config_serial_widget_ui import Ui_SerialWidget
 
 

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -12,14 +12,14 @@ from PyQt5.QtWidgets import (
     QMenu,
 )
 
-from plover import log
+from plover import _, log
 from plover.oslayer import wmctrl
 from plover.oslayer.config import CONFIG_DIR
 from plover.registry import registry
 from plover.resource import resource_filename
 
 from plover.gui_qt.log_qt import NotificationHandler
-from plover.gui_qt.main_window_ui import _, Ui_MainWindow
+from plover.gui_qt.main_window_ui import Ui_MainWindow
 from plover.gui_qt.config_window import ConfigWindow
 from plover.gui_qt.about_dialog import AboutDialog
 from plover.gui_qt.trayicon import TrayIcon

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -11,9 +11,9 @@ from PyQt5.QtWidgets import (
 
 from wcwidth import wcwidth
 
-from plover import system
+from plover import _, system
 
-from plover.gui_qt.paper_tape_ui import _, Ui_PaperTape
+from plover.gui_qt.paper_tape_ui import Ui_PaperTape
 from plover.gui_qt.utils import ToolBar
 from plover.gui_qt.tool import Tool
 

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -12,10 +12,11 @@ from PyQt5.QtWidgets import (
     QMenu,
 )
 
+from plover import _
 from plover.suggestions import Suggestion
 from plover.formatting import RetroFormatter
 
-from plover.gui_qt.suggestions_dialog_ui import _, Ui_SuggestionsDialog
+from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
 from plover.gui_qt.utils import ToolBar
 from plover.gui_qt.tool import Tool
 

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -5,9 +5,10 @@ from PyQt5.QtGui import (
 )
 from PyQt5.QtWidgets import QWidget
 
+from plover import _
 from plover.translation import escape_translation
 
-from plover.gui_qt.suggestions_widget_ui import _, Ui_SuggestionsWidget
+from plover.gui_qt.suggestions_widget_ui import Ui_SuggestionsWidget
 
 
 class SuggestionsWidget(QWidget, Ui_SuggestionsWidget):


### PR DESCRIPTION
## Summary of changes

I just tried to build the latest version of Plover and got a screenful of import errors that I tracked down to imports of the _ translation macro from the generated GUI forms. There's already a circular dependency between the GUI modules and their Qt forms that is handled by having the forms code do imports at the bottom, but the extra import was too much.

After redirecting the imports, I got a clean build. It's possible that my particular combination of build tools contributed to the errors, but even if so, direct imports from the macro's definition in the root module seem like a better idea than indirect imports through dynamically-generated Python code.

EDIT: The build issue turned out to be with the UI code generator, but those imports still don't need to be routed through the stuff it spits out.
