### PR TITLE
Wait for all keys to be released before grabbing

### DIFF
--- a/news.d/bugfix/1728.linux.md
+++ b/news.d/bugfix/1728.linux.md
@@ -1,0 +1,1 @@
+Fix keys getting stuck if keys held when starting Plover and emulating keyboard with Uinput

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -393,7 +393,27 @@ class KeyboardCapture(Capture):
         )
         return not is_uinput and keyboard_keys_present
 
+    def _grab_devices(self):
+        """Grab all devices, waiting for each device to stop having keys pressed.
+
+        If a device is grabbed when keys are being pressed, the key will
+        appear to be always pressed down until the device is ungrabbed and the
+        key is pressed again.
+        See https://stackoverflow.com/questions/41995349/why-does-ioctlfd-eviocgrab-1-cause-key-spam-sometimes
+        There is likely a race condition here between checking active keys and
+        actually grabbing the device, but it appears to work fine.
+        """
+        for device in self._devices.values():
+            if len(device.active_keys()) > 0:
+                for _ in device.read_loop():
+                    if len(device.active_keys()) == 0:
+                        # No keys are pressed. Grab the device
+                        break
+            device.grab()
+
+
     def start(self):
+        self._grab_devices()
         self._running = True
         self._thread = threading.Thread(target=self._run)
         self._thread.start()
@@ -414,7 +434,6 @@ class KeyboardCapture(Capture):
         self._suppressed_keys = suppressed_keys
 
     def _run(self):
-        [dev.grab() for dev in self._devices.values()]
         while self._running:
             """
             The select() call blocks the loop until it gets an input, which meant that the keyboard


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Makes uinput module wait for all keys on each input device to be released before grabbing the device. This prevents keys from being stuck when keys are held while Plover is starting.

Device grabbing was moved from `_run` to `start` to show that the keyboard is still connecting in the UI while waiting for keys to be released (`self._running` is only set when keys are grabbed)

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
