### PR TITLE
Partially drop the dependency on `pkg_resources`

### DIFF
--- a/plover/i18n.py
+++ b/plover/i18n.py
@@ -2,9 +2,8 @@ import os
 import locale
 import gettext
 
-import pkg_resources
-
 from plover.oslayer.config import CONFIG_DIR, PLATFORM
+from plover.resource import ASSET_SCHEME, resource_filename
 
 
 def get_language():
@@ -29,13 +28,10 @@ def get_language():
     return lang
 
 def get_locale_dir(package, resource_dir):
-    for locale_dir in [
-        os.path.join(CONFIG_DIR, 'messages'),
-        pkg_resources.resource_filename(package, resource_dir),
-    ]:
-        if gettext.find(package, locale_dir):
-            break
-    return locale_dir
+    locale_dir = os.path.join(CONFIG_DIR, 'messages')
+    if gettext.find(package, locale_dir):
+        return locale_dir
+    return resource_filename(f'{ASSET_SCHEME}{package}:{resource_dir}')
 
 
 class Translator:

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -54,10 +54,3 @@ PLUGINS_PLATFORM = PLATFORM
 plover_dist = pkg_resources.working_set.by_key['plover']
 
 ASSETS_DIR = plover_dist.get_resource_filename(__name__, 'plover/assets')
-
-# Is support for the QT GUI available?
-HAS_GUI_QT = True
-for req in plover_dist.requires(('gui_qt',)):
-    if pkg_resources.working_set.find(req) is None:
-        HAS_GUI_QT = False
-        break

--- a/plover/oslayer/config.py
+++ b/plover/oslayer/config.py
@@ -7,7 +7,6 @@ import os
 import sys
 
 import appdirs
-import pkg_resources
 
 
 if sys.platform.startswith('darwin'):
@@ -51,6 +50,4 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, CONFIG_BASENAME)
 # Setup plugins directory.
 PLUGINS_PLATFORM = PLATFORM
 
-plover_dist = pkg_resources.working_set.by_key['plover']
-
-ASSETS_DIR = plover_dist.get_resource_filename(__name__, 'plover/assets')
+ASSETS_DIR = os.path.realpath(os.path.join(__file__, '../../assets'))

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -1,4 +1,3 @@
-
 from collections import namedtuple
 
 import pkg_resources
@@ -16,7 +15,7 @@ class Plugin:
         self.__doc__ = obj.__doc__ or ''
 
     def __str__(self):
-        return '%s:%s' % (self.plugin_type, self.name)
+        return f'{self.plugin_type}:{self.name}'
 
 
 PluginDistribution = namedtuple('PluginDistribution', 'dist plugins')
@@ -91,16 +90,16 @@ class Registry:
         for plugin_type in self.PLUGIN_TYPES:
             if plugin_type.startswith('gui.qt.') and not has_gui_qt:
                 continue
-            entrypoint_type = 'plover.%s' % plugin_type
+            entrypoint_type = f'plover.{plugin_type}'
             for entrypoint in pkg_resources.iter_entry_points(entrypoint_type):
                 if 'gui_qt' in entrypoint.extras and not has_gui_qt:
                     continue
                 self.register_plugin_from_entrypoint(plugin_type, entrypoint)
-            if PLUGINS_PLATFORM is not None:
-                entrypoint_type = 'plover.%s.%s' % (PLUGINS_PLATFORM, plugin_type)
-                for entrypoint in pkg_resources.iter_entry_points(entrypoint_type):
-                    self.register_plugin_from_entrypoint(plugin_type, entrypoint)
+            if PLUGINS_PLATFORM is None:
+                continue
+            entrypoint_type = f'plover.{PLUGINS_PLATFORM}.{plugin_type}'
+            for entrypoint in pkg_resources.iter_entry_points(entrypoint_type):
+                self.register_plugin_from_entrypoint(plugin_type, entrypoint)
 
 
 registry = Registry()
-

--- a/plover/registry.py
+++ b/plover/registry.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 import pkg_resources
 
-from plover.oslayer.config import HAS_GUI_QT, PLUGINS_PLATFORM
+from plover.oslayer.config import PLUGINS_PLATFORM
 from plover import log
 
 
@@ -80,12 +80,20 @@ class Registry:
         return [dist for dist_id, dist in sorted(self._distributions.items())]
 
     def update(self):
+        # Is support for the QT GUI available?
+        try:
+            pkg_resources.load_entry_point('plover', 'plover.gui', 'qt')
+        except (pkg_resources.ResolutionError, ImportError):
+            has_gui_qt = False
+        else:
+            has_gui_qt = True
+        # Register available plugins.
         for plugin_type in self.PLUGIN_TYPES:
-            if plugin_type.startswith('gui.qt.') and not HAS_GUI_QT:
+            if plugin_type.startswith('gui.qt.') and not has_gui_qt:
                 continue
             entrypoint_type = 'plover.%s' % plugin_type
             for entrypoint in pkg_resources.iter_entry_points(entrypoint_type):
-                if 'gui_qt' in entrypoint.extras and not HAS_GUI_QT:
+                if 'gui_qt' in entrypoint.extras and not has_gui_qt:
                     continue
                 self.register_plugin_from_entrypoint(plugin_type, entrypoint)
             if PLUGINS_PLATFORM is not None:

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -1,4 +1,3 @@
-
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 import os
@@ -9,22 +8,23 @@ import pkg_resources
 
 ASSET_SCHEME = 'asset:'
 
-def _asset_split(resource_name):
+
+def _asset_filename(resource_name):
     components = resource_name[len(ASSET_SCHEME):].split(':', 1)
     if len(components) != 2:
         raise ValueError('invalid asset: %s' % resource_name)
     if os.path.isabs(components[1]):
         raise ValueError(f'invalid asset: {resource_name}')
-    return components
+    return pkg_resources.resource_filename(*components)
 
 def resource_exists(resource_name):
     if resource_name.startswith(ASSET_SCHEME):
-        return pkg_resources.resource_exists(*_asset_split(resource_name))
+        resource_name = _asset_filename(resource_name)
     return os.path.exists(resource_name)
 
 def resource_filename(resource_name):
     if resource_name.startswith(ASSET_SCHEME):
-        return pkg_resources.resource_filename(*_asset_split(resource_name))
+        resource_name = _asset_filename(resource_name)
     return resource_name
 
 def resource_timestamp(resource_name):

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -1,9 +1,8 @@
 from contextlib import contextmanager
+from importlib.util import find_spec
 from tempfile import NamedTemporaryFile
 import os
 import shutil
-
-import pkg_resources
 
 
 ASSET_SCHEME = 'asset:'
@@ -15,7 +14,8 @@ def _asset_filename(resource_name):
         raise ValueError(f'invalid asset: {resource_name}')
     if os.path.isabs(components[1]):
         raise ValueError(f'invalid asset: {resource_name}')
-    return pkg_resources.resource_filename(*components)
+    package_dir = os.path.dirname(find_spec(components[0]).origin)
+    return os.path.join(package_dir, components[1])
 
 def resource_exists(resource_name):
     if resource_name.startswith(ASSET_SCHEME):

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -33,6 +33,8 @@ def resource_timestamp(resource_name):
 
 @contextmanager
 def resource_update(resource_name):
+    if resource_name.startswith(ASSET_SCHEME):
+        raise ValueError(f'updating an asset is unsupported: {resource_name}')
     filename = resource_filename(resource_name)
     directory = os.path.dirname(filename)
     extension = os.path.splitext(filename)[1]

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -12,7 +12,7 @@ ASSET_SCHEME = 'asset:'
 def _asset_filename(resource_name):
     components = resource_name[len(ASSET_SCHEME):].split(':', 1)
     if len(components) != 2:
-        raise ValueError('invalid asset: %s' % resource_name)
+        raise ValueError(f'invalid asset: {resource_name}')
     if os.path.isabs(components[1]):
         raise ValueError(f'invalid asset: {resource_name}')
     return pkg_resources.resource_filename(*components)

--- a/plover/resource.py
+++ b/plover/resource.py
@@ -13,6 +13,8 @@ def _asset_split(resource_name):
     components = resource_name[len(ASSET_SCHEME):].split(':', 1)
     if len(components) != 2:
         raise ValueError('invalid asset: %s' % resource_name)
+    if os.path.isabs(components[1]):
+        raise ValueError(f'invalid asset: {resource_name}')
     return components
 
 def resource_exists(resource_name):

--- a/plover_build_utils/check_requirements.py
+++ b/plover_build_utils/check_requirements.py
@@ -50,5 +50,5 @@ print('# other')
 for requirement in sorted_requirements(all_requirements):
     if requirement not in plover_deps and \
        requirement not in plugins_deps:
-      print(requirement)
-print('# ''vim: ft=cfg commentstring=#\ %s list')
+        print(requirement)
+print('# ''vim: ft=cfg commentstring=#\\ %s list')

--- a/plover_build_utils/testing/steno_dictionary.py
+++ b/plover_build_utils/testing/steno_dictionary.py
@@ -68,13 +68,10 @@ class _DictionaryTests:
         '''
         with self.sample_dict(tmp_path) as dict_path:
             fake_asset = ASSET_SCHEME + 'fake:' + dict_path.name
-            def fake_asset_only(p, r, v=None):
-                assert (p, r) == ('fake', dict_path.name)
+            def fake_asset_only(r, v=None):
+                assert r.startswith(ASSET_SCHEME + 'fake:')
                 return v
-            monkeypatch.setattr('pkg_resources.resource_exists',
-                                functools.partial(fake_asset_only,
-                                                  v=True))
-            monkeypatch.setattr('pkg_resources.resource_filename',
+            monkeypatch.setattr('plover.resource._asset_filename',
                                 functools.partial(fake_asset_only,
                                                   v=str(dict_path)))
             d = self.DICT_CLASS.load(fake_asset)

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -38,6 +38,8 @@ from plover.resource import (
     ('asset:', ValueError, ValueError),
     # Invalid asset: missing path.
     ('asset:package', ValueError, ValueError),
+    # Invalid asset: absolute resource path.
+    ('asset:plover:/assets/user.json', ValueError, ValueError),
 ))
 def test_resource(resource, exists, filename):
     resource = str(resource)

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -65,6 +65,13 @@ def test_resource(resource, exists, filename):
 
 
 def test_resource_update(tmp_path):
+    # Can't update assets.
+    resource = 'asset:plover:assets/pouet.json'
+    resource_path = Path(resource_filename(resource))
+    with pytest.raises(ValueError):
+        with resource_update(resource):
+            resource_path.write_bytes(b'contents')
+    assert not resource_path.exists()
     # Don't update resource on exception (but still cleanup).
     resource = (tmp_path / 'resource').resolve()
     exception_str = 'Houston, we have a problem'

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+import inspect
+
+import pytest
+
+from plover.misc import normalize_path
+from plover.resource import (
+    resource_exists,
+    resource_filename,
+    resource_timestamp,
+    resource_update,
+)
+
+
+@pytest.mark.parametrize('resource, exists, filename', (
+    # Relative filename.
+    (Path(__file__).relative_to(Path.cwd()), True, None),
+    # Relative directory.
+    (Path(__file__).parent.relative_to(Path.cwd()), True, None),
+    # Absolute filename.
+    (__file__, True, None),
+    # Absolute directory.
+    (Path(__file__).parent, True, None),
+    # Missing relative path.
+    ('test/pouet', False, None),
+    # Missing absolute path.
+    (Path.cwd() / 'test' / 'pouet', False, None),
+    # Asset filename.
+    ('asset:plover:assets/user.json', True,
+     'plover/assets/user.json'),
+    # Asset directory.
+    ('asset:plover:', True, 'plover'),
+    ('asset:plover:assets', True, 'plover/assets'),
+    # Missing asset.
+    ('asset:plover:assets/pouet.json', False,
+     'plover/assets/pouet.json'),
+    # Invalid asset: missing package and path.
+    ('asset:', ValueError, ValueError),
+    # Invalid asset: missing path.
+    ('asset:package', ValueError, ValueError),
+))
+def test_resource(resource, exists, filename):
+    resource = str(resource)
+    if inspect.isclass(exists):
+        exception = exists
+        with pytest.raises(exception):
+            resource_exists(resource)
+        with pytest.raises(exception):
+            resource_filename(resource)
+        with pytest.raises(exception):
+            resource_timestamp(resource)
+        return
+    assert resource_exists(resource) == exists
+    if filename is None:
+        filename = resource
+    assert normalize_path(resource_filename(resource)) == normalize_path(filename)
+    if exists:
+        timestamp = Path(filename).stat().st_mtime
+        assert resource_timestamp(resource) == timestamp
+    else:
+        with pytest.raises(FileNotFoundError):
+            resource_timestamp(resource)
+
+
+def test_resource_update(tmp_path):
+    # Don't update resource on exception (but still cleanup).
+    resource = (tmp_path / 'resource').resolve()
+    exception_str = 'Houston, we have a problem'
+    with pytest.raises(Exception, match=exception_str):
+        with resource_update(str(resource)) as tmpf:
+            tmpf = Path(tmpf)
+            tmpf.write_bytes(b'contents')
+            raise Exception(exception_str)
+    assert not resource.exists()
+    assert not tmpf.exists()
+    # Normal use.
+    with resource_update(str(resource)) as tmpf:
+        tmpf = Path(tmpf).resolve()
+        # Temporary filename must be different.
+        assert tmpf != resource
+        # And must be empty.
+        assert not tmpf.stat().st_size
+        # Temporary file must be created in the same
+        # directory as the target resource (so an
+        # atomic rename can be used).
+        assert tmpf.parent == resource.parent
+        # Save something.
+        tmpf.write_bytes(b'contents')
+        st = tmpf.stat()
+    assert resource.stat() == st
+    assert resource.read_bytes() == b'contents'


### PR DESCRIPTION
## Summary of changes

Salvage parts of #1488: do not switch to `importlib_metadata`, keep using `pkg_resources` in `scripts.main` and for the `registry` implementation, remove other uses.

### Pull Request Checklist
- [x] Changes have tests