### PR TITLE
Allow uninstall of unsupported plugins

### DIFF
--- a/news.d/bugfix/1739.core.md
+++ b/news.d/bugfix/1739.core.md
@@ -1,0 +1,1 @@
+Allow uninstall of installed unsupported plugins.

--- a/plover/plugins_manager/registry.py
+++ b/plover/plugins_manager/registry.py
@@ -137,5 +137,5 @@ class Registry:
                 pkg.available = metadata
                 if pkg.current and pkg.current.parsed_version < pkg.latest.parsed_version:
                     pkg.status = 'outdated'
-            if not self.is_plugin_supported(pkg, unsupported_plugins_dict):
+            if pkg.status != 'installed' and not self.is_plugin_supported(pkg, unsupported_plugins_dict):
                 pkg.status = 'unsupported'


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This makes it possible to uninstall a plugin that is listed as unsupported by not overwriting the `installed` status if the plugin is unsupported.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
