### PR TITLE
 Plover homepage: change download button link to go to latest

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
           <div class="btn-group plover-nav" role="group" aria-label="Navigation">
             <a class="btn btn-lg btn-default" href="http://plover.stenoknight.com/" alt="Mirabai Knight's Plover Blog">Blog</a>
             <a class="btn btn-lg btn-default" href="https://github.com/openstenoproject/plover/wiki" alt="Plover's Wiki on GitHub">Wiki</a>
-            <a class="btn btn-lg btn-default" href="https://github.com/openstenoproject/plover/releases/latest" alt="Latest Plover release on GitHub">Download</a>
+            <a class="btn btn-lg btn-default" href="https://github.com/openstenoproject/plover/releases" alt="Latest Plover release on GitHub">Download</a>
           </div>
         </div>
 
@@ -66,9 +66,9 @@
           <h2>Download</h2>
           <p>Plover sees regular updates, and accepts bug reports, feature requests, art, and usability ideas. Please see <a target="_blank" href="https://github.com/openstenoproject/plover" alt="Plover's GitHub">Plover's GitHub</a> if you would like to contribute. Please follow below to see the latest releases and installation instructions.</p>
           <div class="ploverBtns">
-            <a target="_blank" href="https://github.com/openstenoproject/plover/releases/latest" class="btn btn-lg btn-success">Download Latest Stable</a>
+            <a target="_blank" href="https://github.com/openstenoproject/plover/releases" class="btn btn-lg btn-success">Download Latest</a>
             <span class="text-muted">&nbsp;or&nbsp;</span>
-            <a target="_blank" href="https://github.com/openstenoproject/plover/releases" class="btn btn-default">Weekly Builds</a>
+            <a target="_blank" href="https://github.com/openstenoproject/plover/releases/latest" class="btn btn-default">stable release</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
 the download button links have been changed to direct to the latest release rather than the old stable version.

<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Change the download links to direct to the latest prerelease of Plover rather than the old stable release.
Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
