### PR TITLE
osx: update `relocatable-python`

### DIFF
--- a/osx/deps.sh
+++ b/osx/deps.sh
@@ -1,5 +1,5 @@
 py_installer_version="3.8.10"
 py_installer_macos="10.9"
 py_installer_sha1="a39db7fe48a27474432f2ee3543a57fa49ce3dde"
-reloc_py_url='https://github.com/benoit-pierre/relocatable-python/archive/35dc4a641e28eeacb709c015540c85749af9cd8d.zip'
-reloc_py_sha1='2191ea43d3e2e6535ccd2c64b32f241bd8f9f4a4'
+reloc_py_url='https://github.com/gregneagle/relocatable-python/archive/06b3052afe49c400aa4196f2aada15c0992e3725.zip'
+reloc_py_sha1='ca85e6439a756ed2429eea1664ec160c04f3712e'


### PR DESCRIPTION
Latest upstream master includes support for `--without-pip`.