### PR TITLE
ci: add CI requirements to the default skiplist

### DIFF
--- a/.github/workflows/ci/skiplist_default.txt
+++ b/.github/workflows/ci/skiplist_default.txt
@@ -16,6 +16,7 @@ linux/packpack.mk
 linux/packpack.sh
 news.d/*
 osx/README.md
+reqs/ci.txt
 reqs/release.txt
 test.bat
 test.sh


### PR DESCRIPTION
Those are only needed for generating the workflow itself.