### PR TITLE
Fix bugs in gui_none/add_translation

### DIFF
--- a/news.d/bugfix/1546.ui.md
+++ b/news.d/bugfix/1546.ui.md
@@ -1,0 +1,1 @@
+Fix `{PLOVER:ADD_TRANSLATION}` implementation when using the headless GUI (`-g none`).

--- a/plover/gui_none/add_translation.py
+++ b/plover/gui_none/add_translation.py
@@ -1,4 +1,3 @@
-
 from plover.engine import StartingStrokeState
 
 
@@ -28,9 +27,8 @@ class AddTranslation:
     def _push_state(self):
         self._translator_states.insert(0, self._get_state())
 
-    def _pop_state(self, undo=False):
-        if undo:
-            self._engine.clear_translator_state(True)
+    def _pop_state(self):
+        self._engine.clear_translator_state(True)
         self._set_state(*self._translator_states.pop(0))
 
     @staticmethod
@@ -55,7 +53,7 @@ class AddTranslation:
             assert state.translations
             if len(state.translations) == 1:
                 # Abort add translation.
-                self._pop_state(undo=True)
+                self._pop_state()
                 self._status = None
                 return
             self._strokes = tuple(s.rtfcre
@@ -64,14 +62,13 @@ class AddTranslation:
                                   for s in t.strokes)
             self._clear_state(undo=True)
             self._translation = ''
-            self._status = 'translations'
             self._engine.hook_connect('send_string', self.send_string)
             self._engine.hook_connect('send_backspaces', self.send_backspaces)
+            self._status = 'translations'
         elif self._status == 'translations':
             state = self._get_state()[0]
             self._engine.hook_disconnect('send_string', self.send_string)
             self._engine.hook_disconnect('send_backspaces', self.send_backspaces)
-            self._translation = self._translation.strip()
-            self._engine.add_translation(self._strokes, self._translation)
-            self._pop_state(undo=True)
+            self._engine.add_translation(self._strokes, self._translation.strip())
+            self._pop_state()
             self._status = None

--- a/plover/gui_none/add_translation.py
+++ b/plover/gui_none/add_translation.py
@@ -52,17 +52,16 @@ class AddTranslation:
         elif self._status == 'strokes':
             self._engine.remove_dictionary_filter(self._stroke_filter)
             state = self._get_state()[0]
-            # Ignore add translation stroke.
-            state.translations = state.translations[1:]
-            strokes = []
-            for t in state.translations:
-                strokes.extend(t.strokes)
-            if not strokes:
+            assert state.translations
+            if len(state.translations) == 1:
                 # Abort add translation.
                 self._pop_state(undo=True)
                 self._status = None
                 return
-            self._strokes = tuple(s.rtfcre for s in strokes)
+            self._strokes = tuple(s.rtfcre
+                                  # Ignore add translation strokes.
+                                  for t in state.translations[:-1]
+                                  for s in t.strokes)
             self._clear_state(undo=True)
             self._translation = ''
             self._status = 'translations'
@@ -70,8 +69,6 @@ class AddTranslation:
             self._engine.hook_connect('send_backspaces', self.send_backspaces)
         elif self._status == 'translations':
             state = self._get_state()[0]
-            # Ignore add translation stroke.
-            state.translations = state.translations[1:]
             self._engine.hook_disconnect('send_string', self.send_string)
             self._engine.hook_disconnect('send_backspaces', self.send_backspaces)
             self._translation = self._translation.strip()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fixes a couple of unreported issues in the non_gui implementation for adding entries to a dictionary.

1.  Strokes are incorrectly sliced. Leaving out the initial one and instead including the stroke for {PLOVER:ADD_TRANSLATION} [fixed in 37fa63d636071688fb475bfa7608ce144cd5baea]

2. Input isn't cleared out correctly after each stage of entry (stroke, translation). Leaving the first output in the active text-box [fixed in 37fa63d636071688fb475bfa7608ce144cd5baea]
3. Aborting the dictionary addition without entering any strokes causes an AssertionError (see log below) [fixed in 6ef18d0006536c1e73cc14743ff3fc17444df41e]

```
2022-08-07 14:17:48,654 [Thread-1-engine] ERROR: hook 'add_translation' callback <bound method AddTranslation.trigger of <plover.gui_none.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/plover/engine.py", line 564, in _trigger_hook
    callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/plover/gui_none/add_translation.py", line 63, in trigger
    self._pop_state(undo=True)
  File "/usr/local/lib/python3.9/dist-packages/plover/gui_none/add_translation.py", line 33, in _pop_state
    self._engine.clear_translator_state(True)
  File "/usr/local/lib/python3.9/dist-packages/plover/engine.py", line 75, in _with_lock
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/plover/engine.py", line 530, in clear_translator_state
    self._formatter.format(state.translations, (), None)
  File "/usr/local/lib/python3.9/dist-packages/plover/formatting.py", line 375, in format
    assert undo or do
AssertionError
```

Example of current behavior on addition:
![no-gui_addition_current](https://user-images.githubusercontent.com/17461433/183305189-eac4ab3e-e371-4310-894d-411b51852cde.gif)

Example of behavior after changes:
![no-gui_addition_fixed](https://user-images.githubusercontent.com/17461433/183305194-f992eaab-535f-4408-b9f7-6699c5478c7f.gif)


<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [X] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
