### PR TITLE
Allow system plugins to customize stroke display

### DIFF
--- a/doc/api/system.md
+++ b/doc/api/system.md
@@ -254,6 +254,17 @@ Each line in this word list consists of a word and a number, separated by
 a space. See {data}`ORTHOGRAPHY_WORDS` for more information.
 ```
 
+```{data} display
+:type: Callable[[Tuple[str, ...]], str]
+
+A function called to display a steno outline in this system. The input is a
+tuple of normalized strokes. The output is a string shown to the user when
+making stroke suggestions or browsing a dictionary.
+
+If not defined, the default is `"/".join`, i.e. simply join the normalized
+strokes by slashes.
+```
+
 ## Computed Fields
 
 The fields below are automatically calculated from the values defined by

--- a/doc/plugin-dev/systems.md
+++ b/doc/plugin-dev/systems.md
@@ -38,6 +38,8 @@ KEYMAPS: Dict[str, Dict[str, Union[str, Tuple[str, ...]]]]
 
 DICTIONARIES_ROOT: str
 DEFAULT_DICTIONARIES: Tuple[str, ...]
+
+display: Callable[[Tuple[str, ...]], str]
 ```
 
 Note that there are a lot of possible fields in a system plugin. You must set

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import QApplication, QWidget
 
 from plover import _
 from plover.misc import shorten_path
-from plover.steno import normalize_steno, sort_steno_strokes
+from plover.steno import display_steno, normalize_steno, sort_steno_strokes
 from plover.engine import StartingStrokeState
 from plover.translation import escape_translation, unescape_translation
 from plover.formatting import RetroFormatter
@@ -232,7 +232,7 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
 
     def _format_label(self, fmt, strokes, translation=None, filename=None):
         if strokes:
-            strokes = ', '.join(self._special_fmt % html_escape('/'.join(s))
+            strokes = ', '.join(self._special_fmt % html_escape(display_steno('/'.join(s)))
                                 for s in sort_steno_strokes(strokes))
         if translation:
             translation = self._special_fmt_bold % html_escape(escape_translation(translation))

--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
 from plover import _
 from plover.translation import escape_translation, unescape_translation
 from plover.misc import expand_path, shorten_path
-from plover.steno import normalize_steno, steno_to_sort_key
+from plover.steno import display_steno, normalize_steno, steno_to_sort_key
 
 from plover.gui_qt.dictionary_editor_ui import Ui_DictionaryEditor
 from plover.gui_qt.steno_validator import StenoValidator
@@ -193,7 +193,7 @@ class DictionaryItemModel(QAbstractTableModel):
                     return self._error_icon
             return None
         if column == _COL_STENO:
-            return item.steno
+            return display_steno(item.steno) if role == Qt.DisplayRole else item.steno
         if column == _COL_TRANS:
             return escape_translation(item.translation)
         if column == _COL_DICT:

--- a/plover/gui_qt/suggestions_widget.py
+++ b/plover/gui_qt/suggestions_widget.py
@@ -18,6 +18,7 @@ from PyQt5.QtWidgets import (
 )
 
 from plover import _
+from plover.steno import display_steno
 from plover.translation import escape_translation
 
 from .utils import ActionCopyViewSelectionToClipboard
@@ -67,7 +68,7 @@ class SuggestionsDelegate(QStyledItemDelegate):
             return translation, None
         strokes = ''
         for strokes_list in suggestion.steno_list[:MAX_SUGGESTIONS_COUNT]:
-            strokes += '\n    ' + '/'.join(strokes_list)
+            strokes += '\n    ' + display_steno('/'.join(strokes_list))
         return translation, strokes
 
     def _suggestion_size_hint(self, index):

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -31,7 +31,7 @@ class Stroke(BaseStroke):
 
     @classmethod
     def setup(cls, keys, implicit_hyphen_keys, number_key,
-              numbers, feral_number_key, undo_stroke):
+              numbers, feral_number_key, undo_stroke, display):
         if number_key is None:
             assert not numbers
             numbers = None
@@ -40,6 +40,7 @@ class Stroke(BaseStroke):
         cls._class._class = cls._class
         cls._class.PREFIX_STROKE = cls.PREFIX_STROKE = cls.from_integer(0)
         cls._class.UNDO_STROKE = cls.UNDO_STROKE = cls.from_steno(undo_stroke)
+        cls._class.display = cls.display = display
 
     @classmethod
     def from_steno(cls, steno):
@@ -70,6 +71,11 @@ class Stroke(BaseStroke):
             if strict:
                 raise
             return tuple(steno.split('/'))
+
+    @classmethod
+    def display_steno(cls, steno):
+        normalized = cls.normalize_steno(steno, strict=False)
+        return cls.display(normalized)
 
     @classmethod
     def steno_to_sort_key(cls, steno, strict=True):
@@ -104,6 +110,7 @@ class Stroke(BaseStroke):
 
 normalize_stroke = Stroke.normalize_stroke
 normalize_steno = Stroke.normalize_steno
+display_steno = Stroke.display_steno
 steno_to_sort_key = Stroke.steno_to_sort_key
 
 def sort_steno_strokes(strokes_list):

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -59,6 +59,7 @@ _EXPORTS = {
     'KEYMAPS'                  : lambda mod: mod.KEYMAPS,
     'DICTIONARIES_ROOT'        : lambda mod: mod.DICTIONARIES_ROOT,
     'DEFAULT_DICTIONARIES'     : lambda mod: mod.DEFAULT_DICTIONARIES,
+    'display'                  : lambda mod: getattr(mod, 'display', '/'.join),
 }
 
 def setup(system_name):
@@ -69,6 +70,6 @@ def setup(system_name):
     system_symbols['NAME'] = system_name
     globals().update(system_symbols)
     Stroke.setup(KEYS, IMPLICIT_HYPHEN_KEYS, NUMBER_KEY, NUMBERS,
-                 FERAL_NUMBER_KEY, UNDO_STROKE_STENO)
+                 FERAL_NUMBER_KEY, UNDO_STROKE_STENO, display)
 
 NAME = None

--- a/plover/system/english_stenotype.py
+++ b/plover/system/english_stenotype.py
@@ -317,3 +317,6 @@ KEYMAPS = {
 
 DICTIONARIES_ROOT = 'asset:plover:assets'
 DEFAULT_DICTIONARIES = ('user.json', 'commands.json', 'main.json')
+
+def display(strokes):
+    return "/".join(strokes)


### PR DESCRIPTION
## Summary of changes

System definitions/plugins can now define a function `display`, which is used to render outlines in the UI (suggestions, lookup, dictionary view, etc).

For example, users of Lapwing theory (which uses `#` for proper nouns) may enjoy an override that doesn't convert digits:

```py
# english_stenotype_no_digits.py

from plover.system.english_stenotype import *

UNDIGIT_TABLE = str.maketrans('1234567890', 'STPHAOFPLT')

def display_stroke(stroke):
    undigit = stroke.translate(UNDIGIT_TABLE)
    return stroke if stroke == undigit else '#' + undigit

def display(strokes):
    return '/'.join(map(display_stroke, strokes))
```

Of course, this example shows that this isn't quite the right abstraction: `English Stenotype` and `English Stenotype (no digits)` are not really two different steno systems. But tying the display function to the system keeps things architecturally simple, and it's easy for power users to edit the `display` function in the file that defines their system.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
