### PR TITLE
Also catch ConnectionResetError

### DIFF
--- a/plover/scripts/main.py
+++ b/plover/scripts/main.py
@@ -130,7 +130,7 @@ def main():
                 # Other instance? Try focusing the main window.
                 try:
                     controller.send_command('focus')
-                except ConnectionRefusedError:
+                except (ConnectionRefusedError, ConnectionResetError):
                     log.error('connection to existing instance failed, '
                               'force cleaning before restart')
                     # Assume the previous instance died, leaving


### PR DESCRIPTION
## Summary of changes

As in the title. This happens when Plover starts up and detect another process exists.

The issue is the following: when the other process exits at a certain time (after the connection is made but before the `send_command` is sent… so race condition) then `ConnectionResetError` is sent.

I see this in practice with a stroke defined by `{PLOVER:SHELL:xterm -e tmux new bash -c "sleep 0.5s; setxkbmap us; plover --log-level info; bash" &}{PLOVER:QUIT}` (you can see what it does easily — quit Plover then start a new instance after 0.5 second — although Plover can be slow to exit, so let's say it exits after 0.6 seconds then the above happens. In order to reproduce the error you may need to tune the `0.5s` a bit)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
