### PR TITLE
gui_qt/main_window: fix display lag on startup

### DIFF
--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -147,6 +147,9 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         self._configured = False
         self.dictionaries.on_config_changed(config)
         self.set_visible(not config['start_minimized'])
+        # Process events before starting the engine
+        # (to avoid display lag at window creation).
+        QCoreApplication.processEvents()
         # Start the engine.
         engine.start()
 


### PR DESCRIPTION
On Linux, before:
![before](https://user-images.githubusercontent.com/5104286/119022595-1fd72a00-b9a1-11eb-81c2-aceb21aac555.gif)
After:
![after](https://user-images.githubusercontent.com/5104286/119022599-206fc080-b9a1-11eb-8395-bcf1cc271646.gif)

