### PR TITLE
Fix "Add Translation" formatted translation & raw strokes always using a white background color

### DIFF
--- a/news.d/bugfix/1571.ui.md
+++ b/news.d/bugfix/1571.ui.md
@@ -1,0 +1,1 @@
+Fix "add translation" dialog ignoring the stylesheet's background color for the translation and stroke text.

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -42,14 +42,12 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
         self._special_fmt = (
             '<span style="' +
-            'background-color:' + self.palette().base().color().name() +';' +
             'font-family:monospace;' +
             '">%s</span>'
         )
 
         self._special_fmt_bold = (
             '<span style="' +
-            'background-color:' + self.palette().base().color().name() +';' +
             'font-family:monospace;' +
             'font-weight:bold;' +
             '">%s</span>'


### PR DESCRIPTION
## Summary of changes

Setting the stylesheet resets the palette colors to the system default. For the base color (which was used by the span for the formatted translation & raw stroke text), that'd mean that it'd be reset to `#ffffff`.

While setting the palette from the stylesheet could be done, it's much simpler to instead let the formatted text inherit the background color (i.e. removing the explicit setting of the background color).


Closes #1569

### Pull Request Checklist
- [ ] ~~Changes have tests~~ N/A, UI change
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
