### PR TITLE
windows: drop launch option from installer's final page

### DIFF
--- a/news.d/bugfix/1495.windows.md
+++ b/news.d/bugfix/1495.windows.md
@@ -1,0 +1,1 @@
+Drop launch option from installer's final page: avoid possible issues (e.g. permission errors with the controller's pipe) because Plover was run as admin.

--- a/windows/installer.nsi
+++ b/windows/installer.nsi
@@ -50,10 +50,6 @@
 
   !insertmacro MUI_PAGE_INSTFILES
   
-  !define MUI_FINISHPAGE_RUN $INSTDIR\plover.exe
-  !define MUI_FINISHPAGE_RUN_PARAMETERS ""
-  !insertmacro MUI_PAGE_FINISH
-
   !insertmacro MUI_UNPAGE_CONFIRM
   !insertmacro MUI_UNPAGE_INSTFILES
   


### PR DESCRIPTION
## Summary of changes

Otherwise, if the installer is running as privileged (when installing for all users), Plover will be launched as admin, which can create issues later (e.g. permission errors with the controller's pipe).

### Pull Request Checklist
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
