### PR TITLE
Don't carry capitalisation when translating {\cxfing }

### DIFF
--- a/news.d/bugfix/1480.core.md
+++ b/news.d/bugfix/1480.core.md
@@ -1,0 +1,2 @@
+Small changes to RTF/CRE:
+ - Don't carry capitalisation when translating lower case `{\cxfing}` entries

--- a/plover/dictionary/rtfcre_parse.py
+++ b/plover/dictionary/rtfcre_parse.py
@@ -179,6 +179,8 @@ def parse_rtfcre(text, normalize=lambda s: s, skip_errors=True):
             # Fingerspelling.
             elif g_destination == 'cxfing':
                 text = '{&' + g_text + '}'
+                if g_text.islower():
+                    text = '{>}' + text
             # Plover macro.
             elif g_destination == 'cxplovermacro':
                 text = '=' + g_text

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -338,7 +338,8 @@ RTF_LOAD_TESTS = (
     lambda: rtf_load_test(r'{\cxstit contents}', 'contents'),
 
     # Fingerspelling.
-    lambda: rtf_load_test(r'{\cxfing c}', '{&c}'),
+    lambda: rtf_load_test(r'{\cxfing c}', '{>}{&c}'),
+    lambda: rtf_load_test(r'{\cxfing C}', '{&C}'),
     lambda: rtf_load_test(r'\cxfing Z.', '{&Z.}'),
 
     # Punctuation.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes
In plovers main.json the fingerspelling entries for lowercase characters
are defined as `{>}{&a}` whereas the uppercase characters are defined
as `{&A}`. This patch makes it so that fingerspelling entries from
RTF dictionaries are translated in the same way.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
