### PR TITLE
Add Option for Inserting Delay between Key Press Events

### DIFF
--- a/plover/config.py
+++ b/plover/config.py
@@ -105,12 +105,14 @@ def json_option(name, default, section, option, validate):
 def int_option(name, default, minimum, maximum, section, option=None):
     option = option or name
     def getter(config, key):
-        return config._config[section].getint(option)
+        return config._config[section][option]
     def setter(config, key, value):
         config._set(section, option, str(value))
     def validate(config, key, value):
-        if not isinstance(value, int):
-            raise InvalidConfigOption(value, default)
+        try:
+            value = int(value)
+        except ValueError as e:
+            raise InvalidConfigOption(value, default) from e
         if (minimum is not None and value < minimum) or \
            (maximum is not None and value > maximum):
             message = '%s not in [%s, %s]' % (value, minimum or '-∞', maximum or '∞')

--- a/plover/config.py
+++ b/plover/config.py
@@ -26,6 +26,8 @@ LOGGING_CONFIG_SECTION = 'Logging Configuration'
 OUTPUT_CONFIG_SECTION = 'Output Configuration'
 DEFAULT_UNDO_LEVELS = 100
 MINIMUM_UNDO_LEVELS = 1
+DEFAULT_TIME_BETWEEN_KEY_PRESSES = 0
+MINIMUM_TIME_BETWEEN_KEY_PRESSES = 0
 
 DEFAULT_SYSTEM_NAME = 'English Stenotype'
 
@@ -335,6 +337,7 @@ class Config:
         boolean_option('start_attached', False, OUTPUT_CONFIG_SECTION),
         boolean_option('start_capitalized', False, OUTPUT_CONFIG_SECTION),
         int_option('undo_levels', DEFAULT_UNDO_LEVELS, MINIMUM_UNDO_LEVELS, None, OUTPUT_CONFIG_SECTION),
+        int_option('time_between_key_presses', DEFAULT_TIME_BETWEEN_KEY_PRESSES, MINIMUM_TIME_BETWEEN_KEY_PRESSES, None, OUTPUT_CONFIG_SECTION),
         # Logging.
         path_option('log_file_name', expand_path('strokes.log'), LOGGING_CONFIG_SECTION, 'log_file'),
         boolean_option('enable_stroke_logging', False, LOGGING_CONFIG_SECTION),

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -211,6 +211,7 @@ class StenoEngine:
         self._formatter.start_attached = config['start_attached']
         self._formatter.start_capitalized = config['start_capitalized']
         self._translator.set_min_undo_length(config['undo_levels'])
+        self._keyboard_emulation.set_key_press_delay(config['time_between_key_presses'])
         # Update system.
         system_name = config['system_name']
         if system.NAME != system_name:

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import (
 )
 
 from plover import _
-from plover.config import MINIMUM_UNDO_LEVELS
+from plover.config import MINIMUM_UNDO_LEVELS, MINIMUM_TIME_BETWEEN_KEY_PRESSES
 from plover.misc import expand_path, shorten_path
 from plover.registry import registry
 
@@ -381,6 +381,17 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                                '\n'
                                'Note: the effective value will take into account the\n'
                                'dictionaries entry with the maximum number of strokes.')),
+                ConfigOption(_('Time between key presses:'), 'time_between_key_presses',
+                             partial(IntOption,
+                                     maximum=100000,
+                                     minimum=MINIMUM_TIME_BETWEEN_KEY_PRESSES),
+                             _('Set the delay between emulated key presses (in milliseconds).\n'
+                               '\n'
+                               'Some programs may drop key presses if too many are sent\n'
+                               'within a short period of time. Increasing the delay gives\n'
+                               'programs time to process each key press.\n'
+                               'Setting the delay too high will negatively impact the\n'
+                               'performance of key stroke output.')),
             )),
             # i18n: Widget: “ConfigWindow”.
             (_('Plugins'), (

--- a/plover/oslayer/linux/keyboardcontrol_x11.py
+++ b/plover/oslayer/linux/keyboardcontrol_x11.py
@@ -1233,15 +1233,28 @@ class KeyboardEmulation(Output):
     def send_string(self, string):
         for char in string:
             keysym = uchr_to_keysym(char)
-            mapping = self._get_mapping(keysym)
+            # TODO: can we find mappings for multiple keys at a time?
+            mapping = self._get_mapping(keysym, automatically_map=False)
+            mapping_changed = False
             if mapping is None:
-                continue
+                mapping = self._get_mapping(keysym, automatically_map=True)
+                if mapping is None:
+                    continue
+                if self._key_press_delay > 0:
+                    self._display.sync()
+                    sleep(self._key_press_delay / 2000)
+                mapping_changed = True
+
             self._send_keycode(mapping.keycode,
                                mapping.modifiers)
+
             self._display.sync()
 
             if self._key_press_delay > 0:
-                sleep(self._key_press_delay / 1000)
+                if mapping_changed:
+                    sleep(self._key_press_delay / 2000)
+                else:
+                    sleep(self._key_press_delay / 1000)
 
     def send_key_combination(self, combo):
         # Parse and validate combo.

--- a/plover/oslayer/linux/keyboardcontrol_x11.py
+++ b/plover/oslayer/linux/keyboardcontrol_x11.py
@@ -24,6 +24,7 @@ http://tronche.com/gui/x/xlib/input/keyboard-encoding.html
 import os
 import select
 import threading
+from time import sleep
 
 from Xlib import X, XK
 from Xlib.display import Display
@@ -1157,6 +1158,7 @@ class KeyboardEmulation(Output):
         super().__init__()
         self._display = Display()
         self._update_keymap()
+        self._key_press_delay = 0
 
     def _update_keymap(self):
         '''Analyse keymap, build a mapping of keysym to (keycode + modifiers),
@@ -1216,11 +1218,17 @@ class KeyboardEmulation(Output):
         # Get modifier mapping.
         self.modifier_mapping = self._display.get_modifier_mapping()
 
+    def set_key_press_delay(self, delay_ms):
+        self._key_press_delay = delay_ms
+
     def send_backspaces(self, count):
         for x in range(count):
             self._send_keycode(self._backspace_mapping.keycode,
                                self._backspace_mapping.modifiers)
-        self._display.sync()
+            self._display.sync()
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def send_string(self, string):
         for char in string:
@@ -1230,7 +1238,10 @@ class KeyboardEmulation(Output):
                 continue
             self._send_keycode(mapping.keycode,
                                mapping.modifiers)
-        self._display.sync()
+            self._display.sync()
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def send_key_combination(self, combo):
         # Parse and validate combo.
@@ -1241,7 +1252,10 @@ class KeyboardEmulation(Output):
         # Emulate the key combination by sending key events.
         for keycode, event_type in key_events:
             xtest.fake_input(self._display, event_type, keycode)
-        self._display.sync()
+            self._display.sync()
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def _send_keycode(self, keycode, modifiers=0):
         """Emulate a key press and release.

--- a/plover/oslayer/osx/keyboardcontrol.py
+++ b/plover/oslayer/osx/keyboardcontrol.py
@@ -309,9 +309,12 @@ class KeyboardEmulation(Output):
     def __init__(self):
         super().__init__()
         self._layout = KeyboardLayout()
+        self._key_press_delay = 0
 
-    @staticmethod
-    def send_backspaces(count):
+    def set_key_press_delay(self, delay_ms):
+        self._key_press_delay = delay_ms
+
+    def send_backspaces(self, count):
         for _ in range(count):
             backspace_down = CGEventCreateKeyboardEvent(
                 OUTPUT_SOURCE, BACK_SPACE, True)
@@ -319,6 +322,8 @@ class KeyboardEmulation(Output):
                 OUTPUT_SOURCE, BACK_SPACE, False)
             CGEventPost(kCGSessionEventTap, backspace_down)
             CGEventPost(kCGSessionEventTap, backspace_up)
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def send_string(self, string):
         # Key plan will store the type of output
@@ -367,6 +372,9 @@ class KeyboardEmulation(Output):
             elif press_type is self.RAW_PRESS:
                 self._send_sequence(sequence)
 
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
+
     @staticmethod
     def _send_string_press(c):
         event = CGEventCreateKeyboardEvent(OUTPUT_SOURCE, 0, True)
@@ -396,6 +404,9 @@ class KeyboardEmulation(Output):
         key_events = parse_key_combo(combo, name_to_code)
         # Send events...
         self._send_sequence(key_events)
+
+        if self._key_press_delay > 0:
+            sleep(self._key_press_delay / 1000)
 
     @staticmethod
     def _modifier_to_keycodes(modifier):

--- a/plover/oslayer/windows/keyboardcontrol.py
+++ b/plover/oslayer/windows/keyboardcontrol.py
@@ -430,6 +430,7 @@ class KeyboardEmulation(Output):
     def __init__(self):
         super().__init__()
         self.keyboard_layout = KeyboardLayout()
+        self._key_press_delay = 0
 
     # Sends input types to buffer
     @staticmethod
@@ -497,9 +498,15 @@ class KeyboardEmulation(Output):
                   for code in pairs]
         self._send_input(*inputs)
 
+    def set_key_press_delay(self, delay_ms):
+        self._key_press_delay = delay_ms
+
     def send_backspaces(self, count):
         for _ in range(count):
             self._key_press('\x08')
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def send_string(self, string):
         self._refresh_keyboard_layout()
@@ -511,6 +518,9 @@ class KeyboardEmulation(Output):
                 # Otherwise, we send it as a Unicode string.
                 self._key_unicode(char)
 
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
+
     def send_key_combination(self, combo):
         # Make sure keyboard layout is up-to-date.
         self._refresh_keyboard_layout()
@@ -519,3 +529,6 @@ class KeyboardEmulation(Output):
         # Send events...
         for keycode, pressed in key_events:
             self._key_event(keycode, pressed)
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)

--- a/plover/oslayer/windows/keyboardcontrol.py
+++ b/plover/oslayer/windows/keyboardcontrol.py
@@ -14,6 +14,7 @@ emulate keyboard input.
 """
 
 from ctypes import windll, wintypes
+from time import sleep
 import atexit
 import ctypes
 import multiprocessing

--- a/plover/output/__init__.py
+++ b/plover/output/__init__.py
@@ -16,3 +16,7 @@ class Output:
         See `plover.key_combo` for the format of the `combo` string.
         """
         raise NotImplementedError()
+    
+    def set_key_press_delay(self, delay_ms):
+        """Sets the delay between outputting key press events."""
+        raise NotImplementedError()

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -16,6 +16,7 @@ from plover.machine.base import (
 from plover.machine.keymap import Keymap
 from plover.misc import normalize_path
 from plover.oslayer.controller import Controller
+from plover.output import Output
 from plover.registry import Registry
 from plover.steno_dictionary import StenoDictionaryCollection
 
@@ -50,7 +51,7 @@ class FakeMachine(StenotypeBase):
     def set_suppression(self, enabled):
         self.is_suppressed = enabled
 
-class FakeKeyboardEmulation:
+class FakeKeyboardEmulation(Output):
 
     def send_backspaces(self, b):
         pass
@@ -59,6 +60,9 @@ class FakeKeyboardEmulation:
         pass
 
     def send_key_combination(self, c):
+        pass
+
+    def set_key_press_delay(self, delay_ms):
         pass
 
 class FakeEngine(StenoEngine):


### PR DESCRIPTION
## Summary of changes

On Pop_OS! 22.04, typing in Firefox often drops backspaces when undoing words (likely due to #1030). While it doesn't fix that issue, this is a suitable workaround in the mean time (there are also other input issues for other users on other OSes that are fixed by adding a delay between key presses).

Supersedes #1132 (see [this comment](https://github.com/openstenoproject/plover/pull/1132#issuecomment-1229173322)).

Also keeps the same option name as the original PR so that anyone using the old PR can use this one without having to change anything.

### Notable changes from the original PR

- Also includes [this change](https://github.com/user202729/plover/commit/f4cb21c5f6d178b06340a77c68629d370d0b5944) to delay when changing keymaps in Linux.

- Adds `set_key_press_delay` to Output. When not implemented it currently raises a `NotImplementedError`, although for some output interfaces it may be okay to just leave it as a stub.

Tested on:

- [x] Linux
- [ ] macOS
- [ ] Windows

### Pull Request Checklist
- [x] Changes have tests
    - Note: only for if an int option is missing, not for validating if the delay option is not negative
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
