### PR TITLE
UInput: ungrab devices on exception

### DIFF
--- a/news.d/bugfix/1729.linux.md
+++ b/news.d/bugfix/1729.linux.md
@@ -1,0 +1,1 @@
+When using Uinput, fix devices being disabled upon exceptions.

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -413,17 +413,14 @@ class KeyboardCapture(Capture):
 
 
     def start(self):
-        self._grab_devices()
         self._running = True
         self._thread = threading.Thread(target=self._run)
         self._thread.start()
 
     def cancel(self):
         self._running = False
-        [dev.ungrab() for dev in self._devices.values()]
         if self._thread is not None:
             self._thread.join()
-        self._ui.close()
 
     def suppress(self, suppressed_keys=()):
         """
@@ -434,22 +431,36 @@ class KeyboardCapture(Capture):
         self._suppressed_keys = suppressed_keys
 
     def _run(self):
-        while self._running:
-            """
-            The select() call blocks the loop until it gets an input, which meant that the keyboard
-            had to be pressed once after executing `cancel()`. Now, there is a 1 second delay instead
-            FIXME: maybe use one of the other options to avoid the timeout
-            https://python-evdev.readthedocs.io/en/latest/tutorial.html#reading-events-from-multiple-devices-using-select
-            """
-            r, _, _ = select(self._devices, [], [], 1)
-            for fd in r:
-                for event in self._devices[fd].read():
-                    if event.type == e.EV_KEY:
-                        if event.code in KEYCODE_TO_KEY:
-                            key_name = KEYCODE_TO_KEY[event.code]
-                            if key_name in self._suppressed_keys:
-                                pressed = event.value == 1
-                                (self.key_down if pressed else self.key_up)(key_name)
-                                continue  # Go to the next iteration, skipping the below code:
-                    self._ui.write(e.EV_KEY, event.code, event.value)
-                    self._ui.syn()
+        try:
+            self._grab_devices()
+
+            while self._running:
+                """
+                The select() call blocks the loop until it gets an input, which meant that the keyboard
+                had to be pressed once after executing `cancel()`. Now, there is a 1 second delay instead
+                FIXME: maybe use one of the other options to avoid the timeout
+                https://python-evdev.readthedocs.io/en/latest/tutorial.html#reading-events-from-multiple-devices-using-select
+                """
+                r, _, _ = select(self._devices, [], [], 1)
+                for fd in r:
+                    for event in self._devices[fd].read():
+                        if event.type == e.EV_KEY:
+                            if event.code in KEYCODE_TO_KEY:
+                                key_name = KEYCODE_TO_KEY[event.code]
+                                if key_name in self._suppressed_keys:
+                                    pressed = event.value == 1
+                                    (self.key_down if pressed else self.key_up)(key_name)
+                                    continue  # Go to the next iteration, skipping the below code:
+                        self._ui.write(e.EV_KEY, event.code, event.value)
+                        self._ui.syn()
+        except:
+            log.error("keyboard capture error", exc_info=True)
+        finally:
+            # Always ungrab devices to prevent exceptions in the _run loop
+            # from causing grabbed input devices to be blocked
+            for device in self._devices.values():
+                try:
+                    device.ungrab()
+                except:
+                    log.debug("failed to ungrab device", exc_info=True)
+            self._ui.close()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Improve uinput exception handling by wrapping the keyboard capture loop in a try finally. All devices are ungrabbed in the finally block so that exceptions do not block all grabbed input devices. Currently, if an exception occurs in `_run`, the loop exits and no device inputs are handled. This issue can be reproduced by having multiple keyboards and unplugging one.

A possible UI improvement is to show an error/disconnected state when an exception occurs. I haven't figured a clean way to do this yet.


### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
