### PR TITLE
main: fix exit handlers not getting always executed

### DIFF
--- a/news.d/bugfix/1507.core.md
+++ b/news.d/bugfix/1507.core.md
@@ -1,0 +1,1 @@
+Fix exit handlers not getting always executed.

--- a/news.d/bugfix/1507.windows.md
+++ b/news.d/bugfix/1507.windows.md
@@ -1,0 +1,1 @@
+Fix notifications behavior: no persistent duplicated icons (one for each notification).

--- a/plover/scripts/main.py
+++ b/plover/scripts/main.py
@@ -148,6 +148,8 @@ def main():
     except:
         gui.show_error('Unexpected error', traceback.format_exc())
         code = 2
+    # Execute atexit handlers.
+    atexit._run_exitfuncs()
     if code == -1:
         # Restart.
         args = sys.argv[:]
@@ -156,8 +158,6 @@ def main():
             spec = sys.modules['__main__'].__spec__
             assert sys.argv[0] == spec.origin
             args[0:1] = [sys.executable, '-m', spec.name]
-        # Execute atexit handlers.
-        atexit._run_exitfuncs()
         if PLATFORM == 'win':
             # Workaround https://bugs.python.org/issue19066
             subprocess.Popen(args, cwd=os.getcwd())


### PR DESCRIPTION
## Summary of changes

There were only executed on restart...

Partially address #1502.

### Pull Request Checklist
~- [ ] Changes have tests~
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
