### PR TITLE
engine: fix possible `clear_translator_state` issue

### DIFF
--- a/news.d/bugfix/1547.core.md
+++ b/news.d/bugfix/1547.core.md
@@ -1,0 +1,1 @@
+Fix possible exception when calling `Engine.clear_translator_state(undo=True)`.

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -527,7 +527,8 @@ class StenoEngine:
     def clear_translator_state(self, undo=False):
         if undo:
             state = self._translator.get_state()
-            self._formatter.format(state.translations, (), None)
+            if state.translations:
+                self._formatter.format(state.translations, (), None)
         self._translator.clear_state()
 
     @property

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -264,3 +264,6 @@ def test_engine_running_state(engine):
     # Running state is kept throughout.
     engine.set_output(True)
     assert engine.translator_state == running_state
+
+def test_undo_and_clear_empty_translator_state(engine):
+    engine.clear_translator_state(undo=True)


### PR DESCRIPTION
## Summary of changes

Don't try to undo an empty state.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
