### PR TITLE
engine: fix running state

### DIFF
--- a/news.d/bugfix/1504.core.md
+++ b/news.d/bugfix/1504.core.md
@@ -1,0 +1,1 @@
+Fix engine's running state: make sure the translator' state is empty when enabling output for the first time.

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -119,6 +119,7 @@ class StenoEngine:
         self._dictionaries = self._translator.get_dictionary()
         self._dictionaries_manager = DictionaryLoadingManager()
         self._running_state = self._translator.get_state()
+        self._translator.clear_state()
         self._keyboard_emulation = keyboard_emulation
         self._hooks = { hook: [] for hook in self.HOOKS }
         self._running_extensions = {}

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -105,7 +105,7 @@ def engine(monkeypatch):
         os.unlink(cfg_file.name)
 
 
-def test_engine(engine):
+def test_engine_lifecycle(engine):
     # Config load.
     assert engine.load_config()
     assert engine.events == []
@@ -246,3 +246,21 @@ def test_loading_dictionaries(tmp_path, engine):
             (valid_dict_1, False, False),
             (invalid_dict_2, True, True),
         ]])
+
+def test_engine_running_state(engine):
+    # Running state must be different
+    # from initial (disabled state).
+    initial_state = engine.translator_state
+    assert engine.load_config()
+    engine.set_output(True)
+    running_state = engine.translator_state
+    assert running_state != initial_state
+    # Disabled state is reset every time
+    # output is disabled.
+    engine.set_output(False)
+    disabled_state = engine.translator_state
+    assert disabled_state != running_state
+    assert disabled_state != initial_state
+    # Running state is kept throughout.
+    engine.set_output(True)
+    assert engine.translator_state == running_state


### PR DESCRIPTION
## Summary of changes

Ensure we're not using the initial (disabled) state.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
