### PR TITLE
On linux wayland, warn if ibus or fcitx5 isn't running.

### DIFF
--- a/news.d/feature/1711.linux.md
+++ b/news.d/feature/1711.linux.md
@@ -1,0 +1,1 @@
+On linux wayland, warn if ibus or fcitx5 isn't running.

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -1,6 +1,7 @@
 from evdev import UInput, ecodes as e, util, InputDevice, list_devices
 import threading
 from select import select
+import subprocess
 
 from plover.output.keyboard import GenericKeyboardEmulation
 from plover.machine.keyboard_capture import Capture
@@ -271,6 +272,14 @@ class KeyboardEmulation(GenericKeyboardEmulation):
         # Initialize UInput with all keys available
         self._res = util.find_ecodes_by_regex(r"KEY_.*")
         self._ui = UInput(self._res)
+
+        # Check that ibus or fcitx5 is running
+        processes = subprocess.run(["ps", "x"], capture_output=True)
+        for line in processes.stdout.decode().splitlines():
+            if line.endswith(("ibus", "fcitx5")):
+                break
+        else:
+            log.warning("It appears that an input method, such as ibus or fcitx5, is not running on your system. Without this, some text may not be output correctly.")
 
     def _update_layout(self, layout):
         if not layout in LAYOUTS:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes
When initializing uinput keyboard emulation, this runs the `ps` command to check whether ibus or fcitx5 is running. If not, it logs a warning.

It doesn't strike me as a super efficient or elegant way to acheive this, but it's the only way I could think of for fcitx5. ibus has the `ibus engine` command, but if I'm scanning every process anyway, I see no reason to split the implementation. It also makes it easy to add other supported input methods later.

Closes #1709 

### Pull Request Checklist
- [ ] Changes have tests
    - I'm not really sure how to test this, since it's platform specific and depends on other running processes.
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
