### PR TITLE
system/english_stenotype: improve RTF/CRE compatibility

### DIFF
--- a/news.d/feature/1491.core.md
+++ b/news.d/feature/1491.core.md
@@ -1,0 +1,1 @@
+Improve “English stenotype” system compatibility with RTF/CRE spec: support arbitrary placement of the number sign when parsing steno (e.g. `18#`, `#18`, and `1#8` are all valid and equivalent).

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -30,11 +30,12 @@ class Stroke(BaseStroke):
     UNDO_STROKE = None
 
     @classmethod
-    def setup(cls, keys, implicit_hyphen_keys, number_key, numbers, undo_stroke):
+    def setup(cls, keys, implicit_hyphen_keys, number_key,
+              numbers, feral_number_key, undo_stroke):
         if number_key is None:
             assert not numbers
             numbers = None
-        super().setup(keys, implicit_hyphen_keys, number_key, numbers)
+        super().setup(keys, implicit_hyphen_keys, number_key, numbers, feral_number_key)
         cls._class = type(cls.__name__, (cls,), {'_helper': cls._helper})
         cls._class._class = cls._class
         cls._class.PREFIX_STROKE = cls.PREFIX_STROKE = cls.from_integer(0)

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -46,6 +46,7 @@ _EXPORTS = {
     'KEY_ORDER'                : lambda mod: _key_order(mod.KEYS, mod.NUMBERS),
     'NUMBER_KEY'               : lambda mod: mod.NUMBER_KEY,
     'NUMBERS'                  : lambda mod: dict(mod.NUMBERS),
+    'FERAL_NUMBER_KEY'         : lambda mod: getattr(mod, 'FERAL_NUMBER_KEY', False),
     'SUFFIX_KEYS'              : lambda mod: _suffix_keys(mod.SUFFIX_KEYS),
     'UNDO_STROKE_STENO'        : lambda mod: mod.UNDO_STROKE_STENO,
     'IMPLICIT_HYPHEN_KEYS'     : lambda mod: set(mod.IMPLICIT_HYPHEN_KEYS),
@@ -67,6 +68,7 @@ def setup(system_name):
         system_symbols[symbol] = init(system_mod)
     system_symbols['NAME'] = system_name
     globals().update(system_symbols)
-    Stroke.setup(KEYS, IMPLICIT_HYPHEN_KEYS, NUMBER_KEY, NUMBERS, UNDO_STROKE_STENO)
+    Stroke.setup(KEYS, IMPLICIT_HYPHEN_KEYS, NUMBER_KEY, NUMBERS,
+                 FERAL_NUMBER_KEY, UNDO_STROKE_STENO)
 
 NAME = None

--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -27,6 +27,14 @@ NUMBERS = {
     '-T': '-9',
 }
 
+# For RTF/CRE support:
+#
+#    IV.C.1.iii Number Bar
+#    If the number bar was used in a stroke, the stroke contains a number sign
+#    to indicate that. T͟h͟e͟ ͟n͟u͟m͟b͟e͟r͟ ͟s͟i͟g͟n͟ ͟m͟a͟y͟ ͟b͟e͟ ͟a͟n͟y͟w͟h͟e͟r͟e͟ ͟w͟i͟t͟h͟i͟n͟ ͟t͟h͟e͟ ͟s͟t͟r͟o͟k͟e͟, […]
+#
+FERAL_NUMBER_KEY = True
+
 UNDO_STROKE_STENO = '*'
 
 ORTHOGRAPHY_RULES = [

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -35,7 +35,7 @@ pep517==0.12.0
 pip==21.3.1
 pkginfo==1.7.1
 plover-plugins-manager==0.7.0
-plover-stroke==1.0.1
+plover-stroke==1.1.0
 plover-treal==1.0.1
 pluggy==1.0.0
 py==1.10.0

--- a/reqs/dist.txt
+++ b/reqs/dist.txt
@@ -1,6 +1,6 @@
 appdirs>=1.3.0
 appnope>=0.1.0; "darwin" in sys_platform
-plover-stroke>=1.0.0
+plover-stroke>=1.1.0
 pyobjc-core>=4.0; "darwin" in sys_platform
 pyobjc-framework-Cocoa>=4.0; "darwin" in sys_platform
 pyobjc-framework-Quartz>=4.0; "darwin" in sys_platform

--- a/test/test_rtfcre_dict.py
+++ b/test/test_rtfcre_dict.py
@@ -436,6 +436,15 @@ RTF_LOAD_TESTS = (
         '''
         'TEFT': ''
         '''),
+
+    # RTF/CRE spec allow the number key letter anywhere...
+    lambda: rtf_load_test(
+        r'''
+        {\*\cxs 2#}2
+
+        '2': '2',
+        '''),
+
 )
 
 def rtf_save_test(dict_entries, rtf_entries):

--- a/test/test_steno.py
+++ b/test/test_steno.py
@@ -45,6 +45,12 @@ NORMALIZE_TESTS = (
     lambda: ('#A', ('5',)),
     lambda: ('#0', ('0',)),
     lambda: ('#6', ('-6',)),
+    # RTF/CRE spec allow the number key letter anywhere…
+    lambda: ('#WS', ('#W-S',)),
+    lambda: ('W#S', ('#W-S',)),
+    lambda: ('W-S#', ('#W-S',)),
+    lambda: ('S#A', ('15',)),
+    lambda: ('2#', ('2',)),
     # Implicit hyphens.
     lambda: ('SA-', ('SA',)),
     lambda: ('SA-R', ('SAR',)),
@@ -57,6 +63,7 @@ NORMALIZE_TESTS = (
     lambda: ('S-*R', (ValueError, ('S-*R',))),
     lambda: ('-O-', (ValueError, ('-O-',))),
     lambda: ('-O', (ValueError, ('-O',))),
+    lambda: ('#WS#', (ValueError, ('#WS#',))),
 )
 
 @parametrize(NORMALIZE_TESTS)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Support the arbitrary placement of the number sign when parsing steno. 

Closes #1486.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
