### PR TITLE
First-up chord send for keyboard machine

### DIFF
--- a/news.d/feature/1611.core.md
+++ b/news.d/feature/1611.core.md
@@ -1,0 +1,1 @@
+Implement first-up chord send for keyboard machine.

--- a/plover/gui_qt/config_keyboard_widget.ui
+++ b/plover/gui_qt/config_keyboard_widget.ui
@@ -6,14 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>117</width>
-    <height>38</height>
+    <width>159</width>
+    <height>66</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true"/>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout">
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="first_up_chord_send">
+     <property name="toolTip">
+      <string>When the first key in a chord is released, the chord is sent.
+If the key is pressed and released again, another chord is sent.</string>
+     </property>
+     <property name="text">
+      <string>First-up chord send</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QCheckBox" name="arpeggiate">
      <property name="sizePolicy">
@@ -47,8 +58,25 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>first_up_chord_send</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>KeyboardWidget</receiver>
+   <slot>on_first_up_chord_send_changed(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>79</x>
+     <y>46</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>79</x>
+     <y>32</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>on_arpeggiate_changed(bool)</slot>
+  <slot>on_first_up_chord_send_changed(bool)</slot>
  </slots>
 </ui>

--- a/plover/gui_qt/machine_options.py
+++ b/plover/gui_qt/machine_options.py
@@ -214,7 +214,12 @@ class KeyboardOption(QGroupBox, Ui_KeyboardWidget):
     def setValue(self, value):
         self._value = copy(value)
         self.arpeggiate.setChecked(value['arpeggiate'])
+        self.first_up_chord_send.setChecked(value['first_up_chord_send'])
 
     def on_arpeggiate_changed(self, value):
         self._value['arpeggiate'] = value
+        self.valueChanged.emit(self._value)
+
+    def on_first_up_chord_send_changed(self, value):
+        self._value['first_up_chord_send'] = value
         self.valueChanged.emit(self._value)

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -32,7 +32,7 @@ SET_CONFIG_TESTS = (
     lambda: ('"log_file_name":"c:/whatever/morestrokes.log"',  "c:/whatever/morestrokes.log"),
     lambda: ('"enabled_extensions":[]',                        set()),
     lambda: ('"machine_type":"Keyboard"',                      "Keyboard"),
-    lambda: ('"machine_specific_options":{"arpeggiate":True}', {"arpeggiate": True}),
+    lambda: ('"machine_specific_options":{"arpeggiate":True}', {"arpeggiate": True, "first_up_chord_send": False}),
     lambda: ('"system_keymap":'+str(DEFAULT_KEYMAP),           DEFAULT_KEYMAP),
     lambda: ('"dictionaries":("user.json","main.json")',       list(map(DictionaryConfig, ("user.json", "main.json")))),
 )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -127,7 +127,7 @@ DEFAULTS = {
     'enabled_extensions': set(),
     'auto_start': False,
     'machine_type': 'Keyboard',
-    'machine_specific_options': { 'arpeggiate': False },
+    'machine_specific_options': { 'arpeggiate': False, 'first_up_chord_send': False },
     'system_name': config.DEFAULT_SYSTEM_NAME,
     'system_keymap': DEFAULT_KEYMAP,
     'dictionaries': [DictionaryConfig(p) for p in english_stenotype.DEFAULT_DICTIONARIES]
@@ -249,11 +249,13 @@ CONFIG_TESTS = (
      {
          'machine_specific_options': {
              'arpeggiate': True,
+             'first_up_chord_send': False,
          }
      },
      '''
      [Keyboard]
      arpeggiate = True
+     first_up_chord_send = False
      '''
     ),
 

--- a/test/test_keyboard.py
+++ b/test/test_keyboard.py
@@ -25,17 +25,21 @@ def capture():
     with mock.patch('plover.machine.keyboard.KeyboardCapture', new=lambda: capture):
         yield capture
 
-@pytest.fixture(params=[False])
+@pytest.fixture(params=[{'arpeggiate': False, 'first_up_chord_send': False}])
 def machine(request, capture):
-    machine = Keyboard({'arpeggiate': request.param})
+    machine = Keyboard(request.param)
     keymap = Keymap(Keyboard.KEYS_LAYOUT.split(),
                     system.KEYS + Keyboard.ACTIONS)
     keymap.set_mappings(system.KEYMAPS['Keyboard'])
     machine.set_keymap(keymap)
     return machine
 
-def arpeggiate(func):
-    return pytest.mark.parametrize('machine', [True], indirect=True)(func)
+arpeggiate = pytest.mark.parametrize('machine', [{'arpeggiate': True, 'first_up_chord_send': False}], indirect=True)
+first_up_chord_send = pytest.mark.parametrize('machine', [{'arpeggiate': False, 'first_up_chord_send': True}], indirect=True)
+"""
+These are decorators to be applied on test functions to modify the machine configuration.
+Note that at the moment it's not possible to apply both at the same time.
+"""
 
 @pytest.fixture
 def strokes(machine):
@@ -97,3 +101,13 @@ def test_arpeggiate_2(capture, machine, strokes):
     machine.start_capture()
     send_input(capture, 'a +h +space -space -h w')
     assert strokes == [{'S-', '*'}]
+
+@first_up_chord_send
+def test_first_up_chord_send(capture, machine, strokes):
+    machine.start_capture()
+    send_input(capture, '+a +w +l -l +l')
+    assert strokes == [{'S-', 'T-', '-G'}]
+    send_input(capture, '-l')
+    assert strokes == [{'S-', 'T-', '-G'}, {'S-', 'T-', '-G'}]
+    send_input(capture, '-a -w')
+    assert strokes == [{'S-', 'T-', '-G'}, {'S-', 'T-', '-G'}]


### PR DESCRIPTION
## Summary of changes

See title.

Refer to http://plover.stenoknight.com/2021/09/qmk-extensions-for-hobbyist-stenoboards.html for some detail what first-up chord send is -- basically this allow you to, e.g. if you have STPH-G bound to [→] (`{#Right}{^}`), then you can hold down STPH and repeatedly press -G to press [→] multiple times.

--------

Later it may be useful for things like "repeatedly send a chord with frequency X if it's held for longer than time Y", so making a check box doesn't feel like the best idea.

Currently it gives an error (that can only be fixed by clicking the refresh button) if both options are checked. Maybe it's better to either make a combo box or make the GUI automatically untick the other button if one is ticked (this may be confusing though)?

There's a quirk: currently if I hold down PHRO, then press -LG repeatedly, it should toggle the machine repeatedly, but the problem is it deletes 2 characters on each subsequent enable (when the other keys are not released then somehow the un-suppress does not "register", not sure). I'm not sure what the situation is on other platforms, but if it is then some modification would be in order.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
