### PR TITLE
utils/download: print errors on stderr

### DIFF
--- a/plover_build_utils/download.py
+++ b/plover_build_utils/download.py
@@ -25,7 +25,7 @@ def download(url, sha1=None, filename=None, downloads_dir=DOWNLOADS_DIR):
                 with urlopen(url) as req, open(dst, 'wb') as fp:
                     fp.write(req.read())
             except Exception as e:
-                print('error', e)
+                print('error', e, file=sys.stderr)
                 continue
         if sha1 is None:
             break
@@ -38,7 +38,8 @@ def download(url, sha1=None, filename=None, downloads_dir=DOWNLOADS_DIR):
                 h.update(d)
         if h.hexdigest() == sha1:
             break
-        print('sha1 does not match: %s instead of %s' % (h.hexdigest(), sha1))
+        print('sha1 does not match: %s instead of %s'
+              % (h.hexdigest(), sha1), file=sys.stderr)
         os.unlink(dst)
     assert os.path.exists(dst), 'could not successfully retrieve %s' % url
     return dst


### PR DESCRIPTION
So error messages don't get swallowed when using `var="$(python -m plover_build_utils.download […])"` in shell scripts.