### PR TITLE
tox: remove invalid directive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ install_command =
 
 # Default, Python 3 based, environment.
 [testenv]
-base_python = py3
 envdir = {toxworkdir}/dev
 extras =
 	gui_qt


### PR DESCRIPTION
It's `basepython`, not `base_python`, and it does not work as expected, so just get rid of it.