### PR TITLE
Update machine state on unhandled exceptions

### DIFF
--- a/news.d/bugfix/1560.ui.md
+++ b/news.d/bugfix/1560.ui.md
@@ -1,0 +1,1 @@
+Update the tray icon to "disconnected" when a serial-over-USB machine is unplugged.

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -149,9 +149,17 @@ class ThreadedStenotypeBase(StenotypeBase, threading.Thread):
     """
     def __init__(self):
         threading.Thread.__init__(self)
+        self._on_unhandled_exception(self._error)
         self.name += '-machine'
         StenotypeBase.__init__(self)
         self.finished = threading.Event()
+
+    def _on_unhandled_exception(self, action):
+        super_invoke_excepthook = self._invoke_excepthook
+        def invoke_excepthook(self):
+            action()
+            super_invoke_excepthook(self)
+        self._invoke_excepthook = invoke_excepthook
 
     def run(self):
         """This method should be overridden by a subclass."""

--- a/test/test_machine.py
+++ b/test/test_machine.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+from plover.machine.base import ThreadedStenotypeBase
+
+class MyMachine(ThreadedStenotypeBase):
+    def run(self):
+        raise "some unexpected error"
+
+def test_update_machine_staten_on_unhandled_exception():
+    machine = MyMachine()
+    callback = Mock()
+    machine.add_state_callback(callback)
+    machine.start_capture()
+    machine.join()
+    callback.assert_called_with('disconnected')


### PR DESCRIPTION
## Summary of changes

When the *machine thread* dies due to an unhadled exception then indicate this to the engine (and by extension to the user) by setting the machine state to "disconnected".

This is a first step.  Possible follow-ups:
1. We may choose to handle `serial.serialutil.SerialException` more explicitly as a "disconnect" (say, not even print a stack trace to `stderr`).
2. What I really want from a users perspective is that the machine re-connects automatically (I think it's feasible to do so, stay tuned for a follow-up PR).
3. For `SerialStenotypeBase` specifically, we also want to close the serial port on unhandled exceptions.

Even if we do (1) and/or (2) later, I think we still want this PR as a fallback for arbitrary exceptions.

I will have a separate PR for (3), but again, I think this PR provides merit on its own. So let’s focus on this first.

Closes #1559.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
