### PR TITLE
dictionary: fix KHR*PB stroke

### DIFF
--- a/news.d/bugfix/1463.dict.md
+++ b/news.d/bugfix/1463.dict.md
@@ -1,0 +1,1 @@
+Fix `KHR*PB` stroke to not be misinterpreted as a command.


### PR DESCRIPTION
Currently, this entry gets misparsed as a command and thus throws an
exception. Change it to do a raw attach as suggested in
https://github.com/openstenoproject/plover/issues/1407#issuecomment-914881597

Fix #1407.

Thanks @sammdot 

<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

`{:^}` is parsed as the command `^` incorrectly.
<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
