### PR TITLE
beyond PyQt5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,21 @@ jobs:
       - name: Calculate skip cache keys
         id: set_cache
         run: |
-          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt5.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_pyqt5_gui; job_name='Test (PyQt5 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_qt_api=PyQt5; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt5.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyqt5_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_pyqt5_gui; job_skiplists=(job_test_gui_qt); job_system_deps=''; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PyQt5 GUI'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_pyqt6_gui; job_name='Test (PyQt6 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-20.04; job_python=3.9; job_qt_api=PyQt6; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt6.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyqt6_gui_py-3.9_ubuntu-20.04; job_skip_cache_path=.skip_cache_test_pyqt6_gui; job_skiplists=(job_test_gui_qt); job_system_deps=libegl1; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PyQt6 GUI'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_pyside2_gui; job_name='Test (PySide2 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_qt_api=PySide2; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyside2.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyside2_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_pyside2_gui; job_skiplists=(job_test_gui_qt); job_system_deps=''; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PySide2 GUI'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_pyside6_gui; job_name='Test (PySide6 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-20.04; job_python=3.9; job_qt_api=PySide6; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyside6.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyside6_gui_py-3.9_ubuntu-20.04; job_skip_cache_path=.skip_cache_test_pyside6_gui; job_skiplists=(job_test_gui_qt); job_system_deps=libegl1; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PySide6 GUI'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_system_deps='libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev'; job_type=build; job_variant=Linux; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_system_deps='libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev'; job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_system_deps='libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev'; job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
 
       - name: Check skip cache for Test (Linux)
         uses: actions/cache@v2
@@ -104,13 +107,37 @@ jobs:
           restore-keys:
             0_${{ steps.set_cache.outputs.test_python_310_skip_cache_key }}
 
-      - name: Check skip cache for Test (Qt GUI)
+      - name: Check skip cache for Test (PyQt5 GUI)
         uses: actions/cache@v2
         with:
-          path: .skip_cache_test_qt_gui
-          key: 0_check_${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}_${{ github.run_id }}
+          path: .skip_cache_test_pyqt5_gui
+          key: 0_check_${{ steps.set_cache.outputs.test_pyqt5_gui_skip_cache_key }}_${{ github.run_id }}
           restore-keys:
-            0_${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}
+            0_${{ steps.set_cache.outputs.test_pyqt5_gui_skip_cache_key }}
+
+      - name: Check skip cache for Test (PyQt6 GUI)
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_pyqt6_gui
+          key: 0_check_${{ steps.set_cache.outputs.test_pyqt6_gui_skip_cache_key }}_${{ github.run_id }}
+          restore-keys:
+            0_${{ steps.set_cache.outputs.test_pyqt6_gui_skip_cache_key }}
+
+      - name: Check skip cache for Test (PySide2 GUI)
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_pyside2_gui
+          key: 0_check_${{ steps.set_cache.outputs.test_pyside2_gui_skip_cache_key }}_${{ github.run_id }}
+          restore-keys:
+            0_${{ steps.set_cache.outputs.test_pyside2_gui_skip_cache_key }}
+
+      - name: Check skip cache for Test (PySide6 GUI)
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_pyside6_gui
+          key: 0_check_${{ steps.set_cache.outputs.test_pyside6_gui_skip_cache_key }}_${{ github.run_id }}
+          restore-keys:
+            0_${{ steps.set_cache.outputs.test_pyside6_gui_skip_cache_key }}
 
       - name: Check skip cache for Test (Packaging)
         uses: actions/cache@v2
@@ -150,18 +177,21 @@ jobs:
           CONTINUOUS_RELEASE_BRANCH: ${{ secrets.CONTINUOUS_RELEASE_BRANCH }}
         run: |
           analyze_set_release_info
-          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_job
-          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt5.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_job
+          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_36; job_name='Test (Python 3.6)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.6; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_36_py-3.6_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_36; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.6'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_system_deps=''; job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_pyqt5_gui; job_name='Test (PyQt5 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_qt_api=PyQt5; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt5.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyqt5_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_pyqt5_gui; job_skiplists=(job_test_gui_qt); job_system_deps=''; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PyQt5 GUI'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_pyqt6_gui; job_name='Test (PyQt6 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-20.04; job_python=3.9; job_qt_api=PyQt6; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt6.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyqt6_gui_py-3.9_ubuntu-20.04; job_skip_cache_path=.skip_cache_test_pyqt6_gui; job_skiplists=(job_test_gui_qt); job_system_deps=libegl1; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PyQt6 GUI'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_pyside2_gui; job_name='Test (PySide2 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_qt_api=PySide2; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyside2.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyside2_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_pyside2_gui; job_skiplists=(job_test_gui_qt); job_system_deps=''; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PySide2 GUI'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_pyside6_gui; job_name='Test (PySide6 GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-20.04; job_python=3.9; job_qt_api=PySide6; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyside6.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_pyside6_gui_py-3.9_ubuntu-20.04; job_skip_cache_path=.skip_cache_test_pyside6_gui; job_skiplists=(job_test_gui_qt); job_system_deps=libegl1; job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='PySide6 GUI'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_system_deps='libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev'; job_type=build; job_variant=Linux; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_system_deps='libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev'; job_type=build; job_variant=macOS; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_system_deps='libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev'; job_type=build; job_variant=Windows; analyze_set_job_skip_job
 
     outputs:
       is_release: ${{ steps.set_ouputs.outputs.is_release }}
@@ -180,8 +210,14 @@ jobs:
       test_python_38_skip_cache_key: ${{ steps.set_cache.outputs.test_python_38_skip_cache_key }}
       test_python_310_skip_job: ${{ steps.set_ouputs.outputs.test_python_310_skip_job }}
       test_python_310_skip_cache_key: ${{ steps.set_cache.outputs.test_python_310_skip_cache_key }}
-      test_qt_gui_skip_job: ${{ steps.set_ouputs.outputs.test_qt_gui_skip_job }}
-      test_qt_gui_skip_cache_key: ${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}
+      test_pyqt5_gui_skip_job: ${{ steps.set_ouputs.outputs.test_pyqt5_gui_skip_job }}
+      test_pyqt5_gui_skip_cache_key: ${{ steps.set_cache.outputs.test_pyqt5_gui_skip_cache_key }}
+      test_pyqt6_gui_skip_job: ${{ steps.set_ouputs.outputs.test_pyqt6_gui_skip_job }}
+      test_pyqt6_gui_skip_cache_key: ${{ steps.set_cache.outputs.test_pyqt6_gui_skip_cache_key }}
+      test_pyside2_gui_skip_job: ${{ steps.set_ouputs.outputs.test_pyside2_gui_skip_job }}
+      test_pyside2_gui_skip_cache_key: ${{ steps.set_cache.outputs.test_pyside2_gui_skip_cache_key }}
+      test_pyside6_gui_skip_job: ${{ steps.set_ouputs.outputs.test_pyside6_gui_skip_job }}
+      test_pyside6_gui_skip_cache_key: ${{ steps.set_cache.outputs.test_pyside6_gui_skip_cache_key }}
       test_packaging_skip_job: ${{ steps.set_ouputs.outputs.test_packaging_skip_job }}
       test_packaging_skip_cache_key: ${{ steps.set_cache.outputs.test_packaging_skip_cache_key }}
       build_linux_skip_job: ${{ steps.set_ouputs.outputs.build_linux_skip_job }}
@@ -589,15 +625,15 @@ jobs:
         run: list_cache
   # }}}
 
-  # Job: Test (Qt GUI) {{{
-  test_qt_gui:
+  # Job: Test (PyQt5 GUI) {{{
+  test_pyqt5_gui:
 
-    name: Test (Qt GUI)
+    name: Test (PyQt5 GUI)
     runs-on: ubuntu-18.04
     needs: [analyze, ]
     if: >-
       !cancelled()
-      && needs.analyze.outputs.test_qt_gui_skip_job == 'no'
+      && needs.analyze.outputs.test_pyqt5_gui_skip_job == 'no'
 
     steps:
 
@@ -630,6 +666,8 @@ jobs:
       # Test {{{
 
       - name: Run tests
+        env:
+          QT_API: PyQt5
         run: run_tests test/gui_qt
 
 
@@ -638,11 +676,200 @@ jobs:
       - name: Update skip cache 1
         uses: actions/cache@v2
         with:
-          path: .skip_cache_test_qt_gui
-          key: 0_${{ needs.analyze.outputs.test_qt_gui_skip_cache_key }}
+          path: .skip_cache_test_pyqt5_gui
+          key: 0_${{ needs.analyze.outputs.test_pyqt5_gui_skip_cache_key }}
 
       - name: Update skip cache 2
-        run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_qt_gui'"
+        run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_pyqt5_gui'"
+
+      - name: List cache contents
+        run: list_cache
+  # }}}
+
+  # Job: Test (PyQt6 GUI) {{{
+  test_pyqt6_gui:
+
+    name: Test (PyQt6 GUI)
+    runs-on: ubuntu-20.04
+    needs: [analyze, ]
+    if: >-
+      !cancelled()
+      && needs.analyze.outputs.test_pyqt6_gui_skip_job == 'no'
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Set cache name
+        id: set_cache
+        run: setup_cache_name '3.9' 'ubuntu-20.04'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: .cache
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/dist_pyqt6.txt', 'reqs/setup.txt', 'reqs/test.txt') }}
+
+      - name: Setup pip options
+        run: setup_pip_options
+
+      - name: Install system dependencies
+        run: apt_get_install libegl1
+
+      - name: Setup Python environment
+        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/dist_extra_gui_qt.txt -r reqs/dist_pyqt6.txt -r reqs/setup.txt -r reqs/test.txt
+      - name: Build UI
+        run: python setup.py build_ui
+
+      # Test {{{
+
+      - name: Run tests
+        env:
+          QT_API: PyQt6
+        run: run_tests test/gui_qt
+
+
+      # }}}
+
+      - name: Update skip cache 1
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_pyqt6_gui
+          key: 0_${{ needs.analyze.outputs.test_pyqt6_gui_skip_cache_key }}
+
+      - name: Update skip cache 2
+        run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_pyqt6_gui'"
+
+      - name: List cache contents
+        run: list_cache
+  # }}}
+
+  # Job: Test (PySide2 GUI) {{{
+  test_pyside2_gui:
+
+    name: Test (PySide2 GUI)
+    runs-on: ubuntu-18.04
+    needs: [analyze, ]
+    if: >-
+      !cancelled()
+      && needs.analyze.outputs.test_pyside2_gui_skip_job == 'no'
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Set cache name
+        id: set_cache
+        run: setup_cache_name '3.9' 'ubuntu-18.04'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: .cache
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/dist_pyside2.txt', 'reqs/setup.txt', 'reqs/test.txt') }}
+
+      - name: Setup pip options
+        run: setup_pip_options
+
+      - name: Setup Python environment
+        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/dist_extra_gui_qt.txt -r reqs/dist_pyside2.txt -r reqs/setup.txt -r reqs/test.txt
+      - name: Build UI
+        run: python setup.py build_ui
+
+      # Test {{{
+
+      - name: Run tests
+        env:
+          QT_API: PySide2
+        run: run_tests test/gui_qt
+
+
+      # }}}
+
+      - name: Update skip cache 1
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_pyside2_gui
+          key: 0_${{ needs.analyze.outputs.test_pyside2_gui_skip_cache_key }}
+
+      - name: Update skip cache 2
+        run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_pyside2_gui'"
+
+      - name: List cache contents
+        run: list_cache
+  # }}}
+
+  # Job: Test (PySide6 GUI) {{{
+  test_pyside6_gui:
+
+    name: Test (PySide6 GUI)
+    runs-on: ubuntu-20.04
+    needs: [analyze, ]
+    if: >-
+      !cancelled()
+      && needs.analyze.outputs.test_pyside6_gui_skip_job == 'no'
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Set cache name
+        id: set_cache
+        run: setup_cache_name '3.9' 'ubuntu-20.04'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: .cache
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/dist_pyside6.txt', 'reqs/setup.txt', 'reqs/test.txt') }}
+
+      - name: Setup pip options
+        run: setup_pip_options
+
+      - name: Install system dependencies
+        run: apt_get_install libegl1
+
+      - name: Setup Python environment
+        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/dist_extra_gui_qt.txt -r reqs/dist_pyside6.txt -r reqs/setup.txt -r reqs/test.txt
+      - name: Build UI
+        run: python setup.py build_ui
+
+      # Test {{{
+
+      - name: Run tests
+        env:
+          QT_API: PySide6
+        run: run_tests test/gui_qt
+
+
+      # }}}
+
+      - name: Update skip cache 1
+        uses: actions/cache@v2
+        with:
+          path: .skip_cache_test_pyside6_gui
+          key: 0_${{ needs.analyze.outputs.test_pyside6_gui_skip_cache_key }}
+
+      - name: Update skip cache 2
+        run: run_eval "echo 'https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID' >'.skip_cache_test_pyside6_gui'"
 
       - name: List cache contents
         run: list_cache
@@ -972,7 +1199,7 @@ jobs:
     name: Release
     environment: release
     runs-on: ubuntu-latest
-    needs: [analyze, test_linux, test_macos, test_windows, test_python_36, test_python_37, test_python_38, test_python_310, test_qt_gui, test_packaging, build_linux, build_macos, build_windows]
+    needs: [analyze, test_linux, test_macos, test_windows, test_python_36, test_python_37, test_python_38, test_python_310, test_pyqt5_gui, test_pyqt6_gui, test_pyside2_gui, test_pyside6_gui, test_packaging, build_linux, build_macos, build_windows]
     if: >-
       !cancelled()
       && needs.test_linux.result == 'success'
@@ -982,7 +1209,10 @@ jobs:
       && needs.test_python_37.result == 'success'
       && needs.test_python_38.result == 'success'
       && needs.test_python_310.result == 'success'
-      && needs.test_qt_gui.result == 'success'
+      && needs.test_pyqt5_gui.result == 'success'
+      && needs.test_pyqt6_gui.result == 'success'
+      && needs.test_pyside2_gui.result == 'success'
+      && needs.test_pyside6_gui.result == 'success'
       && needs.test_packaging.result == 'success'
       && needs.build_linux.result == 'success'
       && needs.build_macos.result == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
           job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt5.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_*.txt' linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
 
       - name: Check skip cache for Test (Linux)
         uses: actions/cache@v2
@@ -157,11 +157,11 @@ jobs:
           job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/dist_pyqt5.txt reqs/setup.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_*.txt' linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-18.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-18.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_extra*.txt' reqs/dist_plugins.txt reqs/dist_pyqt5 windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_job
 
     outputs:
       is_release: ${{ steps.set_ouputs.outputs.is_release }}
@@ -617,13 +617,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .cache
-          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/test.txt') }}
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/dist_pyqt5.txt', 'reqs/setup.txt', 'reqs/test.txt') }}
 
       - name: Setup pip options
         run: setup_pip_options
 
       - name: Setup Python environment
-        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/dist_extra_gui_qt.txt -r reqs/test.txt
+        run: setup_python_env -c reqs/constraints.txt -r reqs/dist.txt -r reqs/dist_extra_gui_qt.txt -r reqs/dist_pyqt5.txt -r reqs/setup.txt -r reqs/test.txt
       - name: Build UI
         run: python setup.py build_ui
 
@@ -772,7 +772,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .cache
-          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_*.txt', 'linux/appimage/deps.sh') }}
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'linux/appimage/deps.sh') }}
 
       - name: Setup pip options
         run: setup_pip_options
@@ -840,7 +840,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .cache
-          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_*.txt', 'osx/deps.sh') }}
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'osx/deps.sh') }}
 
       - name: Setup pip options
         run: setup_pip_options
@@ -919,7 +919,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .cache
-          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_*.txt', 'windows/dist_deps.sh') }}
+          key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'windows/dist_deps.sh') }}
 
       - name: Setup pip options
         run: setup_pip_options

--- a/.github/workflows/ci/workflow_context.yml
+++ b/.github/workflows/ci/workflow_context.yml
@@ -69,7 +69,7 @@ jobs:
   - <<: *test
     type: test_gui_qt
     variant: Qt GUI
-    reqs: ['dist', 'dist_extra_gui_qt', 'test']
+    reqs: ['dist', 'dist_extra_gui_qt', 'dist_pyqt5', 'setup', 'test']
     skiplists: ['job_test_gui_qt']
     test_args: test/gui_qt
 
@@ -87,15 +87,15 @@ jobs:
     type: build
     needs: [test_linux]
     reqs: ['build', 'setup']
-    cache_extra_deps: ['reqs/dist_*.txt', 'linux/appimage/deps.sh']
+    cache_extra_deps: ['reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'linux/appimage/deps.sh']
     skiplists: ['job_build', 'os_linux']
   - <<: *build
     <<: *dist_macos
     needs: [test_macos]
-    cache_extra_deps: ['reqs/dist_*.txt', 'osx/deps.sh']
+    cache_extra_deps: ['reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'osx/deps.sh']
     skiplists: ['job_build', 'os_macos']
   - <<: *build
     <<: *dist_win
     needs: [test_windows]
-    cache_extra_deps: ['reqs/dist_*.txt', 'windows/dist_deps.sh']
+    cache_extra_deps: ['reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'windows/dist_deps.sh']
     skiplists: ['job_build', 'os_windows']

--- a/.github/workflows/ci/workflow_context.yml
+++ b/.github/workflows/ci/workflow_context.yml
@@ -14,6 +14,7 @@ vars:
     python: '3.9'
     os: Linux
     platform: ubuntu-18.04
+    system_deps:
 
   - &dist_macos
     variant: macOS
@@ -66,12 +67,30 @@ jobs:
     python: '3.10'
 
   # Qt GUI tests.
-  - <<: *test
+  - &test_gui
+    <<: *test
     type: test_gui_qt
-    variant: Qt GUI
+    variant: PyQt5 GUI
+    qt_api: PyQt5
     reqs: ['dist', 'dist_extra_gui_qt', 'dist_pyqt5', 'setup', 'test']
     skiplists: ['job_test_gui_qt']
     test_args: test/gui_qt
+  - <<: *test_gui
+    platform: ubuntu-20.04
+    variant: PyQt6 GUI
+    qt_api: PyQt6
+    reqs: ['dist', 'dist_extra_gui_qt', 'dist_pyqt6', 'setup', 'test']
+    system_deps: libegl1
+  - <<: *test_gui
+    variant: PySide2 GUI
+    qt_api: PySide2
+    reqs: ['dist', 'dist_extra_gui_qt', 'dist_pyside2', 'setup', 'test']
+  - <<: *test_gui
+    platform: ubuntu-20.04
+    variant: PySide6 GUI
+    qt_api: PySide6
+    reqs: ['dist', 'dist_extra_gui_qt', 'dist_pyside6', 'setup', 'test']
+    system_deps: libegl1
 
   # Packaging tests.
   - <<: *dist_other
@@ -89,6 +108,7 @@ jobs:
     reqs: ['build', 'setup']
     cache_extra_deps: ['reqs/dist_extra*.txt', 'reqs/dist_plugins.txt', 'reqs/dist_pyqt5', 'linux/appimage/deps.sh']
     skiplists: ['job_build', 'os_linux']
+    system_deps: libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev
   - <<: *build
     <<: *dist_macos
     needs: [test_macos]

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -127,9 +127,9 @@ jobs:
         run: setup_osx_python '<@ j.python @>'
 
       <% endif %>
-      <% if j.type == 'build' and j.os == 'Linux' %>
+      <% if j.os == 'Linux' and j.system_deps %>
       - name: Install system dependencies
-        run: apt_get_install libdbus-1-dev libdbus-glib-1-dev libudev-dev libusb-1.0-0-dev
+        run: apt_get_install <@ j.system_deps @>
 
       <% endif %>
       - name: Setup Python environment
@@ -154,6 +154,10 @@ jobs:
       # Test {{{
 
       - name: Run tests
+        <% if j.type == 'test_gui_qt' %>
+        env:
+          QT_API: <@ j.qt_api @>
+        <% endif %>
         run: run_tests <@ j.test_args @>
 
 

--- a/plover/gui_qt/about_dialog.py
+++ b/plover/gui_qt/about_dialog.py
@@ -34,7 +34,7 @@ class AboutDialog(QDialog, Ui_AboutDialog):
             <h2>Credits:</h2>
             <p>%(credits)s</p>
             ''' % {
-                'icon'       : ':/plover.png',
+                'icon'       : 'plover:plover.png',
                 'name'       : plover.__name__.capitalize(),
                 'version'    : plover.__version__,
                 'description': plover.__long_description__,

--- a/plover/gui_qt/about_dialog.py
+++ b/plover/gui_qt/about_dialog.py
@@ -1,7 +1,7 @@
 
 import re
 
-from PyQt5.QtWidgets import QDialog
+from qtpy.QtWidgets import QDialog
 
 import plover
 

--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDialogButtonBox
+from qtpy.QtWidgets import QDialogButtonBox
 
 from plover import _
 

--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -12,7 +12,7 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
     __doc__ = _('Add a new translation to the dictionary.')
 
     TITLE = _('Add Translation')
-    ICON = ':/translation_add.svg'
+    ICON = 'plover:translation_add.svg'
     ROLE = 'add_translation'
     SHORTCUT = 'Ctrl+N'
 

--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -19,7 +19,7 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
     def __init__(self, engine, dictionary_path=None):
         super().__init__(engine)
         self.setupUi(self)
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
         self.add_translation.select_dictionary(dictionary_path)
         self.add_translation.mappingValid.connect(self.on_mapping_valid)
         engine.signal_connect('config_changed', self.on_config_changed)
@@ -29,7 +29,7 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
         self.finished.connect(self.save_state)
 
     def on_mapping_valid(self, valid):
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(valid)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(valid)
 
     def on_config_changed(self, config_update):
         if 'translation_frame_opacity' in config_update:

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -2,8 +2,8 @@ from collections import namedtuple
 from html import escape as html_escape
 from os.path import split as os_path_split
 
-from PyQt5.QtCore import QEvent, pyqtSignal
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import QEvent, Signal
+from qtpy.QtWidgets import QApplication, QWidget
 
 from plover import _
 from plover.misc import shorten_path
@@ -24,7 +24,7 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
     EngineState = namedtuple('EngineState', 'dictionary_filter translator starting_stroke')
 
-    mappingValid = pyqtSignal(bool)
+    mappingValid = Signal(bool)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -102,12 +102,12 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
         self._update_items()
 
     def eventFilter(self, watched, event):
-        if event.type() == QEvent.FocusIn:
+        if event.type() == QEvent.Type.FocusIn:
             if watched == self.strokes:
                 self._focus_strokes()
             elif watched == self.translation:
                 self._focus_translation()
-        elif event.type() == QEvent.FocusOut:
+        elif event.type() == QEvent.Type.FocusOut:
             if watched in (self.strokes, self.translation):
                 self._unfocus()
         return False

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -5,7 +5,6 @@ from functools import partial
 
 from PyQt5.QtCore import (
     Qt,
-    QVariant,
     pyqtSignal,
 )
 from PyQt5.QtWidgets import (
@@ -149,7 +148,7 @@ class TableOption(QTableWidget):
 
 class KeymapOption(TableOption):
 
-    valueChanged = pyqtSignal(QVariant)
+    valueChanged = pyqtSignal(object)
 
     class ItemDelegate(QStyledItemDelegate):
 
@@ -216,7 +215,7 @@ class KeymapOption(TableOption):
 
 class MultipleChoicesOption(TableOption):
 
-    valueChanged = pyqtSignal(QVariant)
+    valueChanged = pyqtSignal(object)
 
     LABELS = (
         # i18n: Widget: “MultipleChoicesOption”.

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -122,9 +122,9 @@ class TableOption(QTableWidget):
     def __init__(self):
         super().__init__()
         self.horizontalHeader().setStretchLastSection(True)
-        self.setSelectionMode(self.SingleSelection)
+        self.setSelectionMode(self.SelectionMode.SingleSelection)
         self.setTabKeyNavigation(False)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.verticalHeader().hide()
         self.currentItemChanged.connect(self._on_current_item_changed)
 
@@ -190,7 +190,7 @@ class KeymapOption(TableOption):
                 row += 1
                 self.insertRow(row)
                 item = QTableWidgetItem(key)
-                item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
                 self.setItem(row, 0, item)
                 item = QTableWidgetItem(action)
                 self.setItem(row, 1, item)
@@ -202,8 +202,8 @@ class KeymapOption(TableOption):
     def _on_cell_changed(self, row, column):
         if self._updating:
             return
-        key = self.item(row, 0).data(Qt.DisplayRole)
-        action = self.item(row, 1).data(Qt.DisplayRole)
+        key = self.item(row, 0).data(Qt.ItemDataRole.DisplayRole)
+        action = self.item(row, 1).data(Qt.ItemDataRole.DisplayRole)
         bindings = self._value.get_bindings()
         if action:
             bindings[key] = action
@@ -256,11 +256,11 @@ class MultipleChoicesOption(TableOption):
             row += 1
             self.insertRow(row)
             item = QTableWidgetItem(self._choices[choice])
-            item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+            item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
             self.setItem(row, 0, item)
             item = QTableWidgetItem()
-            item.setFlags((item.flags() & ~Qt.ItemIsEditable) | Qt.ItemIsUserCheckable)
-            item.setCheckState(Qt.Checked if choice in value else Qt.Unchecked)
+            item.setFlags((item.flags() & ~Qt.ItemFlag.ItemIsEditable) | Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(Qt.CheckState.Checked if choice in value else Qt.CheckState.Unchecked)
             self.setItem(row, 1, item)
         self.resizeColumnsToContents()
         self.setMinimumSize(self.viewportSizeHint())
@@ -270,7 +270,7 @@ class MultipleChoicesOption(TableOption):
         if self._updating:
             return
         assert column == 1
-        choice = self._reversed_choices[self.item(row, 0).data(Qt.DisplayRole)]
+        choice = self._reversed_choices[self.item(row, 0).data(Qt.ItemDataRole.DisplayRole)]
         if self.item(row, 1).checkState():
             self._value.add(choice)
         else:
@@ -436,8 +436,8 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                 (option_by_name[option_name], update_fn)
                 for option_name, update_fn in option.dependents
             ]
-        self.buttons.button(QDialogButtonBox.Ok).clicked.connect(self.on_apply)
-        self.buttons.button(QDialogButtonBox.Apply).clicked.connect(self.on_apply)
+        self.buttons.button(QDialogButtonBox.StandardButton.Ok).clicked.connect(self.on_apply)
+        self.buttons.button(QDialogButtonBox.StandardButton.Apply).clicked.connect(self.on_apply)
         self.tabs.currentWidget().setFocus()
         self.restore_state()
         self.finished.connect(self.save_state)
@@ -490,7 +490,7 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
 
     def keyPressEvent(self, event):
         # Disable Enter/Return key to trigger "OK".
-        if event.key() in (Qt.Key_Enter, Qt.Key_Return):
+        if event.key() in (Qt.Key.Key_Enter, Qt.Key.Key_Return):
             return
         super().keyPressEvent(event)
 

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -3,11 +3,11 @@ from collections import ChainMap
 from copy import copy
 from functools import partial
 
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     Qt,
-    pyqtSignal,
+    Signal,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialog,
@@ -36,7 +36,7 @@ from plover.gui_qt.utils import WindowState
 
 class NopeOption(QLabel):
 
-    valueChanged = pyqtSignal(bool)
+    valueChanged = Signal(bool)
 
     def __init__(self):
         super().__init__()
@@ -50,7 +50,7 @@ class NopeOption(QLabel):
 
 class BooleanOption(QCheckBox):
 
-    valueChanged = pyqtSignal(bool)
+    valueChanged = Signal(bool)
 
     def __init__(self):
         super().__init__()
@@ -72,7 +72,7 @@ class IntOption(QSpinBox):
 
 class ChoiceOption(QComboBox):
 
-    valueChanged = pyqtSignal(str)
+    valueChanged = Signal(str)
 
     def __init__(self, choices=None):
         super().__init__()
@@ -90,7 +90,7 @@ class ChoiceOption(QComboBox):
 
 class FileOption(QGroupBox, Ui_FileWidget):
 
-    valueChanged = pyqtSignal(str)
+    valueChanged = Signal(str)
 
     def __init__(self, dialog_title, dialog_filter):
         super().__init__()
@@ -148,7 +148,7 @@ class TableOption(QTableWidget):
 
 class KeymapOption(TableOption):
 
-    valueChanged = pyqtSignal(object)
+    valueChanged = Signal(object)
 
     class ItemDelegate(QStyledItemDelegate):
 
@@ -215,7 +215,7 @@ class KeymapOption(TableOption):
 
 class MultipleChoicesOption(TableOption):
 
-    valueChanged = pyqtSignal(object)
+    valueChanged = Signal(object)
 
     LABELS = (
         # i18n: Widget: “MultipleChoicesOption”.
@@ -280,7 +280,7 @@ class MultipleChoicesOption(TableOption):
 
 class BooleanAsDualChoiceOption(ChoiceOption):
 
-    valueChanged = pyqtSignal(bool)
+    valueChanged = Signal(bool)
 
     def __init__(self, choice_false, choice_true):
         choices = { False: choice_false, True: choice_true }

--- a/plover/gui_qt/config_window.ui
+++ b/plover/gui_qt/config_window.ui
@@ -15,7 +15,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources/resources.qrc">
-    <normaloff>:/plover.png</normaloff>:/plover.png</iconset>
+    <normaloff>:/plover/plover.png</normaloff>:/plover/plover.png</iconset>
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -29,6 +29,8 @@ from plover.gui_qt.utils import (
     CHECKED_TO_BOOL,
     ToolBar,
     obj_exec,
+    select_open_filenames,
+    select_save_filename,
 )
 
 
@@ -566,7 +568,7 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
             default_name = os.path.join(self._file_dialogs_directory, default_name)
         else:
             default_name = self._file_dialogs_directory
-        new_filename = QFileDialog.getSaveFileName(
+        new_filename = select_save_filename(
             parent=self, caption=title, directory=default_name,
             filter=_dictionary_filters(include_readonly=False),
         )[0]
@@ -636,7 +638,7 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
             self._engine.config = {}
 
     def on_open_dictionaries(self):
-        new_filenames = QFileDialog.getOpenFileNames(
+        new_filenames = select_open_filenames(
             # i18n: Widget: “DictionariesWidget”, “add” file picker.
             parent=self, caption=_('Load dictionaries'),
             directory=self._file_dialogs_directory,

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -496,7 +496,7 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
         assert not self._setup
         self._engine = engine
         self._model = DictionariesModel(engine, {
-            name: QIcon(':/dictionary_%s.svg' % name)
+            name: QIcon('plover:dictionary_%s.svg' % name)
             for name in 'favorite loading error readonly normal'.split()
         })
         self._model.has_undo_changed.connect(self.on_has_undo)

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -95,10 +95,13 @@ class DictionariesModel(QAbstractListModel):
         def is_loaded(self):
             return self.state not in {'loading', 'error'}
 
-    SUPPORTED_ROLES = {
-        Qt.ItemDataRole.AccessibleTextRole, Qt.ItemDataRole.CheckStateRole,
-        Qt.ItemDataRole.DecorationRole, Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.ToolTipRole
-    }
+    SUPPORTED_ROLES = sorted(int(r) for r in (
+            Qt.ItemDataRole.AccessibleTextRole,
+            Qt.ItemDataRole.CheckStateRole,
+            Qt.ItemDataRole.DecorationRole,
+            Qt.ItemDataRole.DisplayRole,
+            Qt.ItemDataRole.ToolTipRole,
+        ))
 
     FLAGS = Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable
 
@@ -354,12 +357,11 @@ class DictionariesModel(QAbstractListModel):
     def rowCount(self, parent=QModelIndex()):
         return 0 if parent.isValid() else len(self._from_row)
 
-    @classmethod
-    def flags(cls, index):
-        return cls.FLAGS if index.isValid() else Qt.ItemFlag.NoItemFlags
+    def flags(self, index):
+        return self.FLAGS if index.isValid() else Qt.ItemFlag.NoItemFlags
 
     def data(self, index, role):
-        if not index.isValid() or role not in self.SUPPORTED_ROLES:
+        if not index.isValid():
             return None
         d = self._from_row[index.row()]
         if role == Qt.ItemDataRole.DisplayRole:

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -96,11 +96,11 @@ class DictionariesModel(QAbstractListModel):
             return self.state not in {'loading', 'error'}
 
     SUPPORTED_ROLES = {
-        Qt.AccessibleTextRole, Qt.CheckStateRole,
-        Qt.DecorationRole, Qt.DisplayRole, Qt.ToolTipRole
+        Qt.ItemDataRole.AccessibleTextRole, Qt.ItemDataRole.CheckStateRole,
+        Qt.ItemDataRole.DecorationRole, Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.ToolTipRole
     }
 
-    FLAGS = Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsUserCheckable
+    FLAGS = Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable
 
     has_undo_changed = pyqtSignal(bool)
 
@@ -356,17 +356,17 @@ class DictionariesModel(QAbstractListModel):
 
     @classmethod
     def flags(cls, index):
-        return cls.FLAGS if index.isValid() else Qt.NoItemFlags
+        return cls.FLAGS if index.isValid() else Qt.ItemFlag.NoItemFlags
 
     def data(self, index, role):
         if not index.isValid() or role not in self.SUPPORTED_ROLES:
             return None
         d = self._from_row[index.row()]
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             return d.short_path
-        if role == Qt.CheckStateRole:
-            return Qt.Checked if d.enabled else Qt.Unchecked
-        if role == Qt.AccessibleTextRole:
+        if role == Qt.ItemDataRole.CheckStateRole:
+            return Qt.CheckState.Checked if d.enabled else Qt.CheckState.Unchecked
+        if role == Qt.ItemDataRole.AccessibleTextRole:
             accessible_text = [d.short_path]
             if not d.enabled:
                 # i18n: Widget: “DictionariesWidget”, accessible text.
@@ -385,9 +385,9 @@ class DictionariesModel(QAbstractListModel):
                 # i18n: Widget: “DictionariesWidget”, accessible text.
                 accessible_text.append(_('read-only'))
             return ', '.join(accessible_text)
-        if role == Qt.DecorationRole:
+        if role == Qt.ItemDataRole.DecorationRole:
             return self._icons.get('favorite' if d is self._favorite else d.state)
-        if role == Qt.ToolTipRole:
+        if role == Qt.ItemDataRole.ToolTipRole:
             # i18n: Widget: “DictionariesWidget”, tooltip.
             tooltip = [_('Full path: {path}.').format(path=d.config.path)]
             if d is self._favorite:
@@ -407,11 +407,11 @@ class DictionariesModel(QAbstractListModel):
         return None
 
     def setData(self, index, value, role):
-        if not index.isValid() or role != Qt.CheckStateRole:
+        if not index.isValid() or role != Qt.ItemDataRole.CheckStateRole:
             return False
-        if value == Qt.Checked:
+        if value == Qt.CheckState.Checked:
             enabled = True
-        elif value == Qt.Unchecked:
+        elif value == Qt.CheckState.Unchecked:
             enabled = False
         else:
             return False
@@ -487,7 +487,7 @@ class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
         edit_menu.addSeparator()
         edit_menu.addAction(self.action_MoveDictionariesUp)
         edit_menu.addAction(self.action_MoveDictionariesDown)
-        self.view.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.view.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.view.customContextMenuRequested.connect(
             lambda p: edit_menu.exec_(self.view.mapToGlobal(p)))
         self.edit_menu = edit_menu

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -1,14 +1,14 @@
 from contextlib import contextmanager
 import os
 
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QAbstractListModel,
     QModelIndex,
     Qt,
-    pyqtSignal,
+    Signal,
 )
-from PyQt5.QtGui import QCursor, QIcon
-from PyQt5.QtWidgets import (
+from qtpy.QtGui import QCursor, QIcon
+from qtpy.QtWidgets import (
     QFileDialog,
     QGroupBox,
     QMenu,
@@ -102,7 +102,7 @@ class DictionariesModel(QAbstractListModel):
 
     FLAGS = Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable
 
-    has_undo_changed = pyqtSignal(bool)
+    has_undo_changed = Signal(bool)
 
     def __init__(self, engine, icons, max_undo=20):
         super().__init__()
@@ -427,7 +427,7 @@ class DictionariesModel(QAbstractListModel):
 
 class DictionariesWidget(QGroupBox, Ui_DictionariesWidget):
 
-    add_translation = pyqtSignal(str)
+    add_translation = Signal(str)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/plover/gui_qt/dictionaries_widget.ui
+++ b/plover/gui_qt/dictionaries_widget.ui
@@ -82,7 +82,7 @@
   <action name="action_EditDictionaries">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/pencil.svg</normaloff>:/pencil.svg</iconset>
+     <normaloff>:/plover/pencil.svg</normaloff>:/plover/pencil.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Edit dictionaries</string>
@@ -97,7 +97,7 @@
   <action name="action_SaveDictionaries">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/save.svg</normaloff>:/save.svg</iconset>
+     <normaloff>:/plover/save.svg</normaloff>:/plover/save.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Save dictionaries as...</string>
@@ -112,7 +112,7 @@
   <action name="action_RemoveDictionaries">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/remove.svg</normaloff>:/remove.svg</iconset>
+     <normaloff>:/plover/remove.svg</normaloff>:/plover/remove.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Remove dictionaries</string>
@@ -127,7 +127,7 @@
   <action name="action_Undo">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/undo.svg</normaloff>:/undo.svg</iconset>
+     <normaloff>:/plover/undo.svg</normaloff>:/plover/undo.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Undo</string>
@@ -142,7 +142,7 @@
   <action name="action_AddDictionaries">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/add.svg</normaloff>:/add.svg</iconset>
+     <normaloff>:/plover/add.svg</normaloff>:/plover/add.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Add dictionaries</string>
@@ -157,7 +157,7 @@
   <action name="action_AddTranslation">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/translation_add.svg</normaloff>:/translation_add.svg</iconset>
+     <normaloff>:/plover/translation_add.svg</normaloff>:/plover/translation_add.svg</iconset>
    </property>
    <property name="text">
     <string>Add &amp;translation</string>
@@ -172,7 +172,7 @@
   <action name="action_MoveDictionariesUp">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/up.svg</normaloff>:/up.svg</iconset>
+     <normaloff>:/plover/up.svg</normaloff>:/plover/up.svg</iconset>
    </property>
    <property name="text">
     <string>Move dictionaries &amp;up</string>
@@ -184,7 +184,7 @@
   <action name="action_MoveDictionariesDown">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/down.svg</normaloff>:/down.svg</iconset>
+     <normaloff>:/plover/down.svg</normaloff>:/plover/down.svg</iconset>
    </property>
    <property name="text">
     <string>Move dictionaries &amp;down</string>

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -65,7 +65,7 @@ class DictionaryItemModel(QAbstractTableModel):
 
     def __init__(self, dictionary_list, sort_column, sort_order):
         super().__init__()
-        self._error_icon = QIcon(':/dictionary_error.svg')
+        self._error_icon = QIcon('plover:dictionary_error.svg')
         self._dictionary_list = dictionary_list
         self._operations = []
         self._entries = []

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -168,7 +168,7 @@ class DictionaryItemModel(QAbstractTableModel):
         return _COL_COUNT
 
     def headerData(self, section, orientation, role):
-        if orientation != Qt.Horizontal or role != Qt.DisplayRole:
+        if orientation != Qt.Orientation.Horizontal or role != Qt.ItemDataRole.DisplayRole:
             return None
         if section == _COL_STENO:
             # i18n: Widget: “DictionaryEditor”.
@@ -180,8 +180,14 @@ class DictionaryItemModel(QAbstractTableModel):
             # i18n: Widget: “DictionaryEditor”.
             return _('Dictionary')
 
+    DATA_ROLES = {
+        Qt.ItemDataRole.DecorationRole,
+        Qt.ItemDataRole.DisplayRole,
+        Qt.ItemDataRole.EditRole,
+    }
+
     def data(self, index, role):
-        if not index.isValid() or role not in (Qt.EditRole, Qt.DisplayRole, Qt.DecorationRole):
+        if not index.isValid() or role not in self.DATA_ROLES:
             return None
         item = self._entries[index.row()]
         column = index.column()
@@ -201,11 +207,11 @@ class DictionaryItemModel(QAbstractTableModel):
 
     def flags(self, index):
         if not index.isValid():
-            return Qt.NoItemFlags
-        f = Qt.ItemIsEnabled | Qt.ItemIsSelectable
+            return Qt.ItemFlag.NoItemFlags
+        f = Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
         item = self._entries[index.row()]
         if not item.dictionary.readonly:
-            f |= Qt.ItemIsEditable
+            f |= Qt.ItemFlag.ItemIsEditable
         return f
 
     def filter(self, strokes_filter=None, translation_filter=None):
@@ -226,13 +232,13 @@ class DictionaryItemModel(QAbstractTableModel):
         else:
             key = itemgetter(column)
         self._entries.sort(key=key,
-                           reverse=(order == Qt.DescendingOrder))
+                           reverse=(order == Qt.SortOrder.DescendingOrder))
         self._sort_column = column
         self._sort_order = order
         self.layoutChanged.emit()
 
-    def setData(self, index, value, role=Qt.EditRole, record=True):
-        assert role == Qt.EditRole
+    def setData(self, index, value, role=Qt.ItemDataRole.EditRole, record=True):
+        assert role == Qt.ItemDataRole.EditRole
         row = index.row()
         column = index.column()
         old_item = self._entries[row]
@@ -315,7 +321,7 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
                 for dictionary in engine.dictionaries.dicts
                 if dictionary.path in dictionary_paths
             ]
-        sort_column, sort_order = _COL_STENO, Qt.AscendingOrder
+        sort_column, sort_order = _COL_STENO, Qt.SortOrder.AscendingOrder
         self._model = DictionaryItemModel(dictionary_list,
                                           sort_column,
                                           sort_order)

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -3,13 +3,13 @@ from operator import attrgetter, itemgetter
 from collections import namedtuple
 from itertools import chain
 
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QAbstractTableModel,
     QModelIndex,
     Qt,
 )
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import (
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import (
     QComboBox,
     QDialog,
     QStyledItemDelegate,

--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -151,7 +151,7 @@
   <action name="action_Delete">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/remove.svg</normaloff>:/remove.svg</iconset>
+     <normaloff>:/plover/remove.svg</normaloff>:/plover/remove.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Delete</string>
@@ -166,7 +166,7 @@
   <action name="action_Undo">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/undo.svg</normaloff>:/undo.svg</iconset>
+     <normaloff>:/plover/undo.svg</normaloff>:/plover/undo.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Undo</string>
@@ -181,7 +181,7 @@
   <action name="action_New">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/add.svg</normaloff>:/add.svg</iconset>
+     <normaloff>:/plover/add.svg</normaloff>:/plover/add.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;New translation</string>

--- a/plover/gui_qt/engine.py
+++ b/plover/gui_qt/engine.py
@@ -1,6 +1,5 @@
 from PyQt5.QtCore import (
     QThread,
-    QVariant,
     pyqtSignal,
 )
 
@@ -11,12 +10,12 @@ from plover.oslayer.config import PLATFORM
 class Engine(StenoEngine, QThread):
 
     # Signals.
-    signal_stroked = pyqtSignal(QVariant)
-    signal_translated = pyqtSignal(QVariant, QVariant)
+    signal_stroked = pyqtSignal(object)
+    signal_translated = pyqtSignal(object, object)
     signal_machine_state_changed = pyqtSignal(str, str)
     signal_output_changed = pyqtSignal(bool)
-    signal_config_changed = pyqtSignal(QVariant)
-    signal_dictionaries_loaded = pyqtSignal(QVariant)
+    signal_config_changed = pyqtSignal(object)
+    signal_dictionaries_loaded = pyqtSignal(object)
     signal_send_string = pyqtSignal(str)
     signal_send_backspaces = pyqtSignal(int)
     signal_send_key_combination = pyqtSignal(str)

--- a/plover/gui_qt/engine.py
+++ b/plover/gui_qt/engine.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QThread,
-    pyqtSignal,
+    Signal,
 )
 
 from plover.engine import StenoEngine
@@ -10,21 +10,21 @@ from plover.oslayer.config import PLATFORM
 class Engine(StenoEngine, QThread):
 
     # Signals.
-    signal_stroked = pyqtSignal(object)
-    signal_translated = pyqtSignal(object, object)
-    signal_machine_state_changed = pyqtSignal(str, str)
-    signal_output_changed = pyqtSignal(bool)
-    signal_config_changed = pyqtSignal(object)
-    signal_dictionaries_loaded = pyqtSignal(object)
-    signal_send_string = pyqtSignal(str)
-    signal_send_backspaces = pyqtSignal(int)
-    signal_send_key_combination = pyqtSignal(str)
-    signal_add_translation = pyqtSignal()
-    signal_focus = pyqtSignal()
-    signal_configure = pyqtSignal()
-    signal_lookup = pyqtSignal()
-    signal_suggestions = pyqtSignal()
-    signal_quit = pyqtSignal()
+    signal_stroked = Signal(object)
+    signal_translated = Signal(object, object)
+    signal_machine_state_changed = Signal(str, str)
+    signal_output_changed = Signal(bool)
+    signal_config_changed = Signal(object)
+    signal_dictionaries_loaded = Signal(object)
+    signal_send_string = Signal(str)
+    signal_send_backspaces = Signal(int)
+    signal_send_key_combination = Signal(str)
+    signal_add_translation = Signal()
+    signal_focus = Signal()
+    signal_configure = Signal()
+    signal_lookup = Signal()
+    signal_suggestions = Signal()
+    signal_quit = Signal()
 
     def __init__(self, config, controller, keyboard_emulation):
         StenoEngine.__init__(self, config, controller, keyboard_emulation)

--- a/plover/gui_qt/log_qt.py
+++ b/plover/gui_qt/log_qt.py
@@ -1,14 +1,14 @@
 
 import logging
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from plover import log
 
 
 class NotificationHandler(QObject, logging.Handler):
 
-    emitSignal = pyqtSignal(int, str)
+    emitSignal = Signal(int, str)
 
     def __init__(self):
         super().__init__()

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -28,8 +28,8 @@ class LookupDialog(Tool, Ui_LookupDialog):
         self.finished.connect(self.save_state)
 
     def eventFilter(self, watched, event):
-        if event.type() == QEvent.KeyPress and \
-           event.key() in (Qt.Key_Enter, Qt.Key_Return):
+        if event.type() == QEvent.Type.KeyPress and \
+           event.key() in (Qt.Key.Key_Enter, Qt.Key.Key_Return):
             return True
         return False
 
@@ -44,6 +44,6 @@ class LookupDialog(Tool, Ui_LookupDialog):
 
     def changeEvent(self, event):
         super().changeEvent(event)
-        if event.type() == QEvent.ActivationChange and self.isActiveWindow():
+        if event.type() == QEvent.Type.ActivationChange and self.isActiveWindow():
             self.pattern.setFocus()
             self.pattern.selectAll()

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -1,5 +1,5 @@
 
-from PyQt5.QtCore import QEvent, Qt
+from qtpy.QtCore import QEvent, Qt
 
 from plover import _
 from plover.translation import unescape_translation

--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -14,7 +14,7 @@ class LookupDialog(Tool, Ui_LookupDialog):
     __doc__ = _('Search the dictionary for translations.')
 
     TITLE = _('Lookup')
-    ICON = ':/lookup.svg'
+    ICON = 'plover:lookup.svg'
     ROLE = 'lookup'
     SHORTCUT = 'Ctrl+L'
 

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -1,15 +1,15 @@
 from copy import copy
 from pathlib import Path
 
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import (
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import (
     QTextCharFormat,
     QTextFrameFormat,
     QTextListFormat,
     QTextCursor,
     QTextDocument,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QGroupBox,
     QStyledItemDelegate,
     QStyle,
@@ -112,7 +112,7 @@ class SerialOption(QGroupBox, Ui_SerialWidget):
             self._format_port(index)
             return self._doc.size().toSize()
 
-    valueChanged = pyqtSignal(object)
+    valueChanged = Signal(object)
 
     def __init__(self):
         super().__init__()
@@ -198,7 +198,7 @@ class SerialOption(QGroupBox, Ui_SerialWidget):
 
 class KeyboardOption(QGroupBox, Ui_KeyboardWidget):
 
-    valueChanged = pyqtSignal(object)
+    valueChanged = Signal(object)
 
     def __init__(self):
         super().__init__()

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -1,7 +1,7 @@
 from copy import copy
 from pathlib import Path
 
-from PyQt5.QtCore import Qt, QVariant, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import (
     QTextCharFormat,
     QTextFrameFormat,
@@ -112,7 +112,7 @@ class SerialOption(QGroupBox, Ui_SerialWidget):
             self._format_port(index)
             return self._doc.size().toSize()
 
-    valueChanged = pyqtSignal(QVariant)
+    valueChanged = pyqtSignal(object)
 
     def __init__(self):
         super().__init__()
@@ -198,7 +198,7 @@ class SerialOption(QGroupBox, Ui_SerialWidget):
 
 class KeyboardOption(QGroupBox, Ui_KeyboardWidget):
 
-    valueChanged = pyqtSignal(QVariant)
+    valueChanged = pyqtSignal(object)
 
     def __init__(self):
         super().__init__()

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import signal
 import sys
 
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QCoreApplication,
     QDir,
     QLibraryInfo,
@@ -11,7 +11,8 @@ from PyQt5.QtCore import (
     Qt,
     pyqtRemoveInputHook,
 )
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from qtpy.QtWidgets import QApplication, QMessageBox
+from qtpy import API as QT_API
 
 from plover import _, __name__ as __software_name__, __version__, log
 from plover.oslayer.keyboardcontrol import KeyboardEmulation
@@ -96,6 +97,7 @@ def default_excepthook(*exc_info):
 
 
 def main(config, controller):
+    log.info('using the `%s` API', QT_API)
     # Setup internationalization support.
     use_qt_notifications = not log.has_platform_handler()
     # Log GUI exceptions that make it back to the event loop.

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 import signal
 import sys
 
 from PyQt5.QtCore import (
     QCoreApplication,
+    QDir,
     QLibraryInfo,
     QTimer,
     QTranslator,
@@ -20,6 +22,10 @@ from plover.gui_qt.engine import Engine
 # Disable pyqtRemoveInputHook to avoid getting
 # spammed when using the debugger.
 pyqtRemoveInputHook()
+
+
+# Setup access to resources.
+QDir.addSearchPath('plover', str(Path(__file__).parent / 'resources'))
 
 
 class Application:

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -9,7 +9,6 @@ from qtpy.QtCore import (
     QTimer,
     QTranslator,
     Qt,
-    pyqtRemoveInputHook,
 )
 from qtpy.QtWidgets import QApplication, QMessageBox
 from qtpy import API as QT_API
@@ -22,7 +21,9 @@ from plover.gui_qt.engine import Engine
 
 # Disable pyqtRemoveInputHook to avoid getting
 # spammed when using the debugger.
-pyqtRemoveInputHook()
+if QT_API.startswith('pyqt'):
+    from qtpy.QtCore import pyqtRemoveInputHook
+    pyqtRemoveInputHook()
 
 
 # Setup access to resources.

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -41,12 +41,12 @@ class Application:
         QCoreApplication.setOrganizationDomain('openstenoproject.org')
 
         self._app = QApplication([sys.argv[0], '-name', 'plover'])
-        self._app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        self._app.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
 
         # Enable localization of standard Qt controls.
         log.info('setting language to: %s', _.lang)
         self._translator = QTranslator()
-        translations_dir = QLibraryInfo.location(QLibraryInfo.TranslationsPath)
+        translations_dir = QLibraryInfo.location(QLibraryInfo.LibraryLocation.TranslationsPath)
         self._translator.load('qtbase_' + _.lang, translations_dir)
         self._app.installTranslator(self._translator)
 

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -45,7 +45,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         self.dictionaries.add_translation.connect(self._add_translation)
         self.dictionaries.setup(engine)
         # Populate edit menu from dictionaries' own.
-        edit_menu = all_actions['menu_Edit'].menu()
+        __, edit_menu = all_actions['menu_Edit']
         for action in self.dictionaries.edit_menu.actions():
             edit_menu.addAction(action)
         # Tray icon.
@@ -72,7 +72,8 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             'action_Quit',
         ):
             if action_name:
-                popup_menu.addAction(all_actions[action_name])
+                action, __ = all_actions[action_name]
+                popup_menu.addAction(action)
             else:
                 popup_menu.addSeparator()
         self._trayicon.set_menu(popup_menu)
@@ -86,7 +87,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
             lambda: self.toolbar_menu.popup(QCursor.pos())
         )
         # Populate tools bar/menu.
-        tools_menu = all_actions['menu_Tools'].menu()
+        __, tools_menu = all_actions['menu_Tools']
         for tool_plugin in registry.list_plugins('gui.qt.tool'):
             tool = tool_plugin.obj
             menu_action = tools_menu.addAction(tool.TITLE)

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -4,9 +4,9 @@ import json
 import os
 import subprocess
 
-from PyQt5.QtCore import QCoreApplication, Qt
-from PyQt5.QtGui import QCursor, QIcon, QKeySequence
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import QCoreApplication, Qt
+from qtpy.QtGui import QCursor, QIcon, QKeySequence
+from qtpy.QtWidgets import (
     QMainWindow,
     QMenu,
 )

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -81,7 +81,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowState):
         self.action_Quit.triggered.connect(engine.quit)
         # Toolbar popup menu for selecting which tools are shown.
         self.toolbar_menu = QMenu()
-        self.toolbar.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.toolbar.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.toolbar.customContextMenuRequested.connect(
             lambda: self.toolbar_menu.popup(QCursor.pos())
         )

--- a/plover/gui_qt/main_window.ui
+++ b/plover/gui_qt/main_window.ui
@@ -24,7 +24,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources/resources.qrc">
-    <normaloff>:/plover.png</normaloff>:/plover.png</iconset>
+    <normaloff>:/plover/plover.png</normaloff>:/plover/plover.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
    <property name="sizePolicy">
@@ -87,7 +87,7 @@
          </property>
          <property name="icon">
           <iconset resource="resources/resources.qrc">
-           <normaloff>:/reconnect.svg</normaloff>:/reconnect.svg</iconset>
+           <normaloff>:/plover/reconnect.svg</normaloff>:/plover/reconnect.svg</iconset>
          </property>
         </widget>
        </item>
@@ -226,7 +226,7 @@
   <action name="action_Configure">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/settings.svg</normaloff>:/settings.svg</iconset>
+     <normaloff>:/plover/settings.svg</normaloff>:/plover/settings.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Configure</string>
@@ -241,7 +241,7 @@
   <action name="action_OpenConfigFolder">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/folder.svg</normaloff>:/folder.svg</iconset>
+     <normaloff>:/plover/folder.svg</normaloff>:/plover/folder.svg</iconset>
    </property>
    <property name="text">
     <string>Open config &amp;folder</string>
@@ -261,7 +261,7 @@
   <action name="action_Reconnect">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/reconnect.svg</normaloff>:/reconnect.svg</iconset>
+     <normaloff>:/plover/reconnect.svg</normaloff>:/plover/reconnect.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Reconnect machine</string>

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -17,7 +17,7 @@ from wcwidth import wcwidth
 from plover import _, system
 
 from plover.gui_qt.paper_tape_ui import Ui_PaperTape
-from plover.gui_qt.utils import ToolBar, select_font
+from plover.gui_qt.utils import ToolBar, obj_exec, select_font
 from plover.gui_qt.tool import Tool
 
 
@@ -208,7 +208,7 @@ class PaperTape(Tool, Ui_PaperTape):
         msgbox.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         # Make sure the message box ends up above the paper tape!
         msgbox.setWindowFlags(msgbox.windowFlags() | (flags & Qt.WindowType.WindowStaysOnTopHint))
-        if QMessageBox.StandardButton.Yes != msgbox.exec_():
+        if QMessageBox.StandardButton.Yes != obj_exec(msgbox):
             return
         self._strokes = []
         self.action_Clear.setEnabled(False)

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -105,7 +105,7 @@ class PaperTape(Tool, Ui_PaperTape):
     __doc__ = _('Paper tape display of strokes.')
 
     TITLE = _('Paper Tape')
-    ICON = ':/tape.svg'
+    ICON = 'plover:tape.svg'
     ROLE = 'paper_tape'
     SHORTCUT = 'Ctrl+T'
 

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -17,7 +17,7 @@ from wcwidth import wcwidth
 from plover import _, system
 
 from plover.gui_qt.paper_tape_ui import Ui_PaperTape
-from plover.gui_qt.utils import ToolBar
+from plover.gui_qt.utils import ToolBar, select_font
 from plover.gui_qt.tool import Tool
 
 
@@ -186,8 +186,8 @@ class PaperTape(Tool, Ui_PaperTape):
             self.tape.scrollToBottom()
 
     def on_select_font(self):
-        font, ok = QFontDialog.getFont(self.tape.font(), self, '',
-                                       QFontDialog.FontDialogOption.MonospacedFonts)
+        font, ok = select_font(self.tape.font(), self, '',
+                               QFontDialog.FontDialogOption.MonospacedFonts)
         if ok:
             self.header.setFont(font)
             self.tape.setFont(font)

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -1,12 +1,12 @@
 import time
 
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QAbstractListModel,
     QModelIndex,
     Qt,
 )
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import (
+from qtpy.QtGui import QFont
+from qtpy.QtWidgets import (
     QFileDialog,
     QFontDialog,
     QMessageBox,

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -71,12 +71,12 @@ class TapeModel(QAbstractListModel):
         if not index.isValid():
             return None
         stroke = self._stroke_list[index.row()]
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             if self._style == STYLE_PAPER:
                 return self._paper_format(stroke)
             if self._style == STYLE_RAW:
                 return self._raw_format(stroke)
-        if role == Qt.AccessibleTextRole:
+        if role == Qt.ItemDataRole.AccessibleTextRole:
             return stroke.rtfcre
         return None
 
@@ -152,7 +152,7 @@ class PaperTape(Tool, Ui_PaperTape):
     def _save_state(self, settings):
         settings.setValue('style', TAPE_STYLES.index(self._style))
         settings.setValue('font', self.tape.font().toString())
-        ontop = bool(self.windowFlags() & Qt.WindowStaysOnTopHint)
+        ontop = bool(self.windowFlags() & Qt.WindowType.WindowStaysOnTopHint)
         settings.setValue('ontop', ontop)
 
     def on_config_changed(self, config):
@@ -187,7 +187,7 @@ class PaperTape(Tool, Ui_PaperTape):
 
     def on_select_font(self):
         font, ok = QFontDialog.getFont(self.tape.font(), self, '',
-                                       QFontDialog.MonospacedFonts)
+                                       QFontDialog.FontDialogOption.MonospacedFonts)
         if ok:
             self.header.setFont(font)
             self.tape.setFont(font)
@@ -195,9 +195,9 @@ class PaperTape(Tool, Ui_PaperTape):
     def on_toggle_ontop(self, ontop):
         flags = self.windowFlags()
         if ontop:
-            flags |= Qt.WindowStaysOnTopHint
+            flags |= Qt.WindowType.WindowStaysOnTopHint
         else:
-            flags &= ~Qt.WindowStaysOnTopHint
+            flags &= ~Qt.WindowType.WindowStaysOnTopHint
         self.setWindowFlags(flags)
         self.show()
 
@@ -205,10 +205,10 @@ class PaperTape(Tool, Ui_PaperTape):
         flags = self.windowFlags()
         msgbox = QMessageBox()
         msgbox.setText(_('Do you want to clear the paper tape?'))
-        msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        msgbox.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         # Make sure the message box ends up above the paper tape!
-        msgbox.setWindowFlags(msgbox.windowFlags() | (flags & Qt.WindowStaysOnTopHint))
-        if QMessageBox.Yes != msgbox.exec_():
+        msgbox.setWindowFlags(msgbox.windowFlags() | (flags & Qt.WindowType.WindowStaysOnTopHint))
+        if QMessageBox.StandardButton.Yes != msgbox.exec_():
             return
         self._strokes = []
         self.action_Clear.setEnabled(False)
@@ -226,4 +226,4 @@ class PaperTape(Tool, Ui_PaperTape):
             return
         with open(filename, 'w') as fp:
             for row in range(self._model.rowCount(self._model.index(-1, -1))):
-                print(self._model.data(self._model.index(row, 0), Qt.DisplayRole), file=fp)
+                print(self._model.data(self._model.index(row, 0), Qt.ItemDataRole.DisplayRole), file=fp)

--- a/plover/gui_qt/paper_tape.ui
+++ b/plover/gui_qt/paper_tape.ui
@@ -155,7 +155,7 @@
  <connections>
   <connection>
    <sender>styles</sender>
-   <signal>activated(QString)</signal>
+   <signal>textActivated(QString)</signal>
    <receiver>PaperTape</receiver>
    <slot>on_style_changed()</slot>
    <hints>

--- a/plover/gui_qt/paper_tape.ui
+++ b/plover/gui_qt/paper_tape.ui
@@ -91,7 +91,7 @@
   <action name="action_Clear">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/trash.svg</normaloff>:/trash.svg</iconset>
+     <normaloff>:/plover/trash.svg</normaloff>:/plover/plover/trash.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Clear</string>
@@ -106,7 +106,7 @@
   <action name="action_Save">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/save.svg</normaloff>:/save.svg</iconset>
+     <normaloff>:/plover/save.svg</normaloff>:/plover/plover/save.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Save</string>
@@ -124,7 +124,7 @@
    </property>
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/pin.svg</normaloff>:/pin.svg</iconset>
+     <normaloff>:/plover/pin.svg</normaloff>:/plover/pin.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Toggle &quot;always on top&quot;</string>
@@ -139,7 +139,7 @@
   <action name="action_SelectFont">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/font_selector.svg</normaloff>:/font_selector.svg</iconset>
+     <normaloff>:/plover/font_selector.svg</normaloff>:/plover/font_selector.svg</iconset>
    </property>
    <property name="text">
     <string>Select &amp;font</string>

--- a/plover/gui_qt/resources/resources.qrc
+++ b/plover/gui_qt/resources/resources.qrc
@@ -1,5 +1,5 @@
 <RCC>
-  <qresource prefix="/">
+  <qresource prefix="plover">
     <file>folder.svg</file>
     <file>up.svg</file>
     <file>down.svg</file>

--- a/plover/gui_qt/steno_validator.py
+++ b/plover/gui_qt/steno_validator.py
@@ -7,17 +7,17 @@ class StenoValidator(QValidator):
 
     def validate(self, text, pos):
         if not text.strip('-/'):
-            state = QValidator.Intermediate
+            state = QValidator.State.Intermediate
         else:
             prefix = text.rstrip('-/')
             if text == prefix:
-                state = QValidator.Acceptable
+                state = QValidator.State.Acceptable
                 steno = text
             else:
-                state = QValidator.Intermediate
+                state = QValidator.State.Intermediate
                 steno = prefix
             try:
                 normalize_steno(steno)
             except ValueError:
-                state = QValidator.Invalid
+                state = QValidator.State.Invalid
         return state, text, pos

--- a/plover/gui_qt/steno_validator.py
+++ b/plover/gui_qt/steno_validator.py
@@ -1,4 +1,4 @@
-from PyQt5.QtGui import QValidator
+from qtpy.QtGui import QValidator
 
 from plover.steno import normalize_steno
 

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -17,7 +17,7 @@ from plover.suggestions import Suggestion
 from plover.formatting import RetroFormatter
 
 from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
-from plover.gui_qt.utils import ToolBar
+from plover.gui_qt.utils import ToolBar, select_font
 from plover.gui_qt.tool import Tool
 
 
@@ -153,7 +153,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             name = 'strokes_font'
             font_options = (QFontDialog.FontDialogOption.MonospacedFonts,)
         font = self._get_font(name)
-        font, ok = QFontDialog.getFont(font, self, '', *font_options)
+        font, ok = select_font(font, self, '', *font_options)
         if ok:
             self._set_font(name, font)
 

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -1,12 +1,12 @@
 
 import re
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import (
+from qtpy.QtCore import Qt
+from qtpy.QtGui import (
     QCursor,
     QFont,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QAction,
     QFontDialog,
     QMenu,

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -17,7 +17,7 @@ from plover.suggestions import Suggestion
 from plover.formatting import RetroFormatter
 
 from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
-from plover.gui_qt.utils import ToolBar, select_font
+from plover.gui_qt.utils import ToolBar, obj_exec, select_font
 from plover.gui_qt.tool import Tool
 
 
@@ -143,7 +143,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             self._show_suggestions(suggestion_list)
 
     def on_select_font(self):
-        action = self._font_menu.exec_(QCursor.pos())
+        action = obj_exec(self._font_menu, QCursor.pos())
         if action is None:
             return
         if action == self._font_menu_text:

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -27,7 +27,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
     __doc__ = _('Suggest possible strokes for the last written words.')
 
     TITLE = _('Suggestions')
-    ICON = ':/lightbulb.svg'
+    ICON = 'plover:lightbulb.svg'
     ROLE = 'suggestions'
     SHORTCUT = 'Ctrl+J'
 

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -95,7 +95,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             font = self._get_font(name)
             font_string = font.toString()
             settings.setValue(name, font_string)
-        ontop = bool(self.windowFlags() & Qt.WindowStaysOnTopHint)
+        ontop = bool(self.windowFlags() & Qt.WindowType.WindowStaysOnTopHint)
         settings.setValue('ontop', ontop)
 
     def _show_suggestions(self, suggestion_list):
@@ -151,7 +151,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             font_options = ()
         elif action == self._font_menu_strokes:
             name = 'strokes_font'
-            font_options = (QFontDialog.MonospacedFonts,)
+            font_options = (QFontDialog.FontDialogOption.MonospacedFonts,)
         font = self._get_font(name)
         font, ok = QFontDialog.getFont(font, self, '', *font_options)
         if ok:
@@ -160,9 +160,9 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
     def on_toggle_ontop(self, ontop):
         flags = self.windowFlags()
         if ontop:
-            flags |= Qt.WindowStaysOnTopHint
+            flags |= Qt.WindowType.WindowStaysOnTopHint
         else:
-            flags &= ~Qt.WindowStaysOnTopHint
+            flags &= ~Qt.WindowType.WindowStaysOnTopHint
         self.setWindowFlags(flags)
         self.show()
 

--- a/plover/gui_qt/suggestions_dialog.ui
+++ b/plover/gui_qt/suggestions_dialog.ui
@@ -33,7 +33,7 @@
   <action name="action_Clear">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/trash.svg</normaloff>:/trash.svg</iconset>
+     <normaloff>:/plover/trash.svg</normaloff>:/plover/trash.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Clear</string>
@@ -51,7 +51,7 @@
    </property>
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/pin.svg</normaloff>:/pin.svg</iconset>
+     <normaloff>:/plover/pin.svg</normaloff>:/plover/pin.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Toggle &quot;always on top&quot;</string>
@@ -66,7 +66,7 @@
   <action name="action_SelectFont">
    <property name="icon">
     <iconset resource="resources/resources.qrc">
-     <normaloff>:/font_selector.svg</normaloff>:/font_selector.svg</iconset>
+     <normaloff>:/plover/font_selector.svg</normaloff>:/plover/font_selector.svg</iconset>
    </property>
    <property name="text">
     <string>Select &amp;font</string>

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -32,7 +32,7 @@ class SuggestionsDelegate(QStyledItemDelegate):
         self._doc = QTextDocument()
         self._translation_char_format = QTextCharFormat()
         self._strokes_char_format = QTextCharFormat()
-        self._strokes_char_format.font().setStyleHint(QFont.Monospace)
+        self._strokes_char_format.font().setStyleHint(QFont.StyleHint.Monospace)
         self._size_hint_cache = {}
 
     def clear_size_hint_cache(self):
@@ -57,7 +57,7 @@ class SuggestionsDelegate(QStyledItemDelegate):
         self.clear_size_hint_cache()
 
     def _format_suggestion(self, index):
-        suggestion = index.data(Qt.DisplayRole)
+        suggestion = index.data(Qt.ItemDataRole.DisplayRole)
         translation = escape_translation(suggestion.text) + ':'
         if not suggestion.steno_list:
             translation += ' ' + NO_SUGGESTIONS_STRING
@@ -76,7 +76,7 @@ class SuggestionsDelegate(QStyledItemDelegate):
 
     def paint(self, painter, option, index):
         painter.save()
-        if option.state & QStyle.State_Selected:
+        if option.state & QStyle.StateFlag.State_Selected:
             painter.fillRect(option.rect, option.palette.highlight())
             text_color = option.palette.highlightedText()
         else:
@@ -115,9 +115,9 @@ class SuggestionsModel(QAbstractListModel):
         if not index.isValid():
             return None
         suggestion = self._suggestion_list[index.row()]
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             return suggestion
-        if role == Qt.AccessibleTextRole:
+        if role == Qt.ItemDataRole.AccessibleTextRole:
             translation = escape_translation(suggestion.text)
             if suggestion.steno_list:
                 steno = ', '.join('/'.join(strokes_list) for strokes_list in
@@ -143,7 +143,7 @@ class SuggestionsWidget(QListView):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self.setResizeMode(self.Adjust)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
         self._model = SuggestionsModel()
         self._delegate = SuggestionsDelegate(self)
         self.setModel(self._model)

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -1,16 +1,16 @@
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QAbstractListModel,
     QModelIndex,
     Qt,
 )
-from PyQt5.QtGui import (
+from qtpy.QtGui import (
     QFont,
     QFontMetrics,
     QTextCharFormat,
     QTextCursor,
     QTextDocument,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QListView,
     QStyle,
     QStyledItemDelegate,

--- a/plover/gui_qt/tool.py
+++ b/plover/gui_qt/tool.py
@@ -1,5 +1,5 @@
 
-from PyQt5.QtWidgets import QDialog
+from qtpy.QtWidgets import QDialog
 
 from plover.gui_qt.utils import WindowState
 

--- a/plover/gui_qt/trayicon.py
+++ b/plover/gui_qt/trayicon.py
@@ -42,7 +42,7 @@ class TrayIcon(QObject):
             self._trayicon.setContextMenu(menu)
 
     def show_message(self, message,
-                     icon=QSystemTrayIcon.Information,
+                     icon=QSystemTrayIcon.MessageIcon.Information,
                      timeout=10000):
         self._trayicon.showMessage(__software_name__.capitalize(),
                                    message, icon, timeout)
@@ -50,22 +50,22 @@ class TrayIcon(QObject):
     def log(self, level, message):
         if self._enabled:
             if level <= log.INFO:
-                icon = QSystemTrayIcon.Information
+                icon = QSystemTrayIcon.MessageIcon.Information
                 timeout = 10
             elif level <= log.WARNING:
-                icon = QSystemTrayIcon.Warning
+                icon = QSystemTrayIcon.MessageIcon.Warning
                 timeout = 15
             else:
-                icon = QSystemTrayIcon.Critical
+                icon = QSystemTrayIcon.MessageIcon.Critical
                 timeout = 25
             self.show_message(message, icon, timeout * 1000)
         else:
             if level <= log.INFO:
-                icon = QMessageBox.Information
+                icon = QMessageBox.Icon.Information
             elif level <= log.WARNING:
-                icon = QMessageBox.Warning
+                icon = QMessageBox.Icon.Warning
             else:
-                icon = QMessageBox.Critical
+                icon = QMessageBox.Icon.Critical
             msgbox = QMessageBox()
             msgbox.setText(message)
             msgbox.setIcon(icon)
@@ -134,5 +134,5 @@ class TrayIcon(QObject):
         )
 
     def _on_activated(self, reason):
-        if reason == QSystemTrayIcon.Trigger:
+        if reason == QSystemTrayIcon.ActivationReason.Trigger:
             self.clicked.emit()

--- a/plover/gui_qt/trayicon.py
+++ b/plover/gui_qt/trayicon.py
@@ -27,7 +27,7 @@ class TrayIcon(QObject):
             'disabled',
             'enabled',
         ):
-            icon = QIcon(':/state-%s.svg' % state)
+            icon = QIcon('plover:state-%s.svg' % state)
             if hasattr(icon, 'setIsMask'):
                 icon.setIsMask(True)
             self._state_icons[state] = icon

--- a/plover/gui_qt/trayicon.py
+++ b/plover/gui_qt/trayicon.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import QObject, pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QMessageBox, QSystemTrayIcon
+from qtpy.QtCore import QObject, Signal
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QMessageBox, QSystemTrayIcon
 
 from plover import _, __name__ as __software_name__
 from plover import log
@@ -107,7 +107,7 @@ class TrayIcon(QObject):
         self._is_running = enabled
         self._update_state()
 
-    clicked = pyqtSignal()
+    clicked = Signal()
 
     def _update_state(self):
         if self._machine_state not in (STATE_INITIALIZING, STATE_RUNNING):

--- a/plover/gui_qt/trayicon.py
+++ b/plover/gui_qt/trayicon.py
@@ -12,6 +12,8 @@ from plover.machine.base import (
     STATE_ERROR,
 )
 
+from plover.gui_qt.utils import obj_exec
+
 
 class TrayIcon(QObject):
 
@@ -69,7 +71,7 @@ class TrayIcon(QObject):
             msgbox = QMessageBox()
             msgbox.setText(message)
             msgbox.setIcon(icon)
-            msgbox.exec_()
+            obj_exec(msgbox)
 
     def is_supported(self):
         return self._supported

--- a/plover/gui_qt/utils.py
+++ b/plover/gui_qt/utils.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import (
     QToolButton,
     QWidget,
 )
+from qtpy import API as QT_API
 
 
 def ToolButton(action):
@@ -75,3 +76,15 @@ def find_menu_actions(menu):
         assert name not in actions_dict
         actions_dict[name] = action
     return actions_dict
+
+
+if QT_API.startswith('pyside'):
+
+    def select_font(*args, **kwargs):
+        ok, font = QFontDialog.getFont(*args, **kwargs)
+        return font, ok
+
+else:
+
+    def select_font(*args, **kwargs):
+        return QFontDialog.getFont(*args, **kwargs)

--- a/plover/gui_qt/utils.py
+++ b/plover/gui_qt/utils.py
@@ -1,6 +1,7 @@
 
-from PyQt5.QtCore import QSettings
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import QSettings
+from qtpy.QtWidgets import (
+    QFontDialog,
     QMainWindow,
     QToolBar,
     QToolButton,

--- a/plover/gui_qt/utils.py
+++ b/plover/gui_qt/utils.py
@@ -1,6 +1,7 @@
 
 from qtpy.QtCore import QSettings, Qt
 from qtpy.QtWidgets import (
+    QFileDialog,
     QFontDialog,
     QMainWindow,
     QMenu,
@@ -108,6 +109,13 @@ if QT_API == 'pyqt6':
         False: Qt.CheckState.Unchecked.value,
     }
 
+elif QT_API == 'pyside6':
+
+    BOOL_TO_CHECKED = {
+        True: int(Qt.CheckState.Checked),
+        False: int(Qt.CheckState.Unchecked),
+    }
+
 else:
 
     BOOL_TO_CHECKED = {
@@ -116,3 +124,20 @@ else:
     }
 
 CHECKED_TO_BOOL = {v: k for k, v in BOOL_TO_CHECKED.items()}
+
+
+if QT_API == 'pyside6':
+
+    def select_open_filenames(*args, directory=None, **kwargs):
+        return QFileDialog.getOpenFileNames(*args, dir=directory, **kwargs)
+
+    def select_save_filename(*args, directory=None, **kwargs):
+        return QFileDialog.getSaveFileName(*args, dir=directory, **kwargs)
+
+else:
+
+    def select_open_filenames(*args, **kwargs):
+        return QFileDialog.getOpenFileNames(*args, **kwargs)
+
+    def select_save_filename(*args, **kwargs):
+        return QFileDialog.getSaveFileName(*args, **kwargs)

--- a/plover_build_utils/functions.sh
+++ b/plover_build_utils/functions.sh
@@ -157,6 +157,7 @@ bootstrap_dist()
     -r reqs/dist_extra_gui_qt.txt \
     -r reqs/dist_extra_log.txt \
     -r reqs/dist_plugins.txt \
+    -r reqs/dist_pyqt5.txt \
     "$@" || die
   # Avoid caching Plover's wheel.
   run rm "$wheels_cache/$(basename "$wheel")"

--- a/plover_build_utils/pyqt.py
+++ b/plover_build_utils/pyqt.py
@@ -46,6 +46,18 @@ def fix_icons(contents):
     )
     return contents
 
+def fix_resources(contents):
+    # remove ``from . import resources_rc``,
+    # and replace ``addFile(":/prefix/font_selector.svg",``
+    # by ``addFile(":/prefix/font_selector.svg",``
+    contents = contents.replace('\nfrom . import resources_rc\n', '')
+    contents = re.sub(
+        r'\baddFile\(":/([^/]+)/([^"]+)",',
+        r'addFile("\1:\2",',
+        contents
+    )
+    return contents
+
 def gettext(contents):
     # replace ``_translate("context", `` by ``_(``
     contents = re.sub(r'\n', (

--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -91,6 +91,7 @@ class BuildUi(Command):
     hooks = '''
     plover_build_utils.pyqt:fix_icons
     plover_build_utils.pyqt:no_autoconnection
+    plover_build_utils.pyqt:use_scoped_enums
     '''.split()
 
     def initialize_options(self):

--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -92,6 +92,7 @@ class BuildUi(Command):
     plover_build_utils.pyqt:fix_icons
     plover_build_utils.pyqt:fix_resources
     plover_build_utils.pyqt:no_autoconnection
+    plover_build_utils.pyqt:use_qtpy
     plover_build_utils.pyqt:use_scoped_enums
     '''.split()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
 	"Babel",
-	"PyQt5>=5.8.2",
+	"PyQt5>=5.14",
 	"setuptools>=38.2.4",
 	"wheel",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,6 @@
 addopts = -ra
 markers =
 	gui_qt: GUI specific tests.
-qt_api = pyqt5
 testpaths =
 	test
 

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -47,7 +47,14 @@ pyparsing==3.0.3
 PyQt5==5.15.6
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.9.0
+PyQt6==6.3.1
+PyQt6-Qt6==6.3.1
+PyQt6-sip==13.4.0
 pyserial==3.5
+PySide2==5.15.2.1
+PySide6==6.3.1
+PySide6-Addons==6.3.1
+PySide6-Essentials==6.3.1
 pytest==6.2.5
 pytest-qt==4.0.2
 python-xlib==0.31
@@ -63,6 +70,8 @@ rfc3986==1.5.0
 rtf-tokenize==1.0.0
 SecretStorage==3.3.1
 setuptools==58.3.0
+shiboken2==5.15.2.1
+shiboken6==6.3.1
 six==1.16.0
 toml==0.10.2
 tomli==1.2.2

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -53,6 +53,7 @@ pytest-qt==4.0.2
 python-xlib==0.31
 pytz==2021.3
 PyYAML==6.0
+QtPy==2.1.0
 readme-renderer==30.0
 requests==2.26.0
 requests-cache==0.9.1

--- a/reqs/dist_extra_gui_qt.txt
+++ b/reqs/dist_extra_gui_qt.txt
@@ -1,3 +1,3 @@
-PyQt5>=5.5
+PyQt5>=5.11
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/reqs/dist_pyqt5.txt
+++ b/reqs/dist_pyqt5.txt
@@ -1,3 +1,3 @@
-QtPy
+PyQt5>=5.11
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/reqs/dist_pyqt5.txt
+++ b/reqs/dist_pyqt5.txt
@@ -1,3 +1,3 @@
-PyQt5>=5.11
+PyQt5>=5.14
 
 # vim: ft=cfg commentstring=#\ %s list

--- a/reqs/dist_pyqt6.txt
+++ b/reqs/dist_pyqt6.txt
@@ -1,0 +1,3 @@
+PyQt6
+
+# vim: ft=cfg commentstring=#\ %s list

--- a/reqs/dist_pyside2.txt
+++ b/reqs/dist_pyside2.txt
@@ -1,0 +1,3 @@
+PySide2
+
+# vim: ft=cfg commentstring=#\ %s list

--- a/reqs/dist_pyside6.txt
+++ b/reqs/dist_pyside6.txt
@@ -1,0 +1,3 @@
+PySide6
+
+# vim: ft=cfg commentstring=#\ %s list

--- a/reqs/setup.txt
+++ b/reqs/setup.txt
@@ -1,5 +1,5 @@
 Babel
-PyQt5>=5.8.2
+PyQt5>=5.14
 setuptools>=38.2.4
 wheel
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,12 +7,31 @@ from plover.config import DEFAULT_SYSTEM_NAME
 from plover.registry import registry
 
 
+# Set pytest-qt's API to QtPy's.
+try:
+    from qtpy import API as QT_API
+    from qtpy import QtCore
+except ImportError:
+    pass
+else:
+    os.environ['PYTEST_QT_API'] = QT_API
+
+
 @pytest.fixture(scope='session', autouse=True)
 def setup_plover():
     registry.update()
     system.setup(DEFAULT_SYSTEM_NAME)
 
 pytest.register_assert_rewrite('plover_build_utils.testing')
+
+def pytest_ignore_collect(path, config):
+    # Ignore `gui_qt` test during collection
+    # if pytest-qt is not available.
+    if 'gui_qt' not in str(path).split(os.path.sep):
+        return False
+    if config.pluginmanager.has_plugin('pytest-qt'):
+        return False
+    return True
 
 def pytest_collection_modifyitems(items):
     for item in items:

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from types import SimpleNamespace
 import operator
 
-from PyQt5.QtCore import (
+from qtpy.QtCore import (
     QAbstractListModel,
     QItemSelectionModel,
     QModelIndex,

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -803,12 +803,13 @@ def widget_test(model_test, monkeypatch, qtbot):
     registry = mock.MagicMock(spec=['list_plugins'])
     registry.list_plugins.side_effect = list_plugins
     monkeypatch.setattr('plover.gui_qt.dictionaries_widget.registry', registry)
-    # Fake file dialog.
+    # Fake calls to file dialog.
     file_dialog = mock.MagicMock(spec='''
-                                 getOpenFileNames
-                                 getSaveFileName
+                                 select_open_filenames
+                                 select_save_filename
                                  '''.split())
-    monkeypatch.setattr('plover.gui_qt.dictionaries_widget.QFileDialog', file_dialog)
+    monkeypatch.setattr('plover.gui_qt.dictionaries_widget.select_open_filenames', file_dialog.select_open_filenames)
+    monkeypatch.setattr('plover.gui_qt.dictionaries_widget.select_save_filename', file_dialog.select_save_filename)
     # Fake `create_dictionary`.
     def create_dictionary(filename, threaded_save=True):
         pass
@@ -900,7 +901,7 @@ def test_widget_save_copy_1(widget_test):
         '',
         expand_path('read-only_copy.json'),
     )
-    widget_test.file_dialog.getSaveFileName.side_effect = [
+    widget_test.file_dialog.select_save_filename.side_effect = [
         [name]
         for name in copy_names
     ]
@@ -914,7 +915,7 @@ def test_widget_save_copy_1(widget_test):
     widget_test.widget.action_CopyDictionaries.trigger()
     # Check.
     assert widget_test.file_dialog.mock_calls == [
-        mock.call.getSaveFileName(
+        mock.call.select_save_filename(
             parent=widget_test.widget,
             caption='Save a copy of %s as...' % name,
             directory=expand_path('%s - Copy.json' % Path(name).stem),
@@ -945,12 +946,12 @@ def test_widget_save_merge_1(widget_test):
     '''
     # Setup.
     merge_name = 'favorite + normal + read-only'
-    widget_test.file_dialog.getSaveFileName.return_value = [expand_path('merge.json')]
+    widget_test.file_dialog.select_save_filename.return_value = [expand_path('merge.json')]
     # Execution.
     widget_test.select(range(5))
     widget_test.widget.action_MergeDictionaries.trigger()
     # Check.
-    assert widget_test.file_dialog.mock_calls == [mock.call.getSaveFileName(
+    assert widget_test.file_dialog.mock_calls == [mock.call.select_save_filename(
         parent=widget_test.widget,
         caption='Merge %s as...' % merge_name,
         directory=expand_path(merge_name + '.json'),
@@ -975,12 +976,12 @@ def test_widget_save_merge_2(widget_test):
     '''
     # Setup.
     merge_name = 'favorite + normal'
-    widget_test.file_dialog.getSaveFileName.return_value = ['']
+    widget_test.file_dialog.select_save_filename.return_value = ['']
     # Execution.
     widget_test.select([0, 2])
     widget_test.widget.action_MergeDictionaries.trigger()
     # Check.
-    assert widget_test.file_dialog.mock_calls == [mock.call.getSaveFileName(
+    assert widget_test.file_dialog.mock_calls == [mock.call.select_save_filename(
         parent=widget_test.widget,
         caption='Merge %s as...' % merge_name,
         directory=expand_path(merge_name + '.json'),

--- a/test/gui_qt/test_steno_validator.py
+++ b/test/gui_qt/test_steno_validator.py
@@ -7,21 +7,21 @@ from plover.gui_qt.steno_validator import StenoValidator
 
 @pytest.mark.parametrize(('text', 'state'), (
     # Acceptable.
-    ('ST', QValidator.Acceptable),
-    ('TEFT', QValidator.Acceptable),
-    ('TEFT/-G', QValidator.Acceptable),
-    ('/ST', QValidator.Acceptable),
-    ('-F', QValidator.Acceptable),
+    ('ST', QValidator.State.Acceptable),
+    ('TEFT', QValidator.State.Acceptable),
+    ('TEFT/-G', QValidator.State.Acceptable),
+    ('/ST', QValidator.State.Acceptable),
+    ('-F', QValidator.State.Acceptable),
     # Intermediate.
-    ('-', QValidator.Intermediate),
-    ('/', QValidator.Intermediate),
-    ('/-', QValidator.Intermediate),
-    ('ST/', QValidator.Intermediate),
-    ('ST/-', QValidator.Intermediate),
-    ('ST//', QValidator.Intermediate),
+    ('-', QValidator.State.Intermediate),
+    ('/', QValidator.State.Intermediate),
+    ('/-', QValidator.State.Intermediate),
+    ('ST/', QValidator.State.Intermediate),
+    ('ST/-', QValidator.State.Intermediate),
+    ('ST//', QValidator.State.Intermediate),
     # Invalid.
-    ('WK', QValidator.Invalid),
-    ('PLOVER', QValidator.Invalid),
+    ('WK', QValidator.State.Invalid),
+    ('PLOVER', QValidator.State.Invalid),
 ))
 def test_steno_validator_validate(text, state):
     validator = StenoValidator()

--- a/test/gui_qt/test_steno_validator.py
+++ b/test/gui_qt/test_steno_validator.py
@@ -1,4 +1,4 @@
-from PyQt5.QtGui import QValidator
+from qtpy.QtGui import QValidator
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,8 @@ deps =
 	-r
 	reqs/dist_extra_log.txt
 	-r
+	reqs/dist_pyqt5.txt
+	-r
 	reqs/packaging.txt
 	-r
 	reqs/release.txt


### PR DESCRIPTION
## Summary of changes

With the Qt5 LTS support moved to [commercial only](https://www.phoronix.com/scan.php?page=news_item&px=Qt-5.15-LTS-Commercial-Phase), the only maintained version seems to be the KDE version, which is shipped by some distributions.

The first Q6 LTS release is also [available](https://www.phoronix.com/scan.php?page=news_item&px=Qt-6.2-LTS-Released), and there are now alternatives to PyQt5 / PyQt6: the official [PySide2](https://pypi.org/project/PySide2/) / [PySide6](https://pypi.org/project/PySide6/#description) bindings.

The 4 sets of bindings are mostly compatible.

By switching to [QtPy](https://pypi.org/project/QtPy/), an abstraction layer for PyQt5/PyQt4/PySide2/PySide, and with a few compatibility fixes, we can target PyQt5, PySide2, PyQt6 and PySide6, making the transition to another set of bindings easier (and transparent for plugins).

Main changes:
- import from `qtpy`
- don't use `QVariant` when declaring signals (just use `object`).
- use scoped enums accesses: e.g. `QDialogButtonBox.StandardButton.Ok` instead of `QDialogButtonBox.Ok`. Necessary for Qt6 compatibility, increases our minimum supported version of PyQt5 to 5.11 (released in 2018).
- ~switch to the official `uic` and `rcc` helpers (provided by [qt5-applications](https://pypi.org/project/qt5-applications/)) for generating UI files, including resources, as PyQt6 drops support for `pyrcc`.~
- load resources directly from filesystem (no need for `pyrcc5` anymore).
- use the `QComboBox` `textActivated(QString)` signal instead of `activated(QString)`. Necessary for Qt6 compatibility, increases our minimum supported version of PyQt5 to 5.14 (released in 2019).
- a few other minor compatibility fixes for supporting PySide2 / PySide6 / PyQt6 / Qt6.

Known issues:
- ~the `qt5-applications` Windows' wheels are missing the `rcc` executable (reported [here](https://github.com/altendky/qt-applications/issues/21)).~
- ~the official `uic` Python generator may generate invalid strings for some Unicode characters (like for [this one in the `plover_wpm_meter` plugin](https://github.com/arxanas/plover_wpm_meter/blob/master/plover_wpm_meter/wpm_meter.ui#L113)).~
- ~the dictionaries widget checkboxes don't work correctly with PyQt6 / PySide6~

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
