### PR TITLE
Update link about accessibility permissions

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -5,14 +5,14 @@
 See the [developer guide](../doc/developer_guide.md).
 
 
-## Gotcha: Assistive Devices Permissions
+## Gotcha: Accessibility Permissions
 
 To grab user inputs and use the keyboard as a steno machine, Plover requires
-[Assistive Devices permissions to be granted (instructions
-included).](https://support.apple.com/kb/ph18391?locale=en_US)
+[accessibility permissions to be granted (instructions
+included).](https://support.apple.com/guide/mac-help/allow-accessibility-apps-to-access-your-mac-mh43185/mac)
 
-When running from source, your terminal application must be granted Assistive
-Devices permissions.
+When running from source, your terminal application must be granted
+accessibility permissions.
 
 If you are running from an application bundle (both in development and for
 releases), every new build will require re-granting the permissions.


### PR DESCRIPTION
## Summary of changes

The old link is dead: https://web.archive.org/web/20170401143114/https://support.apple.com/kb/ph18391?locale=en_US

Also, I guess there was a change toward calling these "accessibility (features/permissions)" rather than "assistive devices"? I don't see the word "assistive device" anymore in the new docs, so I updated the wording in the README as well.

### Pull Request Checklist
- [x] ~~Changes have tests~~  Nothing to test.
- [x] ~~News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/master/doc/developer_guide.md#making-a-pull-request) for details~~  Doesn't seem necessary for this change.
