### PR TITLE
Add configurable key press delay

### DIFF
--- a/news.d/api/1633.new.md
+++ b/news.d/api/1633.new.md
@@ -1,0 +1,1 @@
+Introduces the `GenericKeyboardEmulation` interface which automatically handles output delay.

--- a/news.d/feature/1633.core.md
+++ b/news.d/feature/1633.core.md
@@ -1,0 +1,1 @@
+Added a configurable delay between key presses, to accommodate applications that can't handle fast keyboard emulation.

--- a/plover/config.py
+++ b/plover/config.py
@@ -26,6 +26,8 @@ LOGGING_CONFIG_SECTION = 'Logging Configuration'
 OUTPUT_CONFIG_SECTION = 'Output Configuration'
 DEFAULT_UNDO_LEVELS = 100
 MINIMUM_UNDO_LEVELS = 1
+DEFAULT_TIME_BETWEEN_KEY_PRESSES = 0
+MINIMUM_TIME_BETWEEN_KEY_PRESSES = 0
 
 DEFAULT_SYSTEM_NAME = 'English Stenotype'
 
@@ -105,12 +107,14 @@ def json_option(name, default, section, option, validate):
 def int_option(name, default, minimum, maximum, section, option=None):
     option = option or name
     def getter(config, key):
-        return config._config[section].getint(option)
+        return config._config[section][option]
     def setter(config, key, value):
         config._set(section, option, str(value))
     def validate(config, key, value):
-        if not isinstance(value, int):
-            raise InvalidConfigOption(value, default)
+        try:
+            value = int(value)
+        except ValueError as e:
+            raise InvalidConfigOption(value, default) from e
         if (minimum is not None and value < minimum) or \
            (maximum is not None and value > maximum):
             message = '%s not in [%s, %s]' % (value, minimum or '-∞', maximum or '∞')
@@ -333,6 +337,7 @@ class Config:
         boolean_option('start_attached', False, OUTPUT_CONFIG_SECTION),
         boolean_option('start_capitalized', False, OUTPUT_CONFIG_SECTION),
         int_option('undo_levels', DEFAULT_UNDO_LEVELS, MINIMUM_UNDO_LEVELS, None, OUTPUT_CONFIG_SECTION),
+        int_option('time_between_key_presses', DEFAULT_TIME_BETWEEN_KEY_PRESSES, MINIMUM_TIME_BETWEEN_KEY_PRESSES, None, OUTPUT_CONFIG_SECTION),
         # Logging.
         path_option('log_file_name', expand_path('strokes.log'), LOGGING_CONFIG_SECTION, 'log_file'),
         boolean_option('enable_stroke_logging', False, LOGGING_CONFIG_SECTION),

--- a/plover/engine.py
+++ b/plover/engine.py
@@ -211,6 +211,7 @@ class StenoEngine:
         self._formatter.start_attached = config['start_attached']
         self._formatter.start_capitalized = config['start_capitalized']
         self._translator.set_min_undo_length(config['undo_levels'])
+        self._keyboard_emulation.set_key_press_delay(config['time_between_key_presses'])
         # Update system.
         system_name = config['system_name']
         if system.NAME != system_name:

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import (
 )
 
 from plover import _
-from plover.config import MINIMUM_UNDO_LEVELS
+from plover.config import MINIMUM_UNDO_LEVELS, MINIMUM_TIME_BETWEEN_KEY_PRESSES
 from plover.misc import expand_path, shorten_path
 from plover.registry import registry
 
@@ -381,6 +381,17 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowState):
                                '\n'
                                'Note: the effective value will take into account the\n'
                                'dictionaries entry with the maximum number of strokes.')),
+                ConfigOption(_('Time between key presses:'), 'time_between_key_presses',
+                             partial(IntOption,
+                                     maximum=100000,
+                                     minimum=MINIMUM_TIME_BETWEEN_KEY_PRESSES),
+                             _('Set the delay between emulated key presses (in milliseconds).\n'
+                               '\n'
+                               'Some programs may drop key presses if too many are sent\n'
+                               'within a short period of time. Increasing the delay gives\n'
+                               'programs time to process each key press.\n'
+                               'Setting the delay too high will negatively impact the\n'
+                               'performance of key stroke output.')),
             )),
             # i18n: Widget: “ConfigWindow”.
             (_('Plugins'), (

--- a/plover/oslayer/linux/keyboardcontrol_x11.py
+++ b/plover/oslayer/linux/keyboardcontrol_x11.py
@@ -24,7 +24,6 @@ http://tronche.com/gui/x/xlib/input/keyboard-encoding.html
 import os
 import select
 import threading
-from time import sleep
 
 from Xlib import X, XK
 from Xlib.display import Display
@@ -34,7 +33,7 @@ from Xlib.ext.ge import GenericEventCode
 from plover import log
 from plover.key_combo import add_modifiers_aliases, parse_key_combo
 from plover.machine.keyboard_capture import Capture
-from plover.output import Output
+from plover.output.keyboard import GenericKeyboardEmulation
 
 
 # Enable support for media keys.
@@ -1128,7 +1127,7 @@ def keysym_to_string(keysym):
     return chr(code)
 
 
-class KeyboardEmulation(Output):
+class KeyboardEmulation(GenericKeyboardEmulation):
 
     class Mapping:
 
@@ -1158,7 +1157,6 @@ class KeyboardEmulation(Output):
         super().__init__()
         self._display = Display()
         self._update_keymap()
-        self._key_press_delay = 0
 
     def _update_keymap(self):
         '''Analyse keymap, build a mapping of keysym to (keycode + modifiers),
@@ -1218,20 +1216,14 @@ class KeyboardEmulation(Output):
         # Get modifier mapping.
         self.modifier_mapping = self._display.get_modifier_mapping()
 
-    def set_key_press_delay(self, delay_ms):
-        self._key_press_delay = delay_ms
-
     def send_backspaces(self, count):
-        for x in range(count):
+        for x in self.with_delay(range(count)):
             self._send_keycode(self._backspace_mapping.keycode,
                                self._backspace_mapping.modifiers)
             self._display.sync()
 
-            if self._key_press_delay > 0:
-                sleep(self._key_press_delay / 1000)
-
     def send_string(self, string):
-        for char in string:
+        for char in self.with_delay(string):
             keysym = uchr_to_keysym(char)
             # TODO: can we find mappings for multiple keys at a time?
             mapping = self._get_mapping(keysym, automatically_map=False)
@@ -1240,21 +1232,12 @@ class KeyboardEmulation(Output):
                 mapping = self._get_mapping(keysym, automatically_map=True)
                 if mapping is None:
                     continue
-                if self._key_press_delay > 0:
-                    self._display.sync()
-                    sleep(self._key_press_delay / 2000)
                 mapping_changed = True
 
             self._send_keycode(mapping.keycode,
                                mapping.modifiers)
 
             self._display.sync()
-
-            if self._key_press_delay > 0:
-                if mapping_changed:
-                    sleep(self._key_press_delay / 2000)
-                else:
-                    sleep(self._key_press_delay / 1000)
 
     def send_key_combination(self, combo):
         # Parse and validate combo.
@@ -1263,12 +1246,9 @@ class KeyboardEmulation(Output):
             in parse_key_combo(combo, self._get_keycode_from_keystring)
         ]
         # Emulate the key combination by sending key events.
-        for keycode, event_type in key_events:
+        for keycode, event_type in self.with_delay(key_events):
             xtest.fake_input(self._display, event_type, keycode)
             self._display.sync()
-
-            if self._key_press_delay > 0:
-                sleep(self._key_press_delay / 1000)
 
     def _send_keycode(self, keycode, modifiers=0):
         """Emulate a key press and release.

--- a/plover/oslayer/linux/keyboardcontrol_x11.py
+++ b/plover/oslayer/linux/keyboardcontrol_x11.py
@@ -24,6 +24,7 @@ http://tronche.com/gui/x/xlib/input/keyboard-encoding.html
 import os
 import select
 import threading
+from time import sleep
 
 from Xlib import X, XK
 from Xlib.display import Display
@@ -1223,7 +1224,7 @@ class KeyboardEmulation(GenericKeyboardEmulation):
             self._display.sync()
 
     def send_string(self, string):
-        for char in self.with_delay(string):
+        for char in string:
             keysym = uchr_to_keysym(char)
             # TODO: can we find mappings for multiple keys at a time?
             mapping = self._get_mapping(keysym, automatically_map=False)
@@ -1232,12 +1233,18 @@ class KeyboardEmulation(GenericKeyboardEmulation):
                 mapping = self._get_mapping(keysym, automatically_map=True)
                 if mapping is None:
                     continue
+                self._display.sync()
+                self.half_delay()
                 mapping_changed = True
 
             self._send_keycode(mapping.keycode,
                                mapping.modifiers)
 
             self._display.sync()
+            if mapping_changed:
+                self.half_delay()
+            else:
+                self.delay()
 
     def send_key_combination(self, combo):
         # Parse and validate combo.

--- a/plover/oslayer/osx/keyboardcontrol.py
+++ b/plover/oslayer/osx/keyboardcontrol.py
@@ -437,8 +437,7 @@ class KeyboardEmulation(GenericKeyboardEmulation):
             -1
         ).CGEvent()
 
-    @staticmethod
-    def _send_sequence(sequence):
+    def _send_sequence(self, sequence):
         # There is a bug in the event system that seems to cause inconsistent
         # modifiers on key events:
         # http://stackoverflow.com/questions/2008126/cgeventpost-possible-bug-when-simulating-keyboard-events

--- a/plover/oslayer/osx/keyboardcontrol.py
+++ b/plover/oslayer/osx/keyboardcontrol.py
@@ -309,9 +309,12 @@ class KeyboardEmulation(Output):
     def __init__(self):
         super().__init__()
         self._layout = KeyboardLayout()
+        self._key_press_delay = 0
 
-    @staticmethod
-    def send_backspaces(count):
+    def set_key_press_delay(self, delay_ms):
+        self._key_press_delay = delay_ms
+
+    def send_backspaces(self, count):
         for _ in range(count):
             backspace_down = CGEventCreateKeyboardEvent(
                 OUTPUT_SOURCE, BACK_SPACE, True)
@@ -319,6 +322,8 @@ class KeyboardEmulation(Output):
                 OUTPUT_SOURCE, BACK_SPACE, False)
             CGEventPost(kCGSessionEventTap, backspace_down)
             CGEventPost(kCGSessionEventTap, backspace_up)
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def send_string(self, string):
         # Key plan will store the type of output
@@ -367,6 +372,9 @@ class KeyboardEmulation(Output):
             elif press_type is self.RAW_PRESS:
                 self._send_sequence(sequence)
 
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
+
     @staticmethod
     def _send_string_press(c):
         event = CGEventCreateKeyboardEvent(OUTPUT_SOURCE, 0, True)
@@ -396,6 +404,9 @@ class KeyboardEmulation(Output):
         key_events = parse_key_combo(combo, name_to_code)
         # Send events...
         self._send_sequence(key_events)
+
+        if self._key_press_delay > 0:
+            sleep(self._key_press_delay / 1000)
 
     @staticmethod
     def _modifier_to_keycodes(modifier):

--- a/plover/oslayer/osx/keyboardcontrol.py
+++ b/plover/oslayer/osx/keyboardcontrol.py
@@ -310,9 +310,6 @@ class KeyboardEmulation(GenericKeyboardEmulation):
         super().__init__()
         self._layout = KeyboardLayout()
 
-    def set_key_press_delay(self, delay_ms):
-        self._key_press_delay = delay_ms
-
     def send_backspaces(self, count):
         for _ in self.with_delay(range(count)):
             backspace_down = CGEventCreateKeyboardEvent(

--- a/plover/oslayer/windows/keyboardcontrol.py
+++ b/plover/oslayer/windows/keyboardcontrol.py
@@ -14,6 +14,7 @@ emulate keyboard input.
 """
 
 from ctypes import windll, wintypes
+from time import sleep
 import atexit
 import ctypes
 import multiprocessing
@@ -430,6 +431,7 @@ class KeyboardEmulation(Output):
     def __init__(self):
         super().__init__()
         self.keyboard_layout = KeyboardLayout()
+        self._key_press_delay = 0
 
     # Sends input types to buffer
     @staticmethod
@@ -497,9 +499,15 @@ class KeyboardEmulation(Output):
                   for code in pairs]
         self._send_input(*inputs)
 
+    def set_key_press_delay(self, delay_ms):
+        self._key_press_delay = delay_ms
+
     def send_backspaces(self, count):
         for _ in range(count):
             self._key_press('\x08')
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
 
     def send_string(self, string):
         self._refresh_keyboard_layout()
@@ -511,6 +519,9 @@ class KeyboardEmulation(Output):
                 # Otherwise, we send it as a Unicode string.
                 self._key_unicode(char)
 
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)
+
     def send_key_combination(self, combo):
         # Make sure keyboard layout is up-to-date.
         self._refresh_keyboard_layout()
@@ -519,3 +530,6 @@ class KeyboardEmulation(Output):
         # Send events...
         for keycode, pressed in key_events:
             self._key_event(keycode, pressed)
+
+            if self._key_press_delay > 0:
+                sleep(self._key_press_delay / 1000)

--- a/plover/output/__init__.py
+++ b/plover/output/__init__.py
@@ -16,3 +16,7 @@ class Output:
         See `plover.key_combo` for the format of the `combo` string.
         """
         raise NotImplementedError()
+    
+    def set_key_press_delay(self, delay_ms):
+        """Sets the delay between outputting key press events."""
+        raise NotImplementedError()

--- a/plover/output/keyboard.py
+++ b/plover/output/keyboard.py
@@ -15,6 +15,10 @@ class GenericKeyboardEmulation(Output):
     if self._key_press_delay_ms > 0:
       sleep(self._key_press_delay_ms / 1000)
 
+  def half_delay(self):
+    if self._key_press_delay_ms > 0:
+      sleep(self._key_press_delay_ms / 2000)
+
   def with_delay(self, iterable):
     for item in iterable:
       yield item

--- a/plover/output/keyboard.py
+++ b/plover/output/keyboard.py
@@ -1,0 +1,21 @@
+from time import sleep
+
+from plover.output import Output
+
+
+class GenericKeyboardEmulation(Output):
+  def __init__(self):
+    super().__init__()
+    self._key_press_delay_ms = 0
+
+  def set_key_press_delay(self, delay_ms):
+    self._key_press_delay_ms = delay_ms
+
+  def delay(self):
+    if self._key_press_delay_ms > 0:
+      sleep(self._key_press_delay_ms / 1000)
+
+  def with_delay(self, iterable):
+    for item in iterable:
+      yield item
+      self.delay()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -396,6 +396,17 @@ CONFIG_TESTS = (
      None,
     ),
 
+    ('invalid_options_3',
+     '''
+     [Output Configuration]
+     undo_levels = foobar
+     ''',
+     DEFAULTS,
+     {},
+     {},
+     None,
+    ),
+
     ('invalid_update_1',
      '''
      [Translation Frame]
@@ -505,6 +516,51 @@ def test_config(original_contents, original_config,
     if resulting_contents is None:
         resulting_contents = original_contents
     assert config_file.read_text(encoding='utf-8').strip() == dedent_strip(resulting_contents)
+
+
+CONFIG_MISSING_INTS_TESTS = (
+    ('int_option',
+    config.OUTPUT_CONFIG_SECTION,
+    'undo_levels',
+    config.DEFAULT_UNDO_LEVELS,
+    ),
+
+    ('opacity_option',
+    'Translation Frame',
+    'translation_frame_opacity',
+    100,
+    ),
+)
+
+
+@pytest.mark.parametrize(('which_section', 'which_option', 'fixed_value'),
+                         [t[1:] for t in CONFIG_MISSING_INTS_TESTS],
+                         ids=[t[0] for t in CONFIG_MISSING_INTS_TESTS])
+def test_config_missing_ints(which_section, which_option, fixed_value,
+                               monkeypatch, tmpdir, caplog):
+    registry = Registry()
+    registry.register_plugin('machine', 'Keyboard', Keyboard)
+    registry.register_plugin('system', 'English Stenotype', english_stenotype)
+    monkeypatch.setattr('plover.config.registry', registry)
+    config_file = tmpdir / 'config.cfg'
+
+    # Make config with the appropriate empty section
+    contents = f'''
+    [{which_section}]
+    '''
+    config_file.write_text(contents, encoding='utf-8')
+    cfg = config.Config(config_file.strpath)
+    cfg.load()
+
+    # Try to access an option under that section
+    # (should trigger validation)
+    assert cfg[which_option] == fixed_value
+
+    # Ensure that missing options are handled
+    assert 'InvalidConfigOption: None' not in caplog.text
+    # ... or any that there aren't any unhandled errors
+    for record in caplog.records:
+        assert record.levelname != 'ERROR'
 
 
 CONFIG_DIR_TESTS = (

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -16,6 +16,7 @@ from plover.machine.base import (
 from plover.machine.keymap import Keymap
 from plover.misc import normalize_path
 from plover.oslayer.controller import Controller
+from plover.output import Output
 from plover.registry import Registry
 from plover.steno_dictionary import StenoDictionaryCollection
 
@@ -50,7 +51,7 @@ class FakeMachine(StenotypeBase):
     def set_suppression(self, enabled):
         self.is_suppressed = enabled
 
-class FakeKeyboardEmulation:
+class FakeKeyboardEmulation(Output):
 
     def send_backspaces(self, b):
         pass
@@ -59,6 +60,9 @@ class FakeKeyboardEmulation:
         pass
 
     def send_key_combination(self, c):
+        pass
+
+    def set_key_press_delay(self, delay_ms):
         pass
 
 class FakeEngine(StenoEngine):


### PR DESCRIPTION
This is a continuation of #1584 (and by extension, #1132), primarily refactoring the delay logic so it's not all repeated in the individual OS layer implementations.

Closes #1584; closes #1132.

### Tested on:
- [x] Linux
- [x] macOS
- [x] Windows

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d.