### PR TITLE
Change hover to lover

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           <div class="panel panel-default">
             <div class="panel-body">
               <p id="opening-text">
-                Plover (rhymes with "hover") is a <strong>free, open source stenography engine</strong>. It allows individuals to replace their keyboard and write into any program at speeds of <strong>over 200 words per minute</strong>.
+                Plover (rhymes with "lover") is a <strong>free, open source stenography engine</strong>. It allows individuals to replace their keyboard and write into any program at speeds of <strong>over 200 words per minute</strong>.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Change "rhymes with hover" to "rhymes with lover".

It's a common criticism of the page since it doesn't match with everyone's accents (which can then lead to being turned off of Plover itself, because not being applicable to everyone's accents and writing styles is a big concern).

I've changed this to "lover" since this matches the [wiki](https://github.com/openstenoproject/plover/wiki) and seems to not have as many issues.
