### PR TITLE
steno: fix `Stroke` implementation

### DIFF
--- a/news.d/feature/1452.core.md
+++ b/news.d/feature/1452.core.md
@@ -1,0 +1,1 @@
+Switch to `plover_stroke` for better steno handling: faster and stricter.

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -25,8 +25,6 @@ from plover.registry import registry
 from plover import system
 
 
-PREFIX_STROKE = Stroke(())
-
 _ESCAPE_RX = re.compile('(\\\\[nrt]|[\n\r\t])')
 _ESCAPE_REPLACEMENTS = {
     '\n': r'\n',
@@ -388,7 +386,7 @@ class Translator:
 
     def _lookup_with_prefix(self, last_translations, strokes, suffixes=()):
         if self._previous_word_is_finished(last_translations):
-            mapping = self.lookup([PREFIX_STROKE] + strokes, suffixes)
+            mapping = self.lookup([Stroke.PREFIX_STROKE] + strokes, suffixes)
             if mapping is not None:
                 return mapping
         return self.lookup(strokes, suffixes)

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -34,7 +34,7 @@ pep517==0.12.0
 pip==21.3.1
 pkginfo==1.7.1
 plover-plugins-manager==0.7.0
-plover-stroke==1.0.0
+plover-stroke==1.0.1
 plover-treal==1.0.1
 pluggy==1.0.0
 plyer==2.0.0

--- a/reqs/dist.txt
+++ b/reqs/dist.txt
@@ -1,6 +1,6 @@
 appdirs>=1.3.0
 appnope>=0.1.0; "darwin" in sys_platform
-plover-stroke>=1.0.0dev4
+plover-stroke>=1.0.0
 pyobjc-core>=4.0; "darwin" in sys_platform
 pyobjc-framework-Cocoa>=4.0; "darwin" in sys_platform
 pyobjc-framework-Quartz>=4.0; "darwin" in sys_platform

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -4,6 +4,7 @@ import pytest
 
 from plover import system
 from plover.registry import Registry
+from plover.system import english_stenotype
 
 from plover_build_utils.testing import blackbox_test
 
@@ -43,11 +44,11 @@ def with_melani_system(monkeypatch, request):
         DICTIONARIES_ROOT = None
         DEFAULT_DICTIONARIES = ()
     registry = Registry()
+    registry.register_plugin('system', 'English Stenotype', english_stenotype)
     registry.register_plugin('system', 'Melani', Melani)
     old_system_name = system.NAME
     with monkeypatch.context() as mp:
         mp.setattr('plover.system.registry', registry)
-        system.setup('Melani')
         yield
     system.setup(old_system_name)
 
@@ -1668,6 +1669,7 @@ class TestsBlackbox:
 
     def test_melani_implicit_hyphens(self, with_melani_system):
         r'''
+        :system Melani
         "15/SE/COhro": "XV secolo",
         "16/SE/COhro": "XVI secolo",
 

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -56,11 +56,10 @@ def with_melani_system(monkeypatch, request):
 class TestsBlackbox:
 
     def test_translator_state_handling(self):
-        r'''
         # Check if the translator curtailing the list of last translations
         # according to its dictionary longest key does no affect things
         # like the restrospective repeat-last-stroke command.
-
+        r'''
         "TEFT": "test",
         "R*S": "{*+}",
 
@@ -76,20 +75,18 @@ class TestsBlackbox:
         '''
 
     def test_bug471(self):
-        r'''
         # Repeat-last-stroke after typing two numbers outputs the numbers
         # reversed for some combos.
-
+        r'''
         "R*S": "{*+}",
 
         12/R*S  " 1212"
         '''
 
     def test_bug535(self):
-        r'''
         # Currency formatting a number with a decimal fails by not erasing
         # the previous output.
-
+        r'''
         "P-P": "{^.^}",
         "KR*UR": "{*($c)}",
 
@@ -107,10 +104,9 @@ class TestsBlackbox:
         '''
 
     def test_bug535_spaces_after(self):
-        r'''
         # Currency formatting a number with a decimal fails by not erasing
         # the previous output.
-
+        r'''
         "P-P": "{^.^}",
         "KR*UR": "{*($c)}",
 
@@ -204,11 +200,10 @@ class TestsBlackbox:
         '''
 
     def test_bug557(self):
-        r'''
         # Using the asterisk key to delete letters in fingerspelled words
         # occasionally causes problems when the space placement is set to
         # "After Output".
-
+        r'''
         "EU": "I",
         "HRAOEUBG": "like",
         "T*": "{>}{&t}",
@@ -222,11 +217,10 @@ class TestsBlackbox:
         '''
 
     def test_bug557_resumed(self):
-        r'''
         # Using the asterisk key to delete letters in fingerspelled words
         # occasionally causes problems when the space placement is set to
         # "After Output".
-
+        r'''
         "EU": "I",
         "HRAOEUBG": "like",
         "T*": "{>}{&t}",
@@ -240,11 +234,10 @@ class TestsBlackbox:
         '''
 
     def test_bug557_capitalized(self):
-        r'''
         # Using the asterisk key to delete letters in fingerspelled words
         # occasionally causes problems when the space placement is set to
         # "After Output".
-
+        r'''
         "EU": "I",
         "HRAOEUBG": "like",
         "T*": "{-|}{&t}",
@@ -289,9 +282,8 @@ class TestsBlackbox:
         '''
 
     def test_bug719(self):
-        r'''
         # Glue (&) does not work with "Spaces After".
-
+        r'''
         "P*": "{&P}"
 
         :spaces_after
@@ -299,9 +291,8 @@ class TestsBlackbox:
         '''
 
     def test_bug741(self):
-        r'''
         # Uppercase last word also uppercases next word's prefix.
-
+        r'''
         "KPA*TS": "{*<}",
         "TPAO": "foo",
         "KAUPB": "{con^}",


### PR DESCRIPTION
## Summary of changes
Ensure instances stay valid after a system change. See the blackbox tests for details.

Closes #1448.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
