### PR TITLE
plover/machine/*: DRY up / remove code duplication

### DIFF
--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -90,6 +90,11 @@ class StenotypeBase:
         for callback in self.stroke_subscribers:
             callback(steno_keys)
 
+    def _notify_keys(self, steno_keys):
+        steno_keys = self.keymap.keys_to_actions(steno_keys)
+        if steno_keys:
+            self._notify(steno_keys)
+
     def set_suppression(self, enabled):
         '''Enable keyboard suppression.
 

--- a/plover/machine/geminipr.py
+++ b/plover/machine/geminipr.py
@@ -53,6 +53,4 @@ class GeminiPr(SerialStenotypeBase):
                 for j in range(1, 8):
                     if (b & (0x80 >> j)):
                         steno_keys.append(STENO_KEY_CHART[i * 7 + j - 1])
-            steno_keys = self.keymap.keys_to_actions(steno_keys)
-            if steno_keys:
-                self._notify(steno_keys)
+            self._notify_keys(steno_keys)

--- a/plover/machine/passport.py
+++ b/plover/machine/passport.py
@@ -42,9 +42,7 @@ class Passport(SerialStenotypeBase):
             shadow = int(shadow, base=16)
             if shadow >= 8:
                 steno_keys.append(key)
-        steno_keys = self.keymap.keys_to_actions(steno_keys)
-        if steno_keys:
-            self._notify(steno_keys)
+        self._notify_keys(steno_keys)
 
     def run(self):
         """Overrides base class run method. Do not call directly."""

--- a/plover/machine/procat.py
+++ b/plover/machine/procat.py
@@ -40,11 +40,9 @@ class ProCAT(SerialStenotypeBase):
                 log.error('discarding invalid packet: %s',
                           binascii.hexlify(packet))
                 continue
-            steno_keys = self.keymap.keys_to_actions(
+            self._notify_keys(
                 self.process_steno_packet(packet)
             )
-            if steno_keys:
-                self._notify(steno_keys)
 
     @staticmethod
     def process_steno_packet(raw):

--- a/plover/machine/stentura.py
+++ b/plover/machine/stentura.py
@@ -658,15 +658,10 @@ class Stentura(plover.machine.base.SerialStenotypeBase):
         ^
     '''
 
-    def _on_stroke(self, keys):
-        steno_keys = self.keymap.keys_to_actions(keys)
-        if steno_keys:
-            self._notify(steno_keys)
-
     def run(self):
         """Overrides base class run method. Do not call directly."""
         try:
-            _loop(self.serial_port, self.finished, self._on_stroke, self._ready)
+            _loop(self.serial_port, self.finished, self._notify_keys, self._ready)
         except _StopException:
             pass
         except Exception:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This removes some code duplication. I'm not yet sure if it's worth the effort (e.g. would we want to update the plugin documentation accordingly?).

As this is a refactoring, it technically should not require any new tests.  However, from what I understand only `test/test_passport.py` tests the relevant code right now.

Regarding news fragments + docstring, is this relevant for the plugins api?  If yes, I guess we would want both?

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
