### PR TITLE
Update commands and OS versions in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,16 @@ jobs:
         id: set_cache
         run: |
           job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-22.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-22.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-12; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-12; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2022; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2022; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-22.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-22.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_cache_key
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_cache_key
           job_cache_extra_deps=('reqs/dist_*.txt' linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-22.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-22.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
-          job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-12; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-12; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_cache_key
+          job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2022; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2022; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
 
       - name: Check skip cache for Test (Linux)
         uses: actions/cache@v3
@@ -142,16 +142,16 @@ jobs:
         run: |
           analyze_set_release_info
           job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-22.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-22.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_job
-          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_job
-          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_job
+          job_cache_extra_deps=(osx/deps.sh); job_id=test_macos; job_name='Test (macOS)'; job_needs=(); job_os=macOS; job_platform=macos-12; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_macos_py-3.9_macos-12; job_skip_cache_path=.skip_cache_test_macos; job_skiplists=(job_test os_macos); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=macOS; analyze_set_job_skip_job
+          job_cache_extra_deps=(); job_id=test_windows; job_name='Test (Windows)'; job_needs=(); job_os=Windows; job_platform=windows-2022; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_windows_py-3.9_windows-2022; job_skip_cache_path=.skip_cache_test_windows; job_skiplists=(job_test os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Windows; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_python_37; job_name='Test (Python 3.7)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.7; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_37_py-3.7_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_37; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.7'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_python_38; job_name='Test (Python 3.8)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.8; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_38_py-3.8_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_38; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.8'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_python_310; job_name='Test (Python 3.10)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.10; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_python_310_py-3.10_ubuntu-latest; job_skip_cache_path=.skip_cache_test_python_310; job_skiplists=(job_test os_linux os_macos os_windows); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant='Python 3.10'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_qt_gui; job_name='Test (Qt GUI)'; job_needs=(); job_os=Linux; job_platform=ubuntu-22.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/dist_extra_gui_qt.txt reqs/test.txt); job_skip_cache_name=skip_test_qt_gui_py-3.9_ubuntu-22.04; job_skip_cache_path=.skip_cache_test_qt_gui; job_skiplists=(job_test_gui_qt); job_test_args=test/gui_qt; job_type=test_gui_qt; job_variant='Qt GUI'; analyze_set_job_skip_job
           job_cache_extra_deps=(); job_id=test_packaging; job_name='Test (Packaging)'; job_needs=(); job_os=Linux; job_platform=ubuntu-latest; job_python=3.9; job_reqs=(reqs/packaging.txt reqs/setup.txt); job_skip_cache_name=skip_test_packaging_py-3.9_ubuntu-latest; job_skip_cache_path=.skip_cache_test_packaging; job_skiplists=(job_test_packaging); job_type=test_packaging; job_variant=Packaging; analyze_set_job_skip_job
           job_cache_extra_deps=('reqs/dist_*.txt' linux/appimage/deps.sh); job_id=build_linux; job_name='Build (Linux)'; job_needs=(test_linux); job_os=Linux; job_platform=ubuntu-22.04; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_linux_py-3.9_ubuntu-22.04; job_skip_cache_path=.skip_cache_build_linux; job_skiplists=(job_build os_linux); job_type=build; job_variant=Linux; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-10.15; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-10.15; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_job
-          job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_*.txt' osx/deps.sh); job_id=build_macos; job_name='Build (macOS)'; job_needs=(test_macos); job_os=macOS; job_platform=macos-12; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_macos_py-3.9_macos-12; job_skip_cache_path=.skip_cache_build_macos; job_skiplists=(job_build os_macos); job_type=build; job_variant=macOS; analyze_set_job_skip_job
+          job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2022; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2022; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_job
 
     outputs:
       is_release: ${{ steps.set_ouputs.outputs.is_release }}
@@ -241,7 +241,7 @@ jobs:
   test_macos:
 
     name: Test (macOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: [analyze, ]
     if: >-
       !cancelled()
@@ -254,7 +254,7 @@ jobs:
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.9' 'macos-10.15'
+        run: setup_cache_name '3.9' 'macos-12'
 
       - name: Setup cache
         uses: actions/cache@v3
@@ -296,7 +296,7 @@ jobs:
   test_windows:
 
     name: Test (Windows)
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [analyze, ]
     if: >-
       !cancelled()
@@ -319,7 +319,7 @@ jobs:
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.9' 'windows-2019'
+        run: setup_cache_name '3.9' 'windows-2022'
 
       - name: Setup cache
         uses: actions/cache@v3
@@ -749,7 +749,7 @@ jobs:
   build_macos:
 
     name: Build (macOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: [analyze, test_macos]
     if: >-
       !cancelled()
@@ -766,7 +766,7 @@ jobs:
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.9' 'macos-10.15'
+        run: setup_cache_name '3.9' 'macos-12'
 
       - name: Setup cache
         uses: actions/cache@v3
@@ -818,7 +818,7 @@ jobs:
   build_windows:
 
     name: Build (Windows)
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [analyze, test_windows]
     if: >-
       !cancelled()
@@ -845,7 +845,7 @@ jobs:
 
       - name: Set cache name
         id: set_cache
-        run: setup_cache_name '3.9' 'windows-2019'
+        run: setup_cache_name '3.9' 'windows-2022'
 
       - name: Setup cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Calculate skip cache keys
         id: set_cache
@@ -48,7 +48,7 @@ jobs:
           job_cache_extra_deps=('reqs/dist_*.txt' windows/dist_deps.sh); job_id=build_windows; job_name='Build (Windows)'; job_needs=(test_windows); job_os=Windows; job_platform=windows-2019; job_python=3.9; job_reqs=(reqs/build.txt reqs/setup.txt); job_skip_cache_name=skip_build_windows_py-3.9_windows-2019; job_skip_cache_path=.skip_cache_build_windows; job_skiplists=(job_build os_windows); job_type=build; job_variant=Windows; analyze_set_job_skip_cache_key
 
       - name: Check skip cache for Test (Linux)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_linux
           key: 0_check_${{ steps.set_cache.outputs.test_linux_skip_cache_key }}_${{ github.run_id }}
@@ -56,7 +56,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_linux_skip_cache_key }}
 
       - name: Check skip cache for Test (macOS)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_macos
           key: 0_check_${{ steps.set_cache.outputs.test_macos_skip_cache_key }}_${{ github.run_id }}
@@ -64,7 +64,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_macos_skip_cache_key }}
 
       - name: Check skip cache for Test (Windows)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_windows
           key: 0_check_${{ steps.set_cache.outputs.test_windows_skip_cache_key }}_${{ github.run_id }}
@@ -72,7 +72,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_windows_skip_cache_key }}
 
       - name: Check skip cache for Test (Python 3.7)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_python_37
           key: 0_check_${{ steps.set_cache.outputs.test_python_37_skip_cache_key }}_${{ github.run_id }}
@@ -80,7 +80,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_python_37_skip_cache_key }}
 
       - name: Check skip cache for Test (Python 3.8)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_python_38
           key: 0_check_${{ steps.set_cache.outputs.test_python_38_skip_cache_key }}_${{ github.run_id }}
@@ -88,7 +88,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_python_38_skip_cache_key }}
 
       - name: Check skip cache for Test (Python 3.10)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_python_310
           key: 0_check_${{ steps.set_cache.outputs.test_python_310_skip_cache_key }}_${{ github.run_id }}
@@ -96,7 +96,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_python_310_skip_cache_key }}
 
       - name: Check skip cache for Test (Qt GUI)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_qt_gui
           key: 0_check_${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}_${{ github.run_id }}
@@ -104,7 +104,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_qt_gui_skip_cache_key }}
 
       - name: Check skip cache for Test (Packaging)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_packaging
           key: 0_check_${{ steps.set_cache.outputs.test_packaging_skip_cache_key }}_${{ github.run_id }}
@@ -112,7 +112,7 @@ jobs:
             0_${{ steps.set_cache.outputs.test_packaging_skip_cache_key }}
 
       - name: Check skip cache for Build (Linux)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_build_linux
           key: 0_check_${{ steps.set_cache.outputs.build_linux_skip_cache_key }}_${{ github.run_id }}
@@ -120,7 +120,7 @@ jobs:
             0_${{ steps.set_cache.outputs.build_linux_skip_cache_key }}
 
       - name: Check skip cache for Build (macOS)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_build_macos
           key: 0_check_${{ steps.set_cache.outputs.build_macos_skip_cache_key }}_${{ github.run_id }}
@@ -128,7 +128,7 @@ jobs:
             0_${{ steps.set_cache.outputs.build_macos_skip_cache_key }}
 
       - name: Check skip cache for Build (Windows)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_build_windows
           key: 0_check_${{ steps.set_cache.outputs.build_windows_skip_cache_key }}_${{ github.run_id }}
@@ -194,10 +194,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -206,7 +206,7 @@ jobs:
         run: setup_cache_name '3.9' 'ubuntu-22.04'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
@@ -225,7 +225,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_linux
           key: 0_${{ needs.analyze.outputs.test_linux_skip_cache_key }}
@@ -250,14 +250,14 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set cache name
         id: set_cache
         run: setup_cache_name '3.9' 'macos-10.15'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt', 'osx/deps.sh') }}
@@ -280,7 +280,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_macos
           key: 0_${{ needs.analyze.outputs.test_macos_skip_cache_key }}
@@ -305,10 +305,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -322,7 +322,7 @@ jobs:
         run: setup_cache_name '3.9' 'windows-2019'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
@@ -341,7 +341,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_windows
           key: 0_${{ needs.analyze.outputs.test_windows_skip_cache_key }}
@@ -366,10 +366,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
 
@@ -378,7 +378,7 @@ jobs:
         run: setup_cache_name '3.7' 'ubuntu-latest'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
@@ -397,7 +397,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_python_37
           key: 0_${{ needs.analyze.outputs.test_python_37_skip_cache_key }}
@@ -422,10 +422,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -434,7 +434,7 @@ jobs:
         run: setup_cache_name '3.8' 'ubuntu-latest'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
@@ -453,7 +453,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_python_38
           key: 0_${{ needs.analyze.outputs.test_python_38_skip_cache_key }}
@@ -478,10 +478,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -490,7 +490,7 @@ jobs:
         run: setup_cache_name '3.10' 'ubuntu-latest'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/test.txt') }}
@@ -509,7 +509,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_python_310
           key: 0_${{ needs.analyze.outputs.test_python_310_skip_cache_key }}
@@ -534,10 +534,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -546,7 +546,7 @@ jobs:
         run: setup_cache_name '3.9' 'ubuntu-22.04'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/dist.txt', 'reqs/dist_extra_gui_qt.txt', 'reqs/test.txt') }}
@@ -568,7 +568,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_qt_gui
           key: 0_${{ needs.analyze.outputs.test_qt_gui_skip_cache_key }}
@@ -593,13 +593,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need the whole history for patching the version.
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -608,7 +608,7 @@ jobs:
         run: setup_cache_name '3.9' 'ubuntu-latest'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/packaging.txt', 'reqs/setup.txt') }}
@@ -622,7 +622,7 @@ jobs:
         id: set_version
         run: |
           python setup.py patch_version
-          echo "::set-output name=version::$(python setup.py --version)"
+          echo "version=$(python setup.py --version)" >> $GITHUB_OUTPUT
 
       # Test packaging {{{
 
@@ -631,14 +631,14 @@ jobs:
 
       - name: Archive artifact (sdist)
         if: needs.analyze.outputs.is_release == 'yes'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Source
           path: dist/*.tar.gz
 
       - name: Archive artifact (wheel)
         if: needs.analyze.outputs.is_release == 'yes'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Wheel
           path: dist/*.whl
@@ -649,7 +649,7 @@ jobs:
 
       - name: Archive artifact (translations catalogs)
         if: needs.analyze.outputs.is_release == 'yes'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Translations Catalogs
           path: dist/*-messages.zip
@@ -657,7 +657,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_test_packaging
           key: 0_${{ needs.analyze.outputs.test_packaging_skip_cache_key }}
@@ -686,13 +686,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need the whole history for patching the version.
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -701,7 +701,7 @@ jobs:
         run: setup_cache_name '3.9' 'ubuntu-22.04'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_*.txt', 'linux/appimage/deps.sh') }}
@@ -725,7 +725,7 @@ jobs:
         run: python setup.py -q bdist_appimage --no-update-tools
 
       - name: Archive artifact (Linux AppImage)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Linux AppImage
           path: dist/*.AppImage
@@ -733,7 +733,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_build_linux
           key: 0_${{ needs.analyze.outputs.build_linux_skip_cache_key }}
@@ -759,7 +759,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need the whole history for patching the version.
           fetch-depth: 0
@@ -769,7 +769,7 @@ jobs:
         run: setup_cache_name '3.9' 'macos-10.15'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_*.txt', 'osx/deps.sh') }}
@@ -794,7 +794,7 @@ jobs:
         run: python setup.py -q bdist_dmg
 
       - name: Archive artifact (macOS DMG)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macOS DMG
           path: dist/*.dmg
@@ -802,7 +802,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_build_macos
           key: 0_${{ needs.analyze.outputs.build_macos_skip_cache_key }}
@@ -828,13 +828,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need the whole history for patching the version.
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -848,7 +848,7 @@ jobs:
         run: setup_cache_name '3.9' 'windows-2019'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache
           key: 0_${{ steps.set_cache.outputs.cache_name }}_${{ hashFiles('reqs/constraints.txt', 'reqs/build.txt', 'reqs/setup.txt', 'reqs/dist_*.txt', 'windows/dist_deps.sh') }}
@@ -872,13 +872,13 @@ jobs:
           python setup.py -q bdist_win -t -z -i --bash="$bash"
 
       - name: Archive artifact (Windows Installer)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Windows Installer
           path: dist/*.exe
 
       - name: Archive artifact (Windows ZIP)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Windows ZIP
           path: dist/*.zip
@@ -886,7 +886,7 @@ jobs:
       # }}}
 
       - name: Update skip cache 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .skip_cache_build_windows
           key: 0_${{ needs.analyze.outputs.build_windows_skip_cache_key }}
@@ -923,10 +923,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
@@ -936,7 +936,7 @@ jobs:
           run "$python" -m pip install -c reqs/constraints.txt -r reqs/release.txt
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: dist
 

--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -40,7 +40,7 @@ setup_cache_name()
     [ "$target_python" = "${py_installer_version%.*}" ] || die 1 "versions mismatch: target=$target_python, installer=$py_installer_version"
     target_python="$py_installer_version"
   fi
-  "$python" - "$GITHUB_JOB" "$target_python" "$platform_name" <<\EOF
+  cache_name=$("$python" - "$GITHUB_JOB" "$target_python" "$platform_name" <<\EOF
 import platform
 import re
 import sys
@@ -57,9 +57,9 @@ else:
   assert parts == python_version.split('.')[:len(parts)], \
     'versions mismatch: expected=%s, actual=%s' % (target_python, python_version)
 
-cache_name = '%s_py-%s_%s' % (name, python_version, platform_name)
-print('::set-output name=cache_name::' + cache_name)
-EOF
+print(f'{name}_py-{python_version}_{platform_name}')
+EOF)
+  echo "cache_name=$cache_name" >> $GITHUB_OUTPUT
 }
 
 setup_osx_python()
@@ -246,9 +246,9 @@ analyze_set_release_info()
     skip_release='yes'
   fi
   info "Skip Release? $skip_release ($release_type)"
-  echo "::set-output name=is_release::$is_release"
-  echo "::set-output name=release_type::$release_type"
-  echo "::set-output name=release_skip_job::$skip_release"
+  echo "is_release=$is_release" >> $GITHUB_OUTPUT
+  echo "release_type=$release_type" >> $GITHUB_OUTPUT
+  echo "release_skip_job=$skip_release" >> $GITHUB_OUTPUT
 }
 
 analyze_set_job_skip_cache_key()
@@ -260,7 +260,7 @@ analyze_set_job_skip_cache_key()
     skiplists+=(".github/workflows/ci/skiplist_$list.txt")
   done
   sha1="$(git_tree_sha1 -d '@' "${skiplists[@]}")" || die
-  echo "::set-output name=${job_id}_skip_cache_key::${job_skip_cache_name}_$sha1"
+  echo "${job_id}_skip_cache_key=${job_skip_cache_name}_$sha1" >> $GITHUB_OUTPUT
   echo '::endgroup::' 1>&2
 }
 
@@ -275,7 +275,7 @@ analyze_set_job_skip_job()
     skip_job='no'
   fi
   info "Skip $job_name? $skip_job"
-  echo "::set-output name=${job_id}_skip_job::$skip_job"
+  echo "${job_id}_skip_job=$skip_job" >> $GITHUB_OUTPUT
 }
 
 python='python3'

--- a/.github/workflows/ci/workflow_context.yml
+++ b/.github/workflows/ci/workflow_context.yml
@@ -1,10 +1,10 @@
 cache_epoch: 0 # <- increase number to clear cache.
 
-action_cache: actions/cache@v2
-action_checkout: actions/checkout@v2
-action_setup_python: actions/setup-python@v2
-action_upload_artifact: actions/upload-artifact@v2
-action_download_artifact: actions/download-artifact@v2
+action_cache: actions/cache@v3
+action_checkout: actions/checkout@v3
+action_setup_python: actions/setup-python@v4
+action_upload_artifact: actions/upload-artifact@v3
+action_download_artifact: actions/download-artifact@v3
 
 skippy_enabled: true
 

--- a/.github/workflows/ci/workflow_context.yml
+++ b/.github/workflows/ci/workflow_context.yml
@@ -19,13 +19,13 @@ vars:
     variant: macOS
     python: '3.9'
     os: macOS
-    platform: macos-10.15
+    platform: macos-12
 
   - &dist_win
     variant: Windows
     python: '3.9'
     os: Windows
-    platform: windows-2019
+    platform: windows-2022
 
   - &dist_other
     os: Linux

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -37,7 +37,7 @@ jobs:
 
       <% for j in jobs %>
       - name: Check skip cache for <@ j.name @>
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: <@ j.skip_cache_path @>
           key: <@ cache_epoch @>_check_${{ steps.set_cache.outputs.<@ j.id @>_skip_cache_key }}_${{ github.run_id }}
@@ -56,7 +56,7 @@ jobs:
           <% if skippy_enabled %>
           <@ j.shell_definition @>; analyze_set_job_skip_job
           <% else %>
-          echo "::set-output name=<@ j.id @>_skip_job::no"
+          echo "<@ j.id @>_skip_job=no" >> $GITHUB_OUTPUT
           <% endif %>
           <% endfor %>
 
@@ -141,7 +141,7 @@ jobs:
         run: |
           python setup.py patch_version
           <% if j.type == 'test_packaging' %>
-          echo "::set-output name=version::$(python setup.py --version)"
+          echo "version=$(python setup.py --version)" >> $GITHUB_OUTPUT
           <% endif %>
 
       <% endif %>

--- a/news.d/feature/1598.osx.md
+++ b/news.d/feature/1598.osx.md
@@ -1,0 +1,1 @@
+Update GitHub Actions from macOS 10.15 to 12.

--- a/news.d/feature/1598.windows.md
+++ b/news.d/feature/1598.windows.md
@@ -1,0 +1,1 @@
+Update GitHub Actions from Windows 2019 to 2022.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The goal of this PR is to fix all deprecation warnings that we currently have in our GitHub Action runs, see for example [the latest run on master](https://github.com/openstenoproject/plover/actions/runs/4395109518):
* replaces the deprecated `set-output` command, see [GitHub Blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* updates all imported GitHub Actions such as actions/cache to remove related deprecation warnings
* updates deprecated macos-10.15 version in GitHub Actions
* updates windows-2019 version in GitHub Actions because why not

See [this run](https://github.com/openstenoproject/plover/actions/runs/4396816672) which does not show any warnings.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details