### PR TITLE
add custom stylesheet support for the Qt GUI

### DIFF
--- a/news.d/feature/1514.ui.md
+++ b/news.d/feature/1514.ui.md
@@ -1,0 +1,1 @@
+Add support for styling the Qt GUI: automatically load and apply a custom stylesheet from `plover.qss` (in the configuration directory) when present.

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import signal
 import sys
 
@@ -12,6 +13,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
 from plover import _, __name__ as __software_name__, __version__, log
+from plover.oslayer.config import CONFIG_DIR
 from plover.oslayer.keyboardcontrol import KeyboardEmulation
 
 from plover.gui_qt.engine import Engine
@@ -42,6 +44,12 @@ class Application:
 
         self._app = QApplication([sys.argv[0], '-name', 'plover'])
         self._app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+
+        # Apply custom stylesheet if present.
+        stylesheet_path = Path(CONFIG_DIR) / 'plover.qss'
+        if stylesheet_path.exists():
+            log.info('using stylesheet at: %s', stylesheet_path)
+            self._app.setStyleSheet(stylesheet_path.read_text())
 
         # Enable localization of standard Qt controls.
         log.info('setting language to: %s', _.lang)


### PR DESCRIPTION
Add support for styling the Qt GUI: automatically load and apply a custom stylesheet from `plover.qss` (in the configuration directory) when present.

Closes #1514.

### Pull Request Checklist
- ~[ ] Changes have tests~
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
