### PR TITLE
tox: speed up `developpkg` phase

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ install_command =
 		from plover_build_utils.install_wheels import WHEELS_CACHE, install_wheels; \
 		args = sys.argv[1:]; \
 		subprocess.check_call([sys.executable, "-m", "pip", \
-				       "install", "-f", WHEELS_CACHE] + args) \
+				       "install", "--no-build-isolation", \
+				       "-f", WHEELS_CACHE] + args) \
 		if "-e" in args else \
 		install_wheels(args)'
 


### PR DESCRIPTION
Disable build isolation: we know the build requirements are available.