### PR TITLE
update distributions to Python 3.8.10

### DIFF
--- a/linux/appimage/Dockerfile
+++ b/linux/appimage/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir /usr/local/ssl && \
       ln -s ../lib64 /usr/local/ssl/lib
 
 # Install Python from Github Actions @setup-python.
-ARG GITHUB_ACTIONS_PYTHON="3.8.8-99800/python-3.8.8-linux-16.04-x64.tar.gz"
+ARG GITHUB_ACTIONS_PYTHON="3.8.10-107001/python-3.8.10-linux-16.04-x64.tar.gz"
 RUN wget --quiet "https://github.com/actions/python-versions/releases/download/$GITHUB_ACTIONS_PYTHON"
 RUN tar xaf "${GITHUB_ACTIONS_PYTHON##*/}" -C /usr/local
 RUN rm "${GITHUB_ACTIONS_PYTHON##*/}"

--- a/osx/deps.sh
+++ b/osx/deps.sh
@@ -1,5 +1,5 @@
-py_installer_version="3.8.8"
+py_installer_version="3.8.10"
 py_installer_macos="10.9"
-py_installer_sha1="04d5f5b48ba232f5b98c534200962dd736109cc3"
+py_installer_sha1="a39db7fe48a27474432f2ee3543a57fa49ce3dde"
 reloc_py_url='https://github.com/benoit-pierre/relocatable-python/archive/35dc4a641e28eeacb709c015540c85749af9cd8d.zip'
 reloc_py_sha1='2191ea43d3e2e6535ccd2c64b32f241bd8f9f4a4'

--- a/windows/dist_deps.sh
+++ b/windows/dist_deps.sh
@@ -1,2 +1,2 @@
-py_embed_version='3.8.8'
-py_embed_sha1='678fcb3e998437ffbe7473a824632a7b34cefd03'
+py_embed_version='3.8.10'
+py_embed_sha1='13b0d782fd2114d6d63775a5792bb1c2452dcfed'


### PR DESCRIPTION
Note:
> According to the release calendar specified in PEP 569, Python 3.8.10 is the final regular maintenance release. Starting now, the 3.8 branch will only accept security fixes and releases of those will be made in source-only form until October 2024.

So we'll have to consider upgrading to 3.9 soon.