### PR TITLE
Fixed certain keyboards not getting detected in the uinput module

### DIFF
--- a/news.d/bugfix/1724.linux.md
+++ b/news.d/bugfix/1724.linux.md
@@ -1,0 +1,1 @@
+Fixed keyboards with mouse control functionality not able to be detected in the uinput module.

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -371,9 +371,13 @@ class KeyboardCapture(Capture):
         Filter out devices that should not be grabbed and suppressed, to avoid output feeding into itself.
         """
         is_uinput = device.name == "py-evdev-uinput" or device.phys == "py-evdev-uinput"
-        capabilities = device.capabilities()
-        is_mouse = e.EV_REL in capabilities or e.EV_ABS in capabilities
-        return not is_uinput and not is_mouse
+        # Check for some common keys to make sure it's really a keyboard
+        keys = device.capabilities().get(e.EV_KEY, [])
+        keyboard_keys_present = any(
+            key in keys
+            for key in [e.KEY_ESC, e.KEY_SPACE, e.KEY_ENTER, e.KEY_LEFTSHIFT]
+        )
+        return not is_uinput and keyboard_keys_present
 
     def start(self):
         self._running = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

There was an issue where keyboards that had the ability to control the mouse were not able to be recognized as keyboards in the uinput module. This pr fixes that by checking for keyboard keys instead.

### Pull Request Checklist
-  ~~[ ] Changes have tests~~
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
