### PR TITLE
Fix '"is not" with a literal' warning

### DIFF
--- a/plover/oslayer/osx/keyboardcontrol.py
+++ b/plover/oslayer/osx/keyboardcontrol.py
@@ -330,7 +330,7 @@ class KeyboardEmulation(GenericKeyboardEmulation):
         # and add the sequence to the key plan when called as a function.
         def apply_raw():
             if hasattr(apply_raw, 'sequence') \
-                    and len(apply_raw.sequence) is not 0:
+                    and len(apply_raw.sequence) != 0:
                 apply_raw.sequence.extend(apply_raw.release_modifiers)
                 key_plan.append((self.RAW_PRESS, apply_raw.sequence))
             apply_raw.sequence = []


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix this Python warning:
```
usr/lib/python3.11/site-packages/plover/oslayer/osx/keyboardcontrol.py:334: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  and len(apply_raw.sequence) is not 0:
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
