### PR TITLE
Bump plover-plugins-manager to 0.7.2

### DIFF
--- a/news.d/feature/1700.ui.md
+++ b/news.d/feature/1700.ui.md
@@ -1,0 +1,1 @@
+Added a button to the Plugins Manager for installing plugins via Git URL.

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -33,7 +33,7 @@ packaging==21.0
 pep517==0.12.0
 pip==21.3.1
 pkginfo==1.8.1
-plover-plugins-manager==0.7.0
+plover-plugins-manager==0.7.2
 plover-stroke==1.1.0
 plover-treal==1.0.1
 pluggy==1.0.0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Bump plover-plugins-manager to 0.7.2 to include changes like https://github.com/openstenoproject/plover_plugins_manager/pull/21.

## Tests

Installed the macOS DMG file created via the GitHub actions (on M1 mac). The install via git feature works (tested with [plover2cat](https://github.com/greenwyrt/plover2CAT)).

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
