### PR TITLE
Revert original tabstop order of fields in add translation widget

### DIFF
--- a/plover/gui_qt/add_translation_widget.ui
+++ b/plover/gui_qt/add_translation_widget.ui
@@ -163,9 +163,9 @@
  <tabstops>
   <tabstop>strokes</tabstop>
   <tabstop>translation</tabstop>
+  <tabstop>dictionary</tabstop>
   <tabstop>strokes_info</tabstop>
   <tabstop>translation_info</tabstop>
-  <tabstop>dictionary</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION

## Summary of changes


Closes #1624.

Looks like the change was made in #1308.

I believe reordering the tab stops should not affect the accessibility issues, but it would again be a breaking change. Any opinion?

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
