### PR TITLE
reqs: update `PyQt5` to latest bugfix release

### DIFF
--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -45,7 +45,7 @@ pyobjc-core==7.3
 pyobjc-framework-Cocoa==7.3
 pyobjc-framework-Quartz==7.3
 pyparsing==3.0.3
-PyQt5==5.15.5
+PyQt5==5.15.6
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.9.0
 pyserial==3.5


### PR DESCRIPTION
A minor bugfix release: https://www.riverbankcomputing.com/news/PyQt_v5.15.6_Released.
