### PR TITLE
gui_qt/add_translation: fix #1526

### DIFF
--- a/news.d/bugfix/1527.ui.md
+++ b/news.d/bugfix/1527.ui.md
@@ -1,0 +1,1 @@
+Fix "add translation" dialog "Ok" button not being enabled when the strokes field is automatically populated from the latest untranslate.

--- a/plover/gui_qt/add_translation_dialog.py
+++ b/plover/gui_qt/add_translation_dialog.py
@@ -19,9 +19,9 @@ class AddTranslationDialog(Tool, Ui_AddTranslationDialog):
     def __init__(self, engine, dictionary_path=None):
         super().__init__(engine)
         self.setupUi(self)
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
         self.add_translation.select_dictionary(dictionary_path)
         self.add_translation.mappingValid.connect(self.on_mapping_valid)
+        self.on_mapping_valid(self.add_translation.mapping_is_valid)
         engine.signal_connect('config_changed', self.on_config_changed)
         self.on_config_changed(engine.config)
         self.installEventFilter(self)

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -97,6 +97,10 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
         self._engine_state = self._original_state
         self._focus = None
 
+    @property
+    def mapping_is_valid(self):
+        return self._mapping_is_valid
+
     def select_dictionary(self, dictionary_path):
         self._selected_dictionary = dictionary_path
         self._update_items()


### PR DESCRIPTION
## Summary of changes

Enable the "Ok" button when the dialog "strokes" field is automatically populated from the latest untranslate.

Closes #1526

### Pull Request Checklist
- ~[ ] Changes have tests~
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
