### PR TITLE
Allow setting lookup font

### DIFF
--- a/plover/gui_qt/lookup_dialog.py
+++ b/plover/gui_qt/lookup_dialog.py
@@ -1,10 +1,20 @@
 
 from PyQt5.QtCore import QEvent, Qt
+from PyQt5.QtGui import (
+    QCursor,
+    QFont,
+)
+from PyQt5.QtWidgets import (
+    QAction,
+    QFontDialog,
+    QMenu,
+)
 
 from plover import _
 from plover.translation import unescape_translation
 
 from plover.gui_qt.lookup_dialog_ui import Ui_LookupDialog
+from plover.gui_qt.utils import ToolBar
 from plover.gui_qt.tool import Tool
 
 
@@ -26,6 +36,45 @@ class LookupDialog(Tool, Ui_LookupDialog):
         self.pattern.setFocus()
         self.restore_state()
         self.finished.connect(self.save_state)
+        self.layout().addWidget(ToolBar(
+            self.action_SelectFont,
+        ))
+
+        # Font popup menu.
+        self._font_menu = QMenu()
+        # i18n: Widget: “SuggestionsDialog”, “font” menu.
+        self._font_menu_text = QAction(_('&Text'), self._font_menu)
+        # i18n: Widget: “SuggestionsDialog”, “font” menu.
+        self._font_menu_strokes = QAction(_('&Strokes'), self._font_menu)
+        self._font_menu.addActions([self._font_menu_text, self._font_menu_strokes])
+
+    def _get_font(self, name):
+        return getattr(self.suggestions, name)
+
+    def _set_font(self, name, font):
+        setattr(self.suggestions, name, font)
+
+    def _restore_state(self, settings):
+        for name in (
+            'text_font',
+            'strokes_font',
+        ):
+            font_string = settings.value(name)
+            if font_string is None:
+                continue
+            font = QFont()
+            if not font.fromString(font_string):
+                continue
+            self._set_font(name, font)
+
+    def _save_state(self, settings):
+        for name in (
+            'text_font',
+            'strokes_font',
+        ):
+            font = self._get_font(name)
+            font_string = font.toString()
+            settings.setValue(name, font_string)
 
     def eventFilter(self, watched, event):
         if event.type() == QEvent.KeyPress and \
@@ -47,3 +96,18 @@ class LookupDialog(Tool, Ui_LookupDialog):
         if event.type() == QEvent.ActivationChange and self.isActiveWindow():
             self.pattern.setFocus()
             self.pattern.selectAll()
+
+    def on_select_font(self):
+        action = self._font_menu.exec_(QCursor.pos())
+        if action is None:
+            return
+        if action == self._font_menu_text:
+            name = 'text_font'
+            font_options = ()
+        elif action == self._font_menu_strokes:
+            name = 'strokes_font'
+            font_options = (QFontDialog.MonospacedFonts,)
+        font = self._get_font(name)
+        font, ok = QFontDialog.getFont(font, self, '', *font_options)
+        if ok:
+            self._set_font(name, font)

--- a/plover/gui_qt/lookup_dialog.ui
+++ b/plover/gui_qt/lookup_dialog.ui
@@ -23,16 +23,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::NoButton</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLineEdit" name="pattern">
      <property name="sizePolicy">
@@ -63,6 +53,18 @@
     </widget>
    </item>
   </layout>
+  <action name="action_SelectFont">
+   <property name="icon">
+    <iconset resource="resources/resources.qrc">
+     <normaloff>:/font_selector.svg</normaloff>:/font_selector.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select &amp;font</string>
+   </property>
+   <property name="toolTip">
+    <string>Open font selection dialog.</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -74,38 +76,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>LookupDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>LookupDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>pattern</sender>
    <signal>textEdited(QString)</signal>
@@ -122,8 +92,25 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>action_SelectFont</sender>
+   <signal>triggered()</signal>
+   <receiver>LookupDialog</receiver>
+   <slot>on_select_font()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>123</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>on_lookup(QString)</slot>
+  <slot>on_select_font()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
## Summary of changes

The Suggestions dialog allows setting a font for the text and strokes, but the Lookup dialog (which is powered by the same widget) doesn't have the same button. This PR adds that button:

<img width="301" alt="image" src="https://github.com/openstenoproject/plover/assets/16232127/cb4a5402-b5ec-4d7b-9fc0-0a9737fc713f">

 (would it make sense to have an "always on top" setting here as well?)

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details
