### PR TITLE
Fix distribution blacklists

### DIFF
--- a/linux/appimage/blacklist.txt
+++ b/linux/appimage/blacklist.txt
@@ -49,17 +49,17 @@
   **/*[Ww]ayland*
   **/*[Ww]eb[Ee]ngine*
   bindings
-  Qt/plugins/egldeviceintegrations
-  Qt/plugins/platforms/libqeglfs.so
-  Qt/plugins/platforms/libqlinuxfb.so
-  Qt/plugins/platforms/libqminimal.so
-  Qt/plugins/platforms/libqminimalegl.so
-  Qt/plugins/platforms/libqoffscreen.so
-  Qt/plugins/platforms/libqvnc.so
-  Qt/plugins/platforms/libqwebgl.so
-  Qt/plugins/geoservices
-  Qt/plugins/sceneparsers
-  Qt/plugins/webview
+  Qt5/plugins/egldeviceintegrations
+  Qt5/plugins/geoservices
+  Qt5/plugins/platforms/libqeglfs.so
+  Qt5/plugins/platforms/libqlinuxfb.so
+  Qt5/plugins/platforms/libqminimal.so
+  Qt5/plugins/platforms/libqminimalegl.so
+  Qt5/plugins/platforms/libqoffscreen.so
+  Qt5/plugins/platforms/libqvnc.so
+  Qt5/plugins/platforms/libqwebgl.so
+  Qt5/plugins/sceneparsers
+  Qt5/plugins/webview
   pylupdate*
   pyrcc*
   uic

--- a/osx/app_resources/dist_blacklist.txt
+++ b/osx/app_resources/dist_blacklist.txt
@@ -35,27 +35,27 @@
   **/*Serial*
   **/*Sql*
   **/*Test*
-  Qt/plugins/audio
-  Qt/plugins/bearer
-  Qt/plugins/generic
-  Qt/plugins/geoservices
-  Qt/plugins/mediaservice
-  Qt/plugins/playlistformats
-  Qt/plugins/position
-  Qt/plugins/printsupport
-  Qt/plugins/sceneparsers
-  Qt/plugins/sensor*
-  Qt/plugins/sqldrivers
-  Qt/qml
-  Qt/resources
-  Qt/translations/qt_help_*
-  Qt/translations/qtconnectivity_*
-  Qt/translations/qtdeclarative_*
-  Qt/translations/qtlocation_*
-  Qt/translations/qtmultimedia_*
-  Qt/translations/qtquick*
-  Qt/translations/qtserialport_*
-  Qt/translations/qtwebsockets_*
+  Qt5/plugins/audio
+  Qt5/plugins/bearer
+  Qt5/plugins/generic
+  Qt5/plugins/geoservices
+  Qt5/plugins/mediaservice
+  Qt5/plugins/playlistformats
+  Qt5/plugins/position
+  Qt5/plugins/printsupport
+  Qt5/plugins/sceneparsers
+  Qt5/plugins/sensor*
+  Qt5/plugins/sqldrivers
+  Qt5/qml
+  Qt5/resources
+  Qt5/translations/qt_help_*
+  Qt5/translations/qtconnectivity_*
+  Qt5/translations/qtdeclarative_*
+  Qt5/translations/qtlocation_*
+  Qt5/translations/qtmultimedia_*
+  Qt5/translations/qtquick*
+  Qt5/translations/qtserialport_*
+  Qt5/translations/qtwebsockets_*
   pylupdate*
   pyrcc*
   uic

--- a/windows/dist_blacklist.txt
+++ b/windows/dist_blacklist.txt
@@ -9,12 +9,13 @@
   **/*[Qq]uick*
   **/*[Ww]eb[Ee]ngine*
   bindings
-  Qt/bin/libeay32.dll
-  Qt/bin/ssleay32.dll
-  Qt/plugins/platforms/qminimal.dll
-  Qt/plugins/platforms/qoffscreen.dll
-  Qt/plugins/platforms/qwebgl.dll
-  Qt/plugins/sceneparsers
+  Qt5/bin/libeay32.dll
+  Qt5/bin/ssleay32.dll
+  Qt5/plugins/platforms/qminimal.dll
+  Qt5/plugins/platforms/qoffscreen.dll
+  Qt5/plugins/platforms/qwebgl.dll
+  Qt5/plugins/sceneparsers
+  Qt5/qml
   pylupdate*
   pyrcc*
   uic


### PR DESCRIPTION
The main PyQt5 folder, with all the libraries and plugins, changed from `Qt` to `Qt5` in newer versions.