### PR TITLE
Resolve regex library warnings

### DIFF
--- a/plover_build_utils/pyqt.py
+++ b/plover_build_utils/pyqt.py
@@ -6,7 +6,7 @@ def gettext(contents):
     contents = re.sub(r'\n', (
         '\n'
         '_ = __import__(__package__.split(".", 1)[0])._\n'
-    ), contents, 1)
+    ), contents, count=1)
     contents = re.sub(
         r'\n\s+_translate = QtCore\.QCoreApplication\.translate\n',
         '\n',


### PR DESCRIPTION
## Summary of changes
This small PR resolves the annoying regex library warnings starting Python3.11:
```python
/tmp/plover/plover_build_utils/pyqt.py:9: DeprecationWarning: 'count' is passed as positional argument
```
