### PR TITLE
 Fix QT GUI tests

### DIFF
--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -29,6 +29,7 @@ Jinja2==3.0.2
 keyring==23.2.1
 mac-alias==2.2.0
 MarkupSafe==2.0.1
+mock==4.0.3
 packaging==21.0
 pep517==0.12.0
 pip==21.3.1

--- a/reqs/test.txt
+++ b/reqs/test.txt
@@ -1,3 +1,4 @@
+mock>=3.0.0
 pytest
 pytest-qt
 

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -2,11 +2,11 @@ from collections import namedtuple
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
-from unittest import mock
 import operator
 
 from PyQt5.QtCore import QModelIndex, QPersistentModelIndex, Qt
 
+import mock
 import pytest
 
 from plover.config import DictionaryConfig

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -1,8 +1,8 @@
 from functools import partial
-from unittest.mock import MagicMock
 import os
 import tempfile
 
+from mock import MagicMock
 import pytest
 
 from plover import system

--- a/test/test_keyboard.py
+++ b/test/test_keyboard.py
@@ -1,6 +1,4 @@
-
-from unittest.mock import MagicMock, call, patch
-
+from mock import MagicMock, call, patch
 import pytest
 
 from plover import system

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ description = run tests using {envname}
 base_python = {envname}
 envdir = {toxworkdir}/{envname}
 extras =
+	gui_qt
 deps =
 	-c
 	reqs/constraints.txt
@@ -76,6 +77,8 @@ deps =
 	reqs/setup.txt
 	-r
 	reqs/test.txt
+setenv =
+	{[testenv:test]setenv}
 commands =
 	{[testenv:test]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,8 @@ deps =
 	-r
 	reqs/dist.txt
 	-r
+	reqs/setup.txt
+	-r
 	reqs/test.txt
 commands =
 	{[testenv:test]commands}


### PR DESCRIPTION
## Summary of changes

* fix tox lightweight tests environment so the QT GUI tests can be run
* add `mock` to the tests dependencies: the standard library version provided by Python <= 3.7 is too old