### PR TITLE
Fix setuptools warning

### DIFF
--- a/plover_build_utils/setup.py
+++ b/plover_build_utils/setup.py
@@ -1,4 +1,3 @@
-from distutils import log
 import contextlib
 import importlib
 import os
@@ -110,7 +109,7 @@ class BuildUi(Command):
             '--from-import', src,
         )
         if self.verbose:
-            log.info('generating %s', dst)
+            print('generating', dst)
         contents = subprocess.check_output(cmd).decode('utf-8')
         for hook in self.hooks:
             mod_name, attr_name = hook.split(':')
@@ -130,7 +129,7 @@ class BuildUi(Command):
             src, '-o', dst,
         )
         if self.verbose:
-            log.info('generating %s', dst)
+            print('generating', dst)
         subprocess.check_call(cmd)
 
     def run(self):
@@ -140,7 +139,8 @@ class BuildUi(Command):
             h[len(std_hook_prefix):] if h.startswith(std_hook_prefix) else h
             for h in self.hooks
         ]
-        log.info('generating ui (hooks: %s)', ', '.join(hooks_info))
+        if self.verbose:
+            print('generating UI using hooks:', ', '.join(hooks_info))
         ei_cmd = self.get_finalized_command('egg_info')
         for src in ei_cmd.filelist.files:
             if src.endswith('.qrc'):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2010 Joshua Harlan Lifton.
 # See LICENSE.txt for details.
 
-from distutils import log
 import os
 import re
 import subprocess
@@ -92,7 +91,8 @@ class BinaryDistWin(Command):
         if self.zipdir:
             cmd.append('--zipdir')
         cmd.extend((__software_name__, __version__, self.bdist_wheel()))
-        log.info('running %s', ' '.join(cmd))
+        if self.verbose:
+            print('running', ' '.join(cmd))
         subprocess.check_call(cmd)
 
 if sys.platform.startswith('win32'):
@@ -153,7 +153,8 @@ class PatchVersion(Command):
             version = get_version()
             if version is None:
                 sys.exit(1)
-        log.info('patching version to %s', version)
+        if self.verbose:
+            print('patching version to', version)
         version_file = os.path.join('plover', '__init__.py')
         with open(version_file, 'r') as fp:
             contents = fp.read().split('\n')
@@ -181,7 +182,8 @@ class BinaryDistApp(Command):
 
     def run(self):
         cmd = ['bash', 'osx/make_app.sh', self.bdist_wheel()]
-        log.info('running %s', ' '.join(cmd))
+        if self.verbose:
+            print('running', ' '.join(cmd))
         subprocess.check_call(cmd)
 
 class BinaryDistDmg(Command):
@@ -205,7 +207,8 @@ class BinaryDistDmg(Command):
             name=__software_name__.capitalize(),
             settings='osx/dmg_resources/settings.py',
         )
-        log.info('running dmgbuild(%s)', args)
+        if self.verbose:
+            print('running dmgbuild(%s)' % args)
         script = "__import__('dmgbuild').build_dmg(" + args + ')'
         subprocess.check_call((sys.executable, '-u', '-c', script))
 
@@ -246,7 +249,8 @@ class BinaryDistAppImage(Command):
         if self.no_update_tools:
             cmd.append('--no-update-tools')
         cmd.extend(('--wheel', self.bdist_wheel()))
-        log.info('running %s', ' '.join(cmd))
+        if self.verbose:
+            print('running', ' '.join(cmd))
         subprocess.check_call(cmd)
 
 if sys.platform.startswith('linux'):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix deprecation warning:
```
setup.py:5: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils import log
```