### PR TITLE
Remove explicit background-color setting in add translation widget

### DIFF
--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -42,14 +42,12 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
         self._special_fmt = (
             '<span style="' +
-            'background-color:' + self.palette().base().color().name() +';' +
             'font-family:monospace;' +
             '">%s</span>'
         )
 
         self._special_fmt_bold = (
             '<span style="' +
-            'background-color:' + self.palette().base().color().name() +';' +
             'font-family:monospace;' +
             'font-weight:bold;' +
             '">%s</span>'


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Now Comblinear stylesheet will correctly make the entry in the add translation dialog readable.

https://github.com/openstenoproject/plover/discussions/1415

9f1bdde658f8887e10d651961d5c2eafe9d8742d introduced this change, with justification for the bold part but no justification for the background part.

In my testing, (Linux only!) with no style sheet applied then the background of these spans are white both before and after the change.

(looking at occurrences of `palette()`, the DictionaryEditor also doesn't look good in comblinear style but that's another issue.)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
