### PR TITLE
add support for copying the paper tape / suggestions widget selection to clipboard

### DIFF
--- a/news.d/feature/1539.ui.md
+++ b/news.d/feature/1539.ui.md
@@ -1,0 +1,1 @@
+Change the paper tape / suggestions widget selection mode to "extended" (allow selecting multiple items, support shift/control), and allow copying the current selection to clipboard using the standard copy shortcut.

--- a/plover/gui_qt/utils.py
+++ b/plover/gui_qt/utils.py
@@ -1,11 +1,25 @@
-
 from PyQt5.QtCore import QSettings
+from PyQt5.QtGui import QGuiApplication, QKeySequence
 from PyQt5.QtWidgets import (
+    QAction,
     QMainWindow,
     QToolBar,
     QToolButton,
     QWidget,
 )
+
+from plover import _
+
+
+def ActionCopyViewSelectionToClipboard(view):
+    def copy_selection_to_clipboard():
+        indexes = view.selectedIndexes()
+        data = view.model().mimeData(indexes)
+        QGuiApplication.clipboard().setMimeData(data)
+    action = QAction(_('Copy selection to clipboard'))
+    action.setShortcut(QKeySequence(QKeySequence.Copy))
+    action.triggered.connect(copy_selection_to_clipboard)
+    return action
 
 
 def ToolButton(action):


### PR DESCRIPTION
## Summary of changes

Change the selection mode for the paper tape / suggestions widget to "extended" (allow selecting multiple items, support shift/control), and allow copying the current selection to clipboard using the standard copy shortcut.

### Pull Request Checklist
- ~[ ] Changes have tests~
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
