### PR TITLE
translation: avoid unnecessary lookups

### DIFF
--- a/news.d/feature/1513.core.md
+++ b/news.d/feature/1513.core.md
@@ -1,0 +1,1 @@
+Improve translation stage: cut down on unnecessary / duplicate dictionary lookups.

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -379,6 +379,7 @@ class Translator:
                 t = Translation(strokes, mapping)
                 t.replaced = replaced
                 return t
+        return None
 
     def _lookup_strokes(self, strokes):
         '''Look for a matching translation.

--- a/plover/translation.py
+++ b/plover/translation.py
@@ -380,7 +380,8 @@ class Translator:
             return main_mapping + ' ' + suffix_mapping
         return None
 
-    def _previous_word_is_finished(self, last_translations):
+    @staticmethod
+    def _previous_word_is_finished(last_translations):
         if not last_translations:
             return True
         formatting = last_translations[-1].formatting

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -907,3 +907,42 @@ class TestNoUnnecessaryLookups(TestTranslateStroke):
             -G TEFT
             '''
         )
+
+    def test_lookup_suffixes_once(self):
+        self._prepare_state(
+            '''
+            "HROPBG/EFT/KAOE": "longest key",
+            "HRETS": "let's",
+            "TEFT": "test",
+            "SPH": "some",
+            "SUFBGS": "suffix",
+            "-G": "{^ing}",
+            "-S": "{^s}",
+            "-D": "{^ed}",
+            "-Z": "{^s}",
+            ''',
+            'HRETS TEFT SPH')
+        self.translate('SUFBGSZ')
+        self._check_lookup_history(
+            # Macros.
+            '''
+            /SUFBGSZ
+            SUFBGSZ
+            '''
+            # Without suffix.
+            '''
+            TEFT/SPH/SUFBGSZ
+            /SPH/SUFBGSZ
+            SPH/SUFBGSZ
+            /SUFBGSZ
+            SUFBGSZ
+            '''
+            # Suffix lookups.
+            '''
+            -Z -S -G
+            TEFT/SPH/SUFBGS TEFT/SPH/SUFBGZ TEFT/SPH/SUFBSZ
+            /SPH/SUFBGS /SPH/SUFBGZ /SPH/SUFBSZ
+            SPH/SUFBGS SPH/SUFBGZ SPH/SUFBSZ
+            /SUFBGS /SUFBGZ /SUFBSZ
+            SUFBGS
+            ''')

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -881,7 +881,6 @@ class TestNoUnnecessaryLookups(TestTranslateStroke):
             '''
             SPH/TEFT/-G
             /TEFT/-G TEFT/-G
-            /-G -G
             '''
         )
 
@@ -900,7 +899,6 @@ class TestNoUnnecessaryLookups(TestTranslateStroke):
             '''
             # No suffix.
             '''
-            TEFGT
             '''
             # With suffix.
             '''
@@ -934,8 +932,6 @@ class TestNoUnnecessaryLookups(TestTranslateStroke):
             TEFT/SPH/SUFBGSZ
             /SPH/SUFBGSZ
             SPH/SUFBGSZ
-            /SUFBGSZ
-            SUFBGSZ
             '''
             # Suffix lookups.
             '''

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -884,3 +884,26 @@ class TestNoUnnecessaryLookups(TestTranslateStroke):
             /-G -G
             '''
         )
+
+    def test_no_duplicate_lookups_for_longest_no_suffix_match(self):
+        self._prepare_state(
+            '''
+            "TEFT": "test",
+            "-G": "{^ing}",
+            ''',
+            'TEFT')
+        self.translate('TEFGT')
+        self._check_lookup_history(
+            # Macros.
+            '''
+            TEFGT
+            '''
+            # No suffix.
+            '''
+            TEFGT
+            '''
+            # With suffix.
+            '''
+            -G TEFT
+            '''
+        )

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -852,3 +852,35 @@ class TestNoUnnecessaryLookups(TestTranslateStroke):
             expected: %s
         ''' % (result, expected)
         assert result == expected, msg
+
+    def test_zero_lookups(self):
+        # No lookups at all if longest key is zero.
+        self.translate('TEFT')
+        self._check_lookup_history('')
+        self._check_translations(self.lt('TEFT'))
+
+    def test_no_prefix_lookup_over_the_longest_key_limit(self):
+        self._prepare_state(
+            '''
+            "HROPBG/EFT/KAOE": "longest key",
+            "HRETS": "let's",
+            "TKO": "do",
+            "SPH": "some",
+            "TEFT": "test",
+            "-G": "{^ing}",
+            ''',
+            'HRETS TKO SPH TEFT')
+        self.translate('-G')
+        self._check_lookup_history(
+            # Macros.
+            '''
+            /-G
+            -G
+            '''
+            # Others.
+            '''
+            SPH/TEFT/-G
+            /TEFT/-G TEFT/-G
+            /-G -G
+            '''
+        )


### PR DESCRIPTION
## Summary of changes

With the following dictionary stacks:

- user:
```json
{
  "EUPB/EBGS/PEPBS/EUF": "inexpensive",
}
```
- commands:
```json
{
  "PHROLG": "{PLOVER:TOGGLE}"
}
```
- main:
```json
{
  "A*/KR*/*E/T*/O*/P*/H*/*EU/HR*/*EU/KR*": "acidophilic",
  "OBLG": "okay",
  "-RBGS": "{,}",
  "HRET": "let",
  "AES": "{^'s}",
  "SAOE": "see",
  "HOU": "how",
  "PHAEPB": "many",
  "HRAOUP": "lookup",
  "TP-R": "for",
  "SUFBGS": "suffix",
  "-G": "{^ing}",
  "-S": "{^s}",
  "-D": "{^ed}",
  "-Z": "{^s}",
}
```

Writing `OBLG -RBGS HRET AES SAOE HOU PHAEPB HRAOUP -S TP-R SUFBGSZ`, the last stroke results in the following dictionary collection lookups:

```
# Macros:
/SUFBGSZ in user, main
SUFBGSZ in user, cmds, main
# No suffix:
/-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGSZ
-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGSZ in main
/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGSZ in main
HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGSZ in main
[…]
/SUFBGSZ/SUFBGSZ in user, main
SUFBGSZ/SUFBGSZ in user, main
/SUFBGSZ in user, main
SUFBGSZ in user, cmds, main
# With suffix:
/-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGSZ
-Z in user, cmds, main
/-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGS
-S in user, cmds, main
/-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGZ
-G in user, cmds, main
/-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBSZ
-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGSZ in main
-Z in user, cmds, main
-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGS in main
-S in user, cmds, main
-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBGZ in main
-G in user, cmds, main
-RBGS/HRET/AES/SAOE/HOU/PHAEPB/HRAOUP/-S/TP-R/SUFBGSZ/SUFBSZ in main
[…]
/SUFBGSZ/SUFBSZ in user, main
SUFBGSZ/SUFBGSZ in user, main
-Z in user, cmds, main
SUFBGSZ/SUFBGS in user, main
-S in user, cmds, main
SUFBGSZ/SUFBGZ in user, main
-G in user, cmds, main
SUFBGSZ/SUFBSZ in user, main
/SUFBGSZ in user, main
-Z in user, cmds, main
/SUFBGS in user, main
-S in user, cmds, main
/SUFBGZ in user, main
-G in user, cmds, main
/SUFBSZ in user, main
SUFBGSZ in user, cmds, main
-Z in user, cmds, main
SUFBGS in user, cmds, main
```
Stats:
- dictionary collection: 174
- duplicates           :  85 (`-Z` [21], `-G` [20], `-S` [20], …)
- user                 :  99
- commands             :  68
- main                 : 169
- dictionaries         : 336

This PR cut down on unnecessary / duplicate lookups:
- Avoid lookups over the longest key limit (prefix stroke).
- When calling `_find_longest_match` a second time to account for a possible implicit suffix in the last stroke, don't duplicate     lookups for a non-suffix match.
- Only lookup each possible implicit suffix once (before looking for a longest match).
- Reuse the results of the initial (macro check) lookups of the last stroke if needed, instead of re-doing them.

Stats with this PR:
- dictionary collection:  85
- user                 :  29
- commands             :   5
- main                 :  85
- dictionaries         : 119

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
