### PR TITLE
test: mark code necessary for Python<=3.7 compatibility

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,9 +24,8 @@ include plover_build_utils/*.sh
 include pyproject.toml
 include pytest.ini
 include reqs/*.txt
-include test/__init__.py
-include test/conftest.py
-include test/gui_qt/test_*.py
+include test/*.py
+include test/gui_qt/*.py
 include tox.ini
 include windows/*
 # Exclude: CI/Git/GitHub specific files,

--- a/reqs/test.txt
+++ b/reqs/test.txt
@@ -1,4 +1,4 @@
-mock>=3.0.0
+mock>=3.0.0; python_version <= "3.7"
 pytest
 pytest-qt
 

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -6,7 +6,6 @@ import operator
 
 from PyQt5.QtCore import QModelIndex, QPersistentModelIndex, Qt
 
-import mock
 import pytest
 
 from plover.config import DictionaryConfig
@@ -16,6 +15,8 @@ from plover.steno_dictionary import StenoDictionary, StenoDictionaryCollection
 from plover.misc import expand_path
 
 from plover_build_utils.testing import parametrize
+
+from ..py37compat import mock
 
 
 INVALID_EXCEPTION = Exception('loading error')

--- a/test/py37compat.py
+++ b/test/py37compat.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info[:2] <= (3, 7):
+    import mock
+else:
+    from unittest import mock

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -2,7 +2,6 @@ from functools import partial
 import os
 import tempfile
 
-from mock import MagicMock
 import pytest
 
 from plover import system
@@ -21,6 +20,8 @@ from plover.registry import Registry
 from plover.steno_dictionary import StenoDictionaryCollection
 
 from plover_build_utils.testing import make_dict
+
+from .py37compat import mock
 
 
 class FakeMachine(StenotypeBase):
@@ -88,7 +89,7 @@ def engine(monkeypatch):
     registry.register_plugin('machine', 'Fake', FakeMachine)
     monkeypatch.setattr('plover.config.registry', registry)
     monkeypatch.setattr('plover.engine.registry', registry)
-    ctrl = MagicMock(spec=Controller)
+    ctrl = mock.MagicMock(spec=Controller)
     kbd = FakeKeyboardEmulation()
     cfg_file = tempfile.NamedTemporaryFile(prefix='plover',
                                            suffix='config',

--- a/test/test_keyboard.py
+++ b/test/test_keyboard.py
@@ -1,10 +1,11 @@
-from mock import MagicMock, call, patch
 import pytest
 
 from plover import system
 from plover.machine.keyboard import Keyboard
 from plover.machine.keymap import Keymap
 from plover.oslayer.keyboardcontrol import KeyboardCapture
+
+from .py37compat import mock
 
 
 def send_input(capture, key_events):
@@ -20,8 +21,8 @@ def send_input(capture, key_events):
 
 @pytest.fixture
 def capture():
-    capture = MagicMock(spec=KeyboardCapture)
-    with patch('plover.machine.keyboard.KeyboardCapture', new=lambda: capture):
+    capture = mock.MagicMock(spec=KeyboardCapture)
+    with mock.patch('plover.machine.keyboard.KeyboardCapture', new=lambda: capture):
         yield capture
 
 @pytest.fixture(params=[False])
@@ -47,8 +48,8 @@ def test_lifecycle(capture, machine, strokes):
     # Start machine.
     machine.start_capture()
     assert capture.mock_calls == [
-        call.start(),
-        call.suppress(()),
+        mock.call.start(),
+        mock.call.suppress(()),
     ]
     capture.reset_mock()
     machine.set_suppression(True)
@@ -56,7 +57,7 @@ def test_lifecycle(capture, machine, strokes):
     del suppressed_keys['space']
     assert strokes == []
     assert capture.mock_calls == [
-        call.suppress(suppressed_keys.keys()),
+        mock.call.suppress(suppressed_keys.keys()),
     ]
     # Trigger some strokes.
     capture.reset_mock()
@@ -71,8 +72,8 @@ def test_lifecycle(capture, machine, strokes):
     machine.stop_capture()
     assert strokes == []
     assert capture.mock_calls == [
-        call.suppress(()),
-        call.cancel(),
+        mock.call.suppress(()),
+        mock.call.cancel(),
     ]
 
 def test_unfinished_stroke_1(capture, machine, strokes):


### PR DESCRIPTION
To make it easier to drop support for Python<=3.7 when the time comes.