### PR TITLE
Add tags push trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - 'main'
       - 'maintenance/*'
+    tags:
+      - 'v*'
   pull_request:
     types:
         - opened

--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -215,6 +215,8 @@ publish_pypi_release()
 
 analyze_set_release_info()
 {
+  info "GITHUB_REF: $GITHUB_REF"
+  info "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
   if [[ "$GITHUB_REF" == refs/tags/* ]]
   then
     # Tagged release.

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'main'
       - 'maintenance/*'
+    tags:
+      - 'v*'
   pull_request:
     types:
         - opened

--- a/plover_build_utils/functions.sh
+++ b/plover_build_utils/functions.sh
@@ -267,9 +267,11 @@ release_finalize()
   run git commit -m "$message"
   run git tag -m "$message" "$tag"
   cat <<EOF
-# now all that's left is to push to GitHub,
-# assuming \`origin\` is the correct remote:
-git push origin HEAD "$tag"
+# now all that's left is to push to GitHub:
+# first push the release commit:
+git push
+# and once the build was successful, assuming \`origin\` is the correct remote, push the tag:
+git push origin "$tag"
 EOF
 }
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Adds the `tags` push trigger in our GitHub actions CI. In https://github.com/openstenoproject/plover/pull/1716, `tags-ignore` was removed and thereby no tag pushes were registered anymore. This, however, is important for building releases.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
