### PR TITLE
Send space instead of enter to finalize unicode with uinput

### DIFF
--- a/news.d/bugfix/1731.linux.md
+++ b/news.d/bugfix/1731.linux.md
@@ -1,0 +1,1 @@
+When inputting Unicode with uinput the code now uses space to finalize the Unicode character instead of enter.

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -326,7 +326,7 @@ class KeyboardEmulation(GenericKeyboardEmulation):
         self.delay()
         self.send_string(hex)
         self.delay()
-        self._send_char("\n")
+        self._send_char(" ")
 
     def _send_char(self, char):
         (base, mods) = self._get_key(char)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes
When inputting Unicode with uinput the code now uses space to finalize the Unicode character instead of enter.
<!-- Summary goes here -->

Closes #1725 <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
