### PR TITLE
Remove continuous release logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'maintenance/*'
   pull_request:
     types:
         - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
   push:
     branches:
       - 'main'
-    tags-ignore:
-      # Ignore continuous releases' tag.
-      - 'continuous'
   pull_request:
     types:
         - opened
@@ -132,8 +129,6 @@ jobs:
 
       - name: Set outputs
         id: set_ouputs
-        env:
-          CONTINUOUS_RELEASE_BRANCH: ${{ secrets.CONTINUOUS_RELEASE_BRANCH }}
         run: |
           analyze_set_release_info
           job_cache_extra_deps=(); job_id=test_linux; job_name='Test (Linux)'; job_needs=(); job_os=Linux; job_platform=ubuntu-24.04; job_python=3.9; job_reqs=(reqs/dist.txt reqs/test.txt); job_skip_cache_name=skip_test_linux_py-3.9_ubuntu-24.04; job_skip_cache_path=.skip_cache_test_linux; job_skiplists=(job_test os_linux); job_test_args='-p no:pytest-qt --ignore=test/gui_qt'; job_type=test; job_variant=Linux; analyze_set_job_skip_job

--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -128,15 +128,6 @@ setup_python_env()
 publish_github_release()
 {
   case "$RELEASE_TYPE" in
-    continuous)
-      tag='continuous'
-      title='Continuous build'
-      is_draft=''
-      is_prerelease='yes'
-      overwrite='yes'
-      notes_body='news_draft.md'
-      run_eval "'$python' -m towncrier --draft >$notes_body" || die
-      ;;
     tagged)
       tag="${GITHUB_REF#refs/tags/}"
       title="$tag"
@@ -228,10 +219,6 @@ analyze_set_release_info()
   then
     # Tagged release.
     release_type='tagged'
-  elif [[ "$GITHUB_REF" == refs/heads/$CONTINUOUS_RELEASE_BRANCH ]]
-  then
-    # Continuous release.
-    release_type='continuous'
   else
     # Not a release.
     release_type=''

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'main'
-    tags-ignore:
-      # Ignore continuous releases' tag.
-      - 'continuous'
   pull_request:
     types:
         - opened
@@ -52,8 +49,6 @@ jobs:
       <% endif %>
       - name: Set outputs
         id: set_ouputs
-        env:
-          CONTINUOUS_RELEASE_BRANCH: ${{ secrets.CONTINUOUS_RELEASE_BRANCH }}
         run: |
           analyze_set_release_info
           <% for j in jobs %>

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'maintenance/*'
   pull_request:
     types:
         - opened

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -44,9 +44,8 @@ This job has 2 roles:
 
 ## Release conditions
 
-Two (exclusive) conditions can result in a release:
-- a tag build, and the tag name is not `continuous`
-- a branch build on `secrets.CONTINUOUS_RELEASE_BRANCH`
+A release is triggered if the `GITHUB_REF` environment variable starts with
+`refs/tags/`, which indicates that the workflow is triggered by a Git tag.
 
 
 ## Skipping Test/Build jobs
@@ -117,8 +116,8 @@ to the artifacts when a release is being created.
 
 ## Release job
 
-The final job, only run on release (*tagged* or *continuous*), and if
-all the other jobs completed successfully.
+The final job, only run on a tagged release, and if all the other
+jobs completed successfully.
 
 
 ### PyPI release
@@ -136,19 +135,10 @@ use another PyPI compatible index (e.g. Test PyPI).
 
 On *tagged* release, a new release draft is created on GitHub.
 
-On *continuous* release, the `continuous` release and corresponding tag
-are created / updated, but only if the existing release version is not
-newer, in order to:
-* prevent an old workflow re-run from overwriting the latest continuous release
-* reduce the likelihood that a flurry of merges to the continuous branch will
-  result in the continuous release not pointing to the most recent valid commit
-  (because multiple workflows were created in parallel).
-
 All the artifacts will be included as assets.
 
 The release notes are automatically generated from the last release section in
-`NEWS.md` (*tagged* release) or the existing `news.d` entries (*continuous*
-release), and the template in `.github/RELEASE_DRAFT_TEMPLATE.md`.
+`NEWS.md` (*tagged* release) and the template in `.github/RELEASE_DRAFT_TEMPLATE.md`.
 
 
 ## Limitations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
 	"Babel",
 	"PySide6-Essentials>=6.5.2",
-	"setuptools>=38.2.4",
+	"setuptools>=38.2.4,<77",
 	"wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Removes the logic that generates continuous GitHub releases. See [this discussion](https://discord.com/channels/136953735426473984/144999734254370816/1361076524278747136) on Discord.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
