### PR TITLE
rework dictionaries widget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,13 @@ jobs:
       - name: Calculate skip cache keys
         id: set_cache
         run: |
-          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_type=test; job_variant=Linux; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.8_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_type=test; job_variant=macOS; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.8_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_type=test; job_variant=Windows; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_39; job_name='Test (Python 3.9)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_39_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_39; job_skiplists=(job_test os_linux os_macos os_windows); job_type=test; job_variant='Python 3.9'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.8_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.8_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_39; job_name='Test (Python 3.9)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_39_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_39; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.9'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_cache_key
           job_cache_extra_deps=('reqs/dist_*.txt' linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_cache_key
           job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.8; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.8_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
@@ -94,6 +95,14 @@ jobs:
           restore-keys:
             0_${{ steps.set_cache.outputs.test_python_39_skip_cache_key }}
 
+      - name: Check skip cache for Test (Qt GUI)
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_qt_gui
+          key: 0_check_${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}_${{ github.run_id }}
+          restore-keys:
+            0_${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}
+
       - name: Check skip cache for Test (Packaging)
         uses: actions/cache@v2
         with:
@@ -132,12 +141,13 @@ jobs:
           CONTINUOUS_RELEASE_BRANCH: ${{ secrets.CONTINUOUS_RELEASE_BRANCH }}
         run: |
           analyze_set_release_info
-          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_type=test; job_variant=Linux; analyze_set_job_skip_job
-          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.8_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_type=test; job_variant=macOS; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.8_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_type=test; job_variant=Windows; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_39; job_name='Test (Python 3.9)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_39_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_39; job_skiplists=(job_test os_linux os_macos os_windows); job_type=test; job_variant='Python 3.9'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_job
+          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.8_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.8_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_39; job_name='Test (Python 3.9)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_39_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_39; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.9'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_job
           job_cache_extra_deps=('reqs/dist_*.txt' linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.8; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.8_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_job
           job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.8; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.8_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_job
@@ -158,6 +168,8 @@ jobs:
       test_python_37_skip_cache_key: ${{ steps.set_cache.outputs.test_python_37_skip_cache_key }}
       test_python_39_skip_job: ${{ steps.set_ouputs.outputs.test_python_39_skip_job }}
       test_python_39_skip_cache_key: ${{ steps.set_cache.outputs.test_python_39_skip_cache_key }}
+      test_qt_gui_skip_job: ${{ steps.set_ouputs.outputs.test_qt_gui_skip_job }}
+      test_qt_gui_skip_cache_key: ${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}
       test_packaging_skip_job: ${{ steps.set_ouputs.outputs.test_packaging_skip_job }}
       test_packaging_skip_cache_key: ${{ steps.set_cache.outputs.test_packaging_skip_cache_key }}
       build_linux_skip_job: ${{ steps.set_ouputs.outputs.build_linux_skip_job }}
@@ -207,7 +219,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests -p no:pytest-qt --ignore=test/gui_qt
+
 
       # }}}
 
@@ -261,7 +274,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests -p no:pytest-qt --ignore=test/gui_qt
+
 
       # }}}
 
@@ -321,7 +335,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests -p no:pytest-qt --ignore=test/gui_qt
+
 
       # }}}
 
@@ -376,7 +391,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests -p no:pytest-qt --ignore=test/gui_qt
+
 
       # }}}
 
@@ -431,7 +447,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests -p no:pytest-qt --ignore=test/gui_qt
+
 
       # }}}
 
@@ -486,7 +503,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests -p no:pytest-qt --ignore=test/gui_qt
+
 
       # }}}
 
@@ -498,6 +516,65 @@ jobs:
 
       - name: Update skip cache 2
         run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_python_39'"
+
+      - name: List cache contents
+        run: list_cache
+  # }}}
+
+  # Job: Test (Qt GUI) {{{
+  test_qt_gui:
+
+    name: Test (Qt GUI)
+    runs-on: ubuntu-18.04
+    needs: [analyze, ]
+    if: >-
+      !cancelled()
+      && needs.analyze.outputs.test_qt_gui_skip_job == 'no'
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Set cache name
+        id: set_cache
+        run: setup_cache_name '3.8' 'ubuntu-18.04'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: .cache
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/test.txt') }}
+
+      - name: Setup pip options
+        run: setup_pip_options
+
+      - name: Setup Python environment
+        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/dist_extra_gui_qt.txt -r reqs/test.txt
+      - name: Build UI
+        run: python setup.py build_ui
+
+      # Test {{{
+
+      - name: Run tests
+        run: run_tests test/gui_qt
+
+
+      # }}}
+
+      - name: Update skip cache 1
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_qt_gui
+          key: 0_${{ needs.analyze.outputs.test_qt_gui_skip_cache_key }}
+
+      - name: Update skip cache 2
+        run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_qt_gui'"
 
       - name: List cache contents
         run: list_cache
@@ -827,7 +904,7 @@ jobs:
     name: Release
     environment: release
     runs-on: ubuntu-latest
-    needs: [analyze, test_linux, test_macos, test_windows, test_python_36, test_python_37, test_python_39, test_packaging, build_linux, build_macos, build_windows]
+    needs: [analyze, test_linux, test_macos, test_windows, test_python_36, test_python_37, test_python_39, test_qt_gui, test_packaging, build_linux, build_macos, build_windows]
     if: >-
       !cancelled()
       && needs.test_linux.result == 'success'
@@ -836,6 +913,7 @@ jobs:
       && needs.test_python_36.result == 'success'
       && needs.test_python_37.result == 'success'
       && needs.test_python_39.result == 'success'
+      && needs.test_qt_gui.result == 'success'
       && needs.test_packaging.result == 'success'
       && needs.build_linux.result == 'success'
       && needs.build_macos.result == 'success'

--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -24,7 +24,8 @@ list_cache()
 
 run_tests()
 {
-  "$python" setup.py -q test -- --color=yes --durations=5 -ra "$@"
+  "$python" setup.py -q egg_info
+  "$python" -m pytest --color=yes --durations=5 "$@"
 }
 
 setup_cache_name()

--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -24,8 +24,10 @@ list_cache()
 
 run_tests()
 {
-  "$python" setup.py -q egg_info
-  "$python" -m pytest --color=yes --durations=5 "$@"
+  test_cmd=(env QT_QPA_PLATFORM=offscreen "$python" -m pytest --color=yes --durations=5 "$@")
+  run "$python" setup.py -q egg_info
+  info "$(printf "%q " "${test_cmd[@]}")"
+  "${test_cmd[@]}"
 }
 
 setup_cache_name()

--- a/.github/workflows/ci/skiplist_job_build.txt
+++ b/.github/workflows/ci/skiplist_job_build.txt
@@ -1,5 +1,4 @@
-.github/workflows/ci/skiplist_job_test.txt
-.github/workflows/ci/skiplist_job_test_packaging.txt
+.github/workflows/ci/skiplist_job_test*.txt
 .gitignore
 pyproject.toml
 reqs/packaging.txt

--- a/.github/workflows/ci/skiplist_job_test_gui_qt.txt
+++ b/.github/workflows/ci/skiplist_job_test_gui_qt.txt
@@ -1,5 +1,5 @@
 .github/workflows/ci/skiplist_job_build.txt
-.github/workflows/ci/skiplist_job_test_gui_qt.txt
+.github/workflows/ci/skiplist_job_test.txt
 .github/workflows/ci/skiplist_job_test_packaging.txt
 .gitignore
 LICENSE.txt
@@ -7,13 +7,10 @@ linux/*
 MANIFEST.in
 osx/*_resources
 osx/make_app.sh
-plover/gui_*/*
-plover/messages/*
 pyproject.toml
 reqs/build.txt
-reqs/dist_*.txt
 reqs/packaging.txt
 reqs/setup.txt
-test/gui_qt/*
+test/test_*
 windows/*
 {EOF}

--- a/.github/workflows/ci/skiplist_job_test_packaging.txt
+++ b/.github/workflows/ci/skiplist_job_test_packaging.txt
@@ -1,5 +1,5 @@
 .github/workflows/ci/skiplist_job_build.txt
-.github/workflows/ci/skiplist_job_test.txt
+.github/workflows/ci/skiplist_job_test*.txt
 .github/workflows/ci/skiplist_os_*.txt
 reqs/build.txt
 reqs/release.txt

--- a/.github/workflows/ci/workflow_context.yml
+++ b/.github/workflows/ci/workflow_context.yml
@@ -39,6 +39,7 @@ jobs:
     type: test
     reqs: ['dist', 'test']
     skiplists: ['job_test', 'os_linux']
+    test_args: -p no:pytest-qt --ignore=test/gui_qt
   - <<: *test
     <<: *dist_macos
     cache_extra_deps: ['osx/deps.sh']
@@ -60,6 +61,14 @@ jobs:
   - <<: *python_test
     variant: Python 3.9
     python: '3.9'
+
+  # Qt GUI tests.
+  - <<: *test
+    type: test_gui_qt
+    variant: Qt GUI
+    reqs: ['dist', 'dist_extra_gui_qt', 'test']
+    skiplists: ['job_test_gui_qt']
+    test_args: test/gui_qt
 
   # Packaging tests.
   - <<: *dist_other

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -145,11 +145,17 @@ jobs:
           <% endif %>
 
       <% endif %>
-      <% if j.type == 'test' %>
+      <% if j.type == 'test_gui_qt' %>
+      - name: Build UI
+        run: python setup.py build_ui
+
+      <% endif %>
+      <% if j.type in ['test', 'test_gui_qt'] %>
       # Test {{{
 
       - name: Run tests
-        run: run_tests
+        run: run_tests <@ j.test_args @>
+
 
       # }}}
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ include plover/messages/*/LC_MESSAGES/*.po
 include plover/messages/plover.pot
 include plover_build_utils/*.sh
 include pyproject.toml
+include pytest.ini
 include reqs/*.txt
 include test/__init__.py
 include test/conftest.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,7 @@ include pytest.ini
 include reqs/*.txt
 include test/__init__.py
 include test/conftest.py
+include test/gui_qt/test_*.py
 include tox.ini
 include windows/*
 # Exclude: CI/Git/GitHub specific files,

--- a/plover/config.py
+++ b/plover/config.py
@@ -57,6 +57,9 @@ class DictionaryConfig(namedtuple('DictionaryConfig', 'path enabled')):
     def from_dict(d):
         return DictionaryConfig(**d)
 
+    def __repr__(self):
+        return 'DictionaryConfig(%r, %r)' % (self.short_path, self.enabled)
+
 
 ConfigOption = namedtuple('ConfigOption', '''
                           name default

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -468,6 +468,21 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
         self.view.dragMoveEvent = self._drag_move_event
         self.view.dropEvent = self._drag_drop_event
         self.setFocusProxy(self.view)
+        # Edit context menu.
+        edit_menu = QMenu()
+        edit_menu.addAction(self.action_Undo)
+        edit_menu.addSeparator()
+        edit_menu.addMenu(self.menu_AddDictionaries)
+        edit_menu.addAction(self.action_EditDictionaries)
+        edit_menu.addMenu(self.menu_SaveDictionaries)
+        edit_menu.addAction(self.action_RemoveDictionaries)
+        edit_menu.addSeparator()
+        edit_menu.addAction(self.action_MoveDictionariesUp)
+        edit_menu.addAction(self.action_MoveDictionariesDown)
+        self.view.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.view.customContextMenuRequested.connect(
+            lambda p: edit_menu.exec_(self.view.mapToGlobal(p)))
+        self.edit_menu = edit_menu
 
     def setup(self, engine):
         assert not self._setup

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -445,25 +445,14 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
         # Add menu.
         self.menu_AddDictionaries = QMenu(self.action_AddDictionaries.text())
         self.menu_AddDictionaries.setIcon(self.action_AddDictionaries.icon())
-        self.menu_AddDictionaries.addAction(
-            # i18n: Widget: “DictionariesWidget”, “add” menu.
-            _('Open dictionaries'),
-        ).triggered.connect(self._add_existing_dictionaries)
-        self.menu_AddDictionaries.addAction(
-            # i18n: Widget: “DictionariesWidget”, “add” menu.
-            _('New dictionary'),
-        ).triggered.connect(self._create_new_dictionary)
+        self.menu_AddDictionaries.addAction(self.action_OpenDictionaries)
+        self.menu_AddDictionaries.addAction(self.action_CreateDictionary)
+        self.action_AddDictionaries.setMenu(self.menu_AddDictionaries)
         # Save menu.
         self.menu_SaveDictionaries = QMenu(self.action_SaveDictionaries.text())
         self.menu_SaveDictionaries.setIcon(self.action_SaveDictionaries.icon())
-        self.menu_SaveDictionaries.addAction(
-            # i18n: Widget: “DictionariesWidget”, “save” menu.
-            _('Create a copy of each dictionary'),
-        ).triggered.connect(self._save_dictionaries)
-        self.menu_SaveDictionaries.addAction(
-            # i18n: Widget: “DictionariesWidget”, “save” menu.
-            _('Merge dictionaries into a new one'),
-        ).triggered.connect(functools.partial(self._save_dictionaries, merge=True))
+        self.menu_SaveDictionaries.addAction(self.action_CopyDictionaries)
+        self.menu_SaveDictionaries.addAction(self.action_MergeDictionaries)
         self.view.dragEnterEvent = self._drag_enter_event
         self.view.dragMoveEvent = self._drag_move_event
         self.view.dropEvent = self._drag_drop_event
@@ -621,7 +610,7 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
             # This will trigger a reload of any modified dictionary.
             self._engine.config = {}
 
-    def _add_existing_dictionaries(self):
+    def on_open_dictionaries(self):
         new_filenames = QFileDialog.getOpenFileNames(
             # i18n: Widget: “DictionariesWidget”, “add” file picker.
             parent=self, caption=_('Add dictionaries'),
@@ -633,7 +622,7 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
         self._file_dialogs_directory = os.path.dirname(new_filenames[-1])
         self._model.add(new_filenames)
 
-    def _create_new_dictionary(self):
+    def on_create_dictionary(self):
         # i18n: Widget: “DictionariesWidget”, “new” file picker.
         new_filename = self._get_dictionary_save_name(_('New dictionary'))
         if new_filename is None:
@@ -642,7 +631,13 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
             pass
         self._model.add([new_filename])
 
-    def on_activate(self, index):
+    def on_copy_dictionaries(self):
+        self._save_dictionaries()
+
+    def on_merge_dictionaries(self):
+        self._save_dictionaries(merge=True)
+
+    def on_activate_dictionary(self, index):
         self._edit_dictionaries([index])
 
     def on_add_dictionaries(self):

--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>DictionariesWidget</class>
- <widget class="QWidget" name="DictionariesWidget">
+ <widget class="QGroupBox" name="DictionariesWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -19,6 +19,9 @@
   <property name="windowTitle">
    <string notr="true"/>
   </property>
+  <property name="title">
+   <string>Dictionaries</string>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
     <number>0</number>
@@ -33,7 +36,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QTableWidget" name="table">
+    <widget class="QListView" name="view">
      <property name="frameShape">
       <enum>QFrame::Box</enum>
      </property>
@@ -55,20 +58,18 @@
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
      <property name="textElideMode">
       <enum>Qt::ElideMiddle</enum>
      </property>
-     <attribute name="horizontalHeaderStretchLastSection">
+     <property name="uniformItemSizes">
       <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Dictionaries</string>
-      </property>
-     </column>
+     </property>
     </widget>
    </item>
   </layout>
@@ -193,22 +194,6 @@
  </resources>
  <connections>
   <connection>
-   <sender>table</sender>
-   <signal>itemSelectionChanged()</signal>
-   <receiver>DictionariesWidget</receiver>
-   <slot>on_selection_changed()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>199</x>
-     <y>149</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>199</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>action_RemoveDictionaries</sender>
    <signal>triggered()</signal>
    <receiver>DictionariesWidget</receiver>
@@ -289,10 +274,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>table</sender>
-   <signal>cellActivated(int,int)</signal>
+   <sender>view</sender>
+   <signal>activated(QModelIndex)</signal>
    <receiver>DictionariesWidget</receiver>
-   <slot>on_activate_cell(int,int)</slot>
+   <slot>on_activate(QModelIndex)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>199</x>
@@ -336,33 +321,15 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>table</sender>
-   <signal>itemChanged()</signal>
-   <receiver>DictionariesWidget</receiver>
-   <slot>on_dictionary_changed(QTableWidgetItem*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>182</x>
-     <y>118</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>182</x>
-     <y>118</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <slots>
-  <slot>on_selection_changed()</slot>
   <slot>on_remove_dictionaries()</slot>
   <slot>on_undo()</slot>
   <slot>on_edit_dictionaries()</slot>
   <slot>on_add_dictionaries()</slot>
   <slot>on_add_translation()</slot>
-  <slot>on_activate_cell(int,int)</slot>
+  <slot>on_activate(QModelIndex)</slot>
   <slot>on_move_dictionaries_up()</slot>
   <slot>on_move_dictionaries_down()</slot>
-  <slot>on_dictionary_changed(QTableWidgetItem*)</slot>
  </slots>
 </ui>

--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -187,6 +187,26 @@
     <string>Move selected dictionaries down.</string>
    </property>
   </action>
+  <action name="action_CopyDictionaries">
+   <property name="text">
+    <string>Create a copy of each dictionary</string>
+   </property>
+  </action>
+  <action name="action_MergeDictionaries">
+   <property name="text">
+    <string>Merge dictionaries into a new one</string>
+   </property>
+  </action>
+  <action name="action_OpenDictionaries">
+   <property name="text">
+    <string>Open dictionaries</string>
+   </property>
+  </action>
+  <action name="action_CreateDictionary">
+   <property name="text">
+    <string>New dictionary</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="5" margin="8"/>
  <resources>
@@ -277,7 +297,7 @@
    <sender>view</sender>
    <signal>activated(QModelIndex)</signal>
    <receiver>DictionariesWidget</receiver>
-   <slot>on_activate(QModelIndex)</slot>
+   <slot>on_activate_dictionary(QModelIndex)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>199</x>
@@ -321,6 +341,70 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>action_OpenDictionaries</sender>
+   <signal>triggered()</signal>
+   <receiver>DictionariesWidget</receiver>
+   <slot>on_open_dictionaries()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_CreateDictionary</sender>
+   <signal>triggered()</signal>
+   <receiver>DictionariesWidget</receiver>
+   <slot>on_create_dictionary()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_MergeDictionaries</sender>
+   <signal>triggered()</signal>
+   <receiver>DictionariesWidget</receiver>
+   <slot>on_merge_dictionaries()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_CopyDictionaries</sender>
+   <signal>triggered()</signal>
+   <receiver>DictionariesWidget</receiver>
+   <slot>on_copy_dictionaries()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>on_remove_dictionaries()</slot>
@@ -328,8 +412,12 @@
   <slot>on_edit_dictionaries()</slot>
   <slot>on_add_dictionaries()</slot>
   <slot>on_add_translation()</slot>
-  <slot>on_activate(QModelIndex)</slot>
+  <slot>on_activate_dictionary(QModelIndex)</slot>
   <slot>on_move_dictionaries_up()</slot>
   <slot>on_move_dictionaries_down()</slot>
+  <slot>on_open_dictionaries()</slot>
+  <slot>on_create_dictionary()</slot>
+  <slot>on_merge_dictionaries()</slot>
+  <slot>on_copy_dictionaries()</slot>
  </slots>
 </ui>

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -89,14 +89,14 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         engine.signal_connect('machine_state_changed', self._trayicon.update_machine_state)
         engine.signal_connect('quit', self.on_quit)
         self.action_Quit.triggered.connect(engine.quit)
-        # Populate tools bar/menu.
-        tools_menu = all_actions['menu_Tools'].menu()
         # Toolbar popup menu for selecting which tools are shown.
         self.toolbar_menu = QMenu()
         self.toolbar.setContextMenuPolicy(Qt.CustomContextMenu)
         self.toolbar.customContextMenuRequested.connect(
             lambda: self.toolbar_menu.popup(QCursor.pos())
         )
+        # Populate tools bar/menu.
+        tools_menu = all_actions['menu_Tools'].menu()
         for tool_plugin in registry.list_plugins('gui.qt.tool'):
             tool = tool_plugin.obj
             menu_action = tools_menu.addAction(tool.TITLE)

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -43,9 +43,8 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         }
         all_actions = find_menu_actions(self.menubar)
         # Dictionaries.
-        self.dictionaries = self.scroll_area.widget()
         self.dictionaries.add_translation.connect(self._add_translation)
-        self.dictionaries.setFocus()
+        self.dictionaries.setup(engine)
         edit_menu = all_actions['menu_Edit'].menu()
         edit_menu.addAction(self.dictionaries.action_Undo)
         edit_menu.addSeparator()
@@ -145,7 +144,6 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         config = self._engine.config
         self._update_machine(config['machine_type'])
         self._configured = False
-        self.dictionaries.on_config_changed(config)
         self.set_visible(not config['start_minimized'])
         # Process events before starting the engine
         # (to avoid display lag at window creation).

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -45,19 +45,10 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         # Dictionaries.
         self.dictionaries.add_translation.connect(self._add_translation)
         self.dictionaries.setup(engine)
+        # Populate edit menu from dictionaries' own.
         edit_menu = all_actions['menu_Edit'].menu()
-        edit_menu.addAction(self.dictionaries.action_Undo)
-        edit_menu.addSeparator()
-        edit_menu.addMenu(self.dictionaries.menu_AddDictionaries)
-        edit_menu.addAction(self.dictionaries.action_EditDictionaries)
-        edit_menu.addMenu(self.dictionaries.menu_SaveDictionaries)
-        edit_menu.addAction(self.dictionaries.action_RemoveDictionaries)
-        edit_menu.addSeparator()
-        edit_menu.addAction(self.dictionaries.action_MoveDictionariesUp)
-        edit_menu.addAction(self.dictionaries.action_MoveDictionariesDown)
-        self.dictionaries.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.dictionaries.customContextMenuRequested.connect(
-            lambda p: edit_menu.exec_(self.dictionaries.mapToGlobal(p)))
+        for action in self.dictionaries.edit_menu.actions():
+            edit_menu.addAction(action)
         # Tray icon.
         self._trayicon = TrayIcon()
         self._trayicon.enable()

--- a/plover/gui_qt/main_window.ui
+++ b/plover/gui_qt/main_window.ui
@@ -93,24 +93,7 @@
      </widget>
     </item>
     <item row="2" column="0" colspan="3">
-     <widget class="QScrollArea" name="scroll_area">
-      <property name="frameShape">
-       <enum>QFrame::Panel</enum>
-      </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="DictionariesWidget" name="dictionaries">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>311</width>
-         <height>233</height>
-        </rect>
-       </property>
-      </widget>
-     </widget>
+     <widget class="DictionariesWidget" name="dictionaries" native="true"/>
     </item>
     <item row="0" column="1">
      <widget class="QGroupBox" name="groupBox">
@@ -304,7 +287,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>scroll_area</tabstop>
+  <tabstop>dictionaries</tabstop>
   <tabstop>machine_type</tabstop>
   <tabstop>reconnect</tabstop>
   <tabstop>output_enable</tabstop>

--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -2,7 +2,6 @@ from distutils import log
 import contextlib
 import importlib
 import os
-import shutil
 import subprocess
 import sys
 
@@ -48,52 +47,6 @@ class Command(setuptools.Command):
             if cmd == 'bdist_wheel':
                 return dist_path
         raise Exception('could not find wheel path')
-
-# `test` command. {{{
-
-class Test(Command):
-
-    description = 'run unit tests after in-place build'
-    command_consumes_arguments = True
-    user_options = []
-    test_dir = 'test'
-    build_before = True
-
-    def initialize_options(self):
-        self.args = []
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        with self.project_on_sys_path(build=self.build_before):
-            self.run_tests()
-
-    def run_tests(self):
-        # Remove __pycache__ directory so pytest does not freak out
-        # when switching between the Linux/Windows versions.
-        pycache = os.path.join(self.test_dir, '__pycache__')
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
-        custom_testsuite = None
-        args = []
-        for a in self.args:
-            if '-' == a[0]:
-                args.append(a)
-            elif os.path.exists(a):
-                custom_testsuite = a
-                args.append(a)
-            else:
-                args.extend(('-k', a))
-        if custom_testsuite is None:
-            args.insert(0, self.test_dir)
-        sys.argv[1:] = args
-        main = pkg_resources.load_entry_point('pytest',
-                                              'console_scripts',
-                                              'py.test')
-        sys.exit(main())
-
-# }}}
 
 # i18n support. {{{
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -ra
+testpaths =
+	test
+
+# vim: commentstring=#\ %s list

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
 addopts = -ra
+markers =
+	gui_qt: GUI specific tests.
+qt_api = pyqt5
 testpaths =
 	test
 

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -48,6 +48,7 @@ PyQt5-Qt5==5.15.2
 PyQt5-sip==12.8.1
 pyserial==3.5
 pytest==6.2.2
+pytest-qt==3.3.0
 python-xlib==0.29
 pytz==2021.1
 PyYAML==5.4.1

--- a/reqs/test.txt
+++ b/reqs/test.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-qt
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/setup.py
+++ b/setup.py
@@ -24,18 +24,16 @@ with open(os.path.join(__software_name__, '__init__.py')) as fp:
     exec(fp.read())
 
 from plover_build_utils.setup import (
-    BuildPy, BuildUi, Command, Develop, Test, babel_options
+    BuildPy, BuildUi, Command, Develop, babel_options
 )
 
 
 BuildPy.build_dependencies.append('build_ui')
 Develop.build_dependencies.append('build_py')
-Test.build_before = False
 cmdclass = {
     'build_py': BuildPy,
     'build_ui': BuildUi,
     'develop': Develop,
-    'test': Test,
 }
 options = {}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from plover import system
@@ -11,3 +13,9 @@ def setup_plover():
     system.setup(DEFAULT_SYSTEM_NAME)
 
 pytest.register_assert_rewrite('plover_build_utils.testing')
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # Mark `gui_qt` tests.
+        if 'gui_qt' in item.location[0].split(os.path.sep):
+            item.add_marker(pytest.mark.gui_qt)

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -1,0 +1,703 @@
+from collections import namedtuple
+from pathlib import Path
+from textwrap import dedent
+from unittest import mock
+import operator
+
+from PyQt5.QtCore import QModelIndex, QPersistentModelIndex, Qt
+
+import pytest
+
+from plover.config import DictionaryConfig
+from plover.engine import ErroredDictionary
+from plover.gui_qt.dictionaries_widget import DictionariesModel, DictionariesWidget
+from plover.steno_dictionary import StenoDictionary, StenoDictionaryCollection
+from plover.misc import expand_path
+
+
+INVALID_EXCEPTION = Exception('loading error')
+
+ICON_TO_CHAR = {
+    'error': '!',
+    'favorite': '★',
+    'loading': '🗘',
+    'normal': '⎕',
+    'readonly': '🛇',
+}
+ICON_FROM_CHAR = {c: i for i, c in ICON_TO_CHAR.items()}
+
+ENABLED_TO_CHAR = {
+    False: '☐',
+    True: '☑',
+}
+ENABLED_FROM_CHAR = {c: e for e, c in ENABLED_TO_CHAR.items()}
+
+CHECKED_TO_BOOL = {
+    Qt.Checked: True,
+    Qt.Unchecked: False,
+}
+
+MODEL_ROLES = sorted([Qt.CheckStateRole, Qt.DecorationRole, Qt.DisplayRole, Qt.ToolTipRole])
+
+
+def parse_state(state_str):
+    state_str = dedent(state_str).strip()
+    if not state_str:
+        return
+    for line in state_str.split('\n'):
+        enabled, icon, path = line.split()
+        yield ENABLED_FROM_CHAR[enabled], ICON_FROM_CHAR[icon], path
+
+def config_dictionaries_from_state(state_str):
+    return [
+        DictionaryConfig(path, enabled)
+        for enabled, icon, path in parse_state(state_str)
+    ]
+
+def steno_dictionaries_from_state(state_str, existing_dictionaries=None):
+    new_dictionaries = []
+    for enabled, icon, path in parse_state(state_str):
+        if icon == 'loading':
+            continue
+        path = expand_path(path)
+        if existing_dictionaries is None:
+            steno_dict = None
+        else:
+            steno_dict = existing_dictionaries.get(path)
+        if steno_dict is None:
+            if icon == 'error' or path.endswith('.bad'):
+                steno_dict = ErroredDictionary(path, INVALID_EXCEPTION)
+            else:
+                steno_dict = StenoDictionary()
+                steno_dict.path = path
+                steno_dict.readonly = (
+                    icon == 'readonly' or
+                    path.endswith('.ro') or
+                    path.startswith('asset:')
+                )
+            steno_dict.enabled = enabled
+        new_dictionaries.append(steno_dict)
+    return new_dictionaries
+
+
+class ModelTest(namedtuple('ModelTest', '''
+                           config dictionaries engine
+                           model signals connections
+                           initial_state
+                           ''')):
+
+    def configure(self, **kwargs):
+        self.connections['config_changed'](kwargs)
+
+    def configure_dictionaries(self, state):
+        self.configure(dictionaries=config_dictionaries_from_state(state))
+
+    def load_dictionaries(self, state):
+        self.dictionaries.set_dicts(steno_dictionaries_from_state(state, self.dictionaries))
+        self.connections['dictionaries_loaded'](self.dictionaries)
+        loaded = [row
+                  for row, (enabled, icon, path)
+                  in enumerate(parse_state(state))
+                  if icon != 'loading']
+
+    def check(self, expected,
+              config_change=None, data_change=None,
+              layout_change=False, undo_change=None):
+        __tracebackhide__ = operator.methodcaller('errisinstance', AssertionError)
+        expected = dedent(expected).strip()
+        if expected:
+            expected_config = expected
+            expected_state = expected.split('\n')
+        else:
+            expected_config = ''
+            expected_state = []
+        actual_state = []
+        for row in range(self.model.rowCount()):
+            index = self.model.index(row)
+            enabled = CHECKED_TO_BOOL[index.data(Qt.CheckStateRole)]
+            icon = index.data(Qt.DecorationRole)
+            path = index.data(Qt.DisplayRole)
+            actual_state.append('%s %s %s' % (
+                ENABLED_TO_CHAR.get(enabled, '?'),
+                ICON_TO_CHAR.get(icon, '?'),
+                path))
+        assert actual_state == expected_state
+        assert not self.engine.mock_calls, 'unexpected engine call'
+        if config_change == 'reload':
+            assert self.config.mock_calls == [mock.call({})]
+            self.config.reset_mock()
+        elif config_change == 'update':
+            config_update = {
+                'dictionaries': config_dictionaries_from_state(expected_config),
+            }
+            assert self.config.mock_calls == [mock.call(config_update)]
+            self.config.reset_mock()
+        else:
+            assert not self.config.mock_calls, 'unexpected config call'
+        signal_calls = self.signals.mock_calls[:]
+        if undo_change is not None:
+            call = signal_calls.pop(0)
+            assert call == mock.call.has_undo_changed(undo_change)
+        if data_change is not None:
+            for row in data_change:
+                index = self.model.index(row)
+                call = signal_calls.pop(0)
+                call.args[2].sort()
+                assert call == mock.call.dataChanged(index, index, MODEL_ROLES)
+        if layout_change:
+            assert signal_calls[0:2] == [mock.call.layoutAboutToBeChanged([], self.model.NoLayoutChangeHint),
+                                         mock.call.layoutChanged([], self.model.NoLayoutChangeHint)]
+            del signal_calls[0:2]
+        assert not signal_calls
+        self.signals.reset_mock()
+
+    def reset_mocks(self):
+        self.config.reset_mock()
+        self.engine.reset_mock()
+        self.signals.reset_mock()
+
+
+@pytest.fixture
+def model_test(monkeypatch, request):
+    state = request.function.__doc__
+    # Patch configuration directory.
+    current_dir = Path('.').resolve()
+    monkeypatch.setattr('plover.misc.CONFIG_DIR', str(current_dir))
+    # Disable i18n support.
+    monkeypatch.setattr('plover.gui_qt.dictionaries_widget._', lambda s: s)
+    # Fake config.
+    config = mock.PropertyMock()
+    config.return_value = {}
+    # Dictionaries.
+    dictionaries = StenoDictionaryCollection()
+    # Fake engine.
+    engine = mock.MagicMock(spec='''
+                            __enter__ __exit__
+                            config signal_connect
+                            '''.split())
+    engine.__enter__.return_value = engine
+    type(engine).config = config
+    signals = mock.MagicMock()
+    config.return_value = {
+        'dictionaries': config_dictionaries_from_state(state) if state else [],
+        'classic_dictionaries_display_order': False,
+    }
+    # Setup model.
+    model = DictionariesModel(engine, {name: name for name in ICON_TO_CHAR}, max_undo=5)
+    for slot in '''
+    dataChanged
+    layoutAboutToBeChanged
+    layoutChanged
+    has_undo_changed
+    '''.split():
+        getattr(model, slot).connect(getattr(signals, slot))
+    connections = dict(call.args for call in engine.signal_connect.mock_calls)
+    assert connections.keys() == {'config_changed', 'dictionaries_loaded'}
+    config.reset_mock()
+    engine.reset_mock()
+    # Test helper.
+    test = ModelTest(config, dictionaries, engine, model, signals, connections, state)
+    if state and any(icon != 'loading' for enabled, icon, path in parse_state(state)):
+        test.load_dictionaries(state)
+        test.reset_mocks()
+    return test
+
+
+def test_model_add_existing(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☐ ⎕ main.json
+    '''
+    model_test.model.add([expand_path('main.json')])
+    model_test.check(model_test.initial_state, config_change='reload')
+
+def test_model_add_new_1(model_test):
+    '''
+    ☑ ★ user.json
+    ☐ ⎕ commands.json
+    ☑ 🗘 main.json
+    '''
+    model_test.model.add([expand_path('read-only.ro')])
+    model_test.check(
+        '''
+        ☑ 🗘 read-only.ro
+        ☑ ★ user.json
+        ☐ ⎕ commands.json
+        ☑ 🗘 main.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+
+def test_model_add_new_2(model_test):
+    '''
+    ☑ ★ user.json
+    ☐ ⎕ commands.json
+    ☑ 🗘 main.json
+    '''
+    model_test.model.add(['duplicated.json',
+                          'unique.json',
+                          'duplicated.json'])
+    model_test.check(
+        '''
+        ☑ 🗘 duplicated.json
+        ☑ 🗘 unique.json
+        ☑ ★ user.json
+        ☐ ⎕ commands.json
+        ☑ 🗘 main.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+
+def test_model_add_nothing(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    model_test.model.add([])
+    model_test.check(model_test.initial_state)
+
+def test_model_config_update(model_test):
+    '''
+    ☐ ⎕ user.json
+    ☑ ★ commands.json
+    ☑ 🛇 read-only.ro
+    ☑ ! invalid.bad
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    state = '''
+    ☑ ★ user.json
+    ☐ ⎕ commands.json
+    ☑ 🗘 main.json
+    '''
+    model_test.configure_dictionaries(state)
+    model_test.check(state, layout_change=True)
+    state = '''
+    ☑ ★ user.json
+    ☐ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    model_test.load_dictionaries(state)
+    model_test.check(state, data_change=[2])
+
+def test_model_insert_1(model_test):
+    '''
+    ☐ ⎕ user.json
+    ☑ ★ commands.json
+    ☑ 🛇 read-only.ro
+    ☑ ! invalid.bad
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    model_test.model.insert(model_test.model.index(2),
+                            ['main.json',
+                             'commands.json',
+                             'read-only.ro'])
+    model_test.check(
+        '''
+        ☐ ⎕ user.json
+        ☑ 🗘 main.json
+        ☑ ★ commands.json
+        ☑ 🛇 read-only.ro
+        ☑ ! invalid.bad
+        ☐ 🛇 asset:plover:assets/main.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+
+
+def test_model_insert_2(model_test):
+    '''
+    ☐ ⎕ user.json
+    ☑ 🗘 main.json
+    ☑ ★ commands.json
+    ☑ 🛇 read-only.ro
+    ☑ ! invalid.bad
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    model_test.model.insert(QModelIndex(),
+                            ['commands.json',
+                             'user.json',
+                             'commands.json'])
+    model_test.check(
+        '''
+        ☑ 🗘 main.json
+        ☑ 🛇 read-only.ro
+        ☑ ! invalid.bad
+        ☐ 🛇 asset:plover:assets/main.json
+        ☑ ★ commands.json
+        ☐ ⎕ user.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+
+def test_model_insert_3(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    model_test.model.insert(QModelIndex(), [])
+    model_test.check(model_test.initial_state)
+
+def test_model_display_order(model_test):
+    '''
+    ☑ 🛇 read-only.ro
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    state = model_test.initial_state
+    # Flip display order.
+    model_test.configure(classic_dictionaries_display_order=True)
+    model_test.check('\n'.join(reversed(state.split('\n'))), layout_change=True)
+    # Reset display order to default.
+    model_test.configure(classic_dictionaries_display_order=False)
+    model_test.check(state, layout_change=True)
+
+def test_model_favorite(model_test):
+    '''
+    ☑ 🛇 read-only.ro
+    ☑ ★ user.json
+    ☑ ! invalid.bad
+    ☑ ⎕ commands.json
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    # New favorite.
+    model_test.model.setData(model_test.model.index(1), Qt.Unchecked, Qt.CheckStateRole)
+    model_test.check(
+        '''
+        ☑ 🛇 read-only.ro
+        ☐ ⎕ user.json
+        ☑ ! invalid.bad
+        ☑ ★ commands.json
+        ☐ 🛇 asset:plover:assets/main.json
+        ''',
+        config_change='update',
+        data_change=[1, 3],
+        undo_change=True,
+    )
+    # No favorite.
+    model_test.model.setData(model_test.model.index(3), Qt.Unchecked, Qt.CheckStateRole)
+    model_test.check(
+        '''
+        ☑ 🛇 read-only.ro
+        ☐ ⎕ user.json
+        ☑ ! invalid.bad
+        ☐ ⎕ commands.json
+        ☐ 🛇 asset:plover:assets/main.json
+        ''',
+        config_change='update',
+        data_change=[3],
+    )
+
+def test_model_initial_setup(model_test):
+    '''
+    ☑ 🗘 read-only.ro
+    ☑ 🗘 user.json
+    ☑ 🗘 invalid.bad
+    ☑ 🗘 commands.json
+    ☐ 🗘 asset:plover:assets/main.json
+    '''
+    state = model_test.initial_state
+    # Initial state.
+    model_test.check(state)
+    # First config notification: no-op.
+    model_test.configure(**model_test.config.return_value)
+    model_test.check(state)
+    # After loading dictionaries.
+    state = '''
+    ☑ 🛇 read-only.ro
+    ☑ ★ user.json
+    ☑ ! invalid.bad
+    ☑ ⎕ commands.json
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    model_test.load_dictionaries(state)
+    model_test.check(state, data_change=range(5))
+
+def test_model_iter_loaded(model_test):
+    '''
+    ☑ 🗘 magnum.json
+    ☑ ★ user.json
+    ☐ ⎕ commands.json
+    ☑ 🗘 main.json
+    '''
+    model_test.check(model_test.initial_state)
+    index_list = [model_test.model.index(n) for n in range(4)]
+    index_list.append(QModelIndex())
+    assert list(model_test.model.iter_loaded(index_list)) == model_test.dictionaries.dicts
+    assert list(model_test.model.iter_loaded(reversed(index_list))) == model_test.dictionaries.dicts
+    model_test.configure(classic_dictionaries_display_order=False)
+    assert list(model_test.model.iter_loaded(index_list)) == model_test.dictionaries.dicts
+    assert list(model_test.model.iter_loaded(reversed(index_list))) == model_test.dictionaries.dicts
+
+def test_model_move_dictionaries(model_test):
+    '''
+    ☑ 🛇 read-only.ro
+    ☐ ⎕ commands.json
+    ☑ ★ user.json
+    ☑ ⎕ main.json
+    '''
+    model_test.check(model_test.initial_state)
+    model_test.model.move(QModelIndex(), [model_test.model.index(0),
+                                          model_test.model.index(2)])
+    model_test.check(
+        '''
+        ☐ ⎕ commands.json
+        ☑ ★ main.json
+        ☑ 🛇 read-only.ro
+        ☑ ⎕ user.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+
+def test_model_move_down(model_test):
+    '''
+    ☐ ⎕ commands.json
+    ☑ ★ main.json
+    ☑ 🛇 read-only.ro
+    ☑ ⎕ user.json
+    '''
+    model_test.model.move_down([model_test.model.index(n) for n in [1]])
+    model_test.check(
+        '''
+        ☐ ⎕ commands.json
+        ☑ 🛇 read-only.ro
+        ☑ ★ main.json
+        ☑ ⎕ user.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+    model_test.model.move_down([model_test.model.index(n) for n in [0, 2]])
+    model_test.check(
+        '''
+        ☑ 🛇 read-only.ro
+        ☐ ⎕ commands.json
+        ☑ ★ user.json
+        ☑ ⎕ main.json
+        ''',
+        config_change='update',
+        layout_change=True,
+    )
+    model_test.model.move_down([model_test.model.index(n) for n in [1]])
+    model_test.check(
+        '''
+        ☑ 🛇 read-only.ro
+        ☑ ★ user.json
+        ☐ ⎕ commands.json
+        ☑ ⎕ main.json
+        ''',
+        config_change='update',
+        layout_change=True,
+    )
+
+def test_model_move_down_nothing(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    model_test.model.move_down([QModelIndex()])
+    model_test.check(model_test.initial_state)
+
+def test_model_move_up(model_test):
+    '''
+    ☑ 🛇 read-only.ro
+    ☑ ⎕ user.json
+    ☐ ⎕ commands.json
+    ☑ ★ main.json
+    '''
+    model_test.model.move_up([model_test.model.index(n) for n in [2, 3]])
+    model_test.check(
+        '''
+        ☑ 🛇 read-only.ro
+        ☐ ⎕ commands.json
+        ☑ ★ main.json
+        ☑ ⎕ user.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+    model_test.model.move_up([model_test.model.index(n) for n in [1, 2]])
+    model_test.check(
+        '''
+        ☐ ⎕ commands.json
+        ☑ ★ main.json
+        ☑ 🛇 read-only.ro
+        ☑ ⎕ user.json
+        ''',
+        config_change='update',
+        layout_change=True,
+    )
+
+def test_model_move_up_nothing(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    model_test.model.move_up([QModelIndex()])
+    model_test.check(model_test.initial_state)
+
+def test_model_persistent_index(model_test):
+    '''
+    ☑ 🛇 read-only.ro
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    persistent_index = QPersistentModelIndex(model_test.model.index(1))
+    assert persistent_index.row() == 1
+    assert persistent_index.data(Qt.CheckStateRole) == Qt.Checked
+    assert persistent_index.data(Qt.DecorationRole) == 'favorite'
+    assert persistent_index.data(Qt.DisplayRole) == 'user.json'
+    model_test.configure(classic_dictionaries_display_order=True)
+    assert persistent_index.row() == 2
+    assert persistent_index.data(Qt.CheckStateRole) == Qt.Checked
+    assert persistent_index.data(Qt.DecorationRole) == 'favorite'
+    assert persistent_index.data(Qt.DisplayRole) == 'user.json'
+    model_test.model.setData(persistent_index, Qt.Unchecked, Qt.CheckStateRole)
+    assert persistent_index.row() == 2
+    assert persistent_index.data(Qt.CheckStateRole) == Qt.Unchecked
+    assert persistent_index.data(Qt.DecorationRole) == 'normal'
+    assert persistent_index.data(Qt.DisplayRole) == 'user.json'
+
+def test_model_qtmodeltester(model_test, qtmodeltester):
+    '''
+    ☑ 🛇 read-only.ro
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☐ 🛇 asset:plover:assets/main.json
+    '''
+    qtmodeltester.check(model_test.model)
+
+def test_model_remove(model_test):
+    '''
+    ☐ ⎕ commands.json
+    ☑ 🛇 read-only.ro
+    ☑ ★ main.json
+    ☑ ⎕ user.json
+    '''
+    model_test.model.remove([model_test.model.index(n) for n in [0, 3]])
+    model_test.check(
+        '''
+        ☑ 🛇 read-only.ro
+        ☑ ★ main.json
+        ''',
+        config_change='update',
+        layout_change=True,
+        undo_change=True,
+    )
+    model_test.model.remove([model_test.model.index(n) for n in [0, 1]])
+    model_test.check('', config_change='update', layout_change=True)
+
+def test_model_remove_nothing_1(model_test):
+    '''
+    ☐ ⎕ commands.json
+    ☑ 🛇 read-only.ro
+    ☑ ★ main.json
+    ☑ ⎕ user.json
+    '''
+    model_test.model.remove([])
+    model_test.check(model_test.initial_state)
+
+def test_model_remove_nothing_2(model_test):
+    '''
+    ☐ ⎕ commands.json
+    ☑ 🛇 read-only.ro
+    ☑ ★ main.json
+    ☑ ⎕ user.json
+    '''
+    model_test.model.remove([QModelIndex()])
+    model_test.check(model_test.initial_state)
+
+def test_model_set_checked(model_test):
+    on_state = '☑ 🗘 user.json'
+    off_state = '☐ 🗘 user.json'
+    model_test.model.add(['user.json'])
+    model_test.check(on_state, config_change='update',
+                     layout_change=True, undo_change=True)
+    first_index = model_test.model.index(0)
+    for index, value, ret, state in (
+        # Invalid index.
+        (QModelIndex(), Qt.Unchecked, False, on_state),
+        # Invalid values.
+        (first_index, 'pouet', False, on_state),
+        (first_index, Qt.PartiallyChecked, False, on_state),
+        # Already checked.
+        (first_index, Qt.Checked, False, on_state),
+        # Uncheck.
+        (first_index, Qt.Unchecked, True, off_state),
+        # Recheck.
+        (first_index, Qt.Checked, True, on_state),
+    ):
+        assert model_test.model.setData(index, value, Qt.CheckStateRole) == ret
+        model_test.check(state, config_change='update' if ret else None,
+                         data_change=[index.row()] if ret else None)
+
+def test_model_unrelated_config_change(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    model_test.configure(start_minimized=True)
+    model_test.check(model_test.initial_state)
+
+def test_model_undo_1(model_test):
+    '''
+    ☐ 🗘 1.json
+    ☐ 🗘 2.json
+    ☐ 🗘 3.json
+    ☐ 🗘 4.json
+    ☐ 🗘 5.json
+    ☐ 🗘 6.json
+    '''
+    # Check max undo size.
+    state = dedent(model_test.initial_state).strip()
+    state_stack = []
+    for n in range(6):
+        state_stack.append(state)
+        state = state.split('\n')
+        state[n] = '☑' + state[n][1:]
+        state = '\n'.join(state)
+        model_test.model.setData(model_test.model.index(n), Qt.Checked, Qt.CheckStateRole)
+        model_test.check(state, config_change='update', data_change=[n],
+                         undo_change=(True if n == 0 else None))
+    for n in range(5):
+        model_test.model.undo()
+        model_test.check(state_stack.pop(),
+                         config_change='update',
+                         layout_change=True,
+                         undo_change=(False if n == 4 else None))
+
+def test_model_undo_2(model_test):
+    '''
+    ☑ ★ user.json
+    ☑ ⎕ commands.json
+    ☑ ⎕ main.json
+    '''
+    # Changing display order as no impact on the undo stack.
+    model_test.configure(classic_dictionaries_display_order=True)
+    model_test.check(
+        '''
+        ☑ ⎕ main.json
+        ☑ ⎕ commands.json
+        ☑ ★ user.json
+        ''',
+        layout_change=True,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -112,6 +112,6 @@ commands =
 [testenv:test]
 description = run tests
 commands =
-	{envpython} setup.py -q test -- {posargs}
+	{envpython} -m pytest {posargs}
 
 # vim: ft=cfg list

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,8 @@ commands =
 
 [testenv:test]
 description = run tests
+setenv =
+	QT_QPA_PLATFORM=offscreen
 commands =
 	{envpython} -m pytest {posargs}
 


### PR DESCRIPTION
## Summary of changes

* initially part of #1308, change the widget to use a list with a custom model instead of table
* add preliminary support for testing the Qt GUI (only the dictionaries widget for now)
* tweak the widget context menu to only trigger on the list (and not other parts of the frame, like the toolbar)

Note: this drop the custom `test` command, as the custom argument list handling make using some pytest options impossible (e.g. `-m gui_qt`), and the workaround for pytest cache handling is not necessary anymore.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
