### PR TITLE
Close serial port when disconnected to ensure clean reconnection

### DIFF
--- a/news.d/bugfix/1636.core.md
+++ b/news.d/bugfix/1636.core.md
@@ -1,0 +1,1 @@
+Closes serial ports upon disconnection to ensure clean reconnections.

--- a/plover/machine/base.py
+++ b/plover/machine/base.py
@@ -212,6 +212,7 @@ class SerialStenotypeBase(ThreadedStenotypeBase):
 
         """
         ThreadedStenotypeBase.__init__(self)
+        self._on_unhandled_exception(self._handle_disconnect)
         self.serial_port = None
         self.serial_params = serial_params
 
@@ -220,6 +221,10 @@ class SerialStenotypeBase(ThreadedStenotypeBase):
             return
         self.serial_port.close()
         self.serial_port = None
+
+    def _handle_disconnect(self):
+        self._close_port()
+        self._error()
 
     def start_capture(self):
         self._close_port()


### PR DESCRIPTION
In addition to the changes from #1560, this PR closes a serial port on error to handle this issue from #1054:
> Now an exception in the run method is reported as an error to the system
and additionally the SerialStenotypeBase class does close the com port on
error.
> 
> **Otherwise the com port resource might still be taken by plover upon
reconnect of the writer, and a different com port might be taken by the OS
and plover might not be able to reconnect to that machine.**

Closes #1054.

- [x] News fragment added in news.d
