### PR TITLE
gui_qt/main: capture and log Qt messages

### DIFF
--- a/news.d/feature/1534.ui.md
+++ b/news.d/feature/1534.ui.md
@@ -1,0 +1,1 @@
+Capture and log Qt messages.


### PR DESCRIPTION
## Summary of changes

Qt messages (like a warning when calling `setStyleSheet` with an invalid stylesheet) are currently printed to stderr, with no user feedback. Capture and reroute them through our standard logger.

### Pull Request Checklist
- ~[ ] Changes have tests~
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
