### PR TITLE
Fix setup develop command

### DIFF
--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 from setuptools.command.build_py import build_py
+from setuptools.command.develop import develop
 import pkg_resources
 import setuptools
 
@@ -206,5 +207,18 @@ class BuildPy(build_py):
         for command in self.build_dependencies:
             self.run_command(command)
         build_py.run(self)
+
+# }}}
+
+# Patched `develop` command. {{{
+
+class Develop(develop):
+
+    build_dependencies = []
+
+    def run(self):
+        for command in self.build_dependencies:
+            self.run_command(command)
+        develop.run(self)
 
 # }}}

--- a/setup.py
+++ b/setup.py
@@ -24,15 +24,17 @@ with open(os.path.join(__software_name__, '__init__.py')) as fp:
     exec(fp.read())
 
 from plover_build_utils.setup import (
-    BuildPy, BuildUi, Command, Test, babel_options
+    BuildPy, BuildUi, Command, Develop, Test, babel_options
 )
 
 
 BuildPy.build_dependencies.append('build_ui')
+Develop.build_dependencies.append('build_py')
 Test.build_before = False
 cmdclass = {
     'build_py': BuildPy,
     'build_ui': BuildUi,
+    'develop': Develop,
     'test': Test,
 }
 options = {}


### PR DESCRIPTION
`build_py` is not called by `develop`, so we need to patch it to ensure the UI files are generated. And we can't path the `build` or `build_ext` command instead because all 4 use cases tend to behave differently (`build`, `install`, `develop` and `bdist_wheel`).