### PR TITLE
Change links at the bottom of the webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,7 @@
           <h2>Download</h2>
           <p>Plover sees regular updates, and accepts bug reports, feature requests, art, and usability ideas. Please see <a target="_blank" href="https://github.com/openstenoproject/plover" alt="Plover's GitHub">Plover's GitHub</a> if you would like to contribute. Please follow below to see the latest releases and installation instructions.</p>
           <div class="ploverBtns">
-            <a target="_blank" href="https://github.com/openstenoproject/plover/releases/latest" class="btn btn-lg btn-success">Download Latest Stable</a>
-            <span class="text-muted">&nbsp;or&nbsp;</span>
-            <a target="_blank" href="https://github.com/openstenoproject/plover/releases" class="btn btn-default">Weekly Builds</a>
+            <a target="_blank" href="https://github.com/openstenoproject/plover/wiki/Beginner's-Guide:-Get-Started-with-Plover" class="btn btn-lg btn-success">Get Started</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Removes the two links "Download Latest Stable" and "Weekly Builds"
  - These links don't convey that the v4 version is what most people on the discord recommend
  - They link to the releases page and it's tempting to scroll down to the files instead of reading the text and clicking through to the installation guide. This isn't great because on Mac it's necessary to read this and do a few more steps.
  - The troubleshooting guide is even more hidden (you have to click to the installation guide first)
- Replaces with the beginner's guide
  - This is the same link as on the [open steno homepage](https://www.openstenoproject.org/).
  - It might make sense to also add the link to the community page, but since the section is titled "download" and I didn't want to change too much I left it at the one link

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
