### PR TITLE
Fix missing font family warnings

### DIFF
--- a/news.d/bugfix/1740.core.md
+++ b/news.d/bugfix/1740.core.md
@@ -1,0 +1,1 @@
+Fix missing font family warnings.

--- a/plover/gui_qt/add_translation_widget.py
+++ b/plover/gui_qt/add_translation_widget.py
@@ -3,6 +3,7 @@ from html import escape as html_escape
 from os.path import split as os_path_split
 
 from PySide6.QtCore import QEvent, Signal, Slot
+from PySide6.QtGui import QFontDatabase
 from PySide6.QtWidgets import QApplication, QWidget
 
 from plover import _
@@ -40,17 +41,13 @@ class AddTranslationWidget(QWidget, Ui_AddTranslationWidget):
         engine.signal_connect('dictionaries_loaded', self.on_dictionaries_loaded)
         self.on_dictionaries_loaded(self._engine.dictionaries)
 
-        self._special_fmt = (
-            '<span style="' +
-            'font-family:monospace;' +
-            '">%s</span>'
-        )
+        fixed_family = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont).family()
 
+        self._special_fmt = (
+            f'<span style="font-family:{fixed_family};">%s</span>'
+        )
         self._special_fmt_bold = (
-            '<span style="' +
-            'font-family:monospace;' +
-            'font-weight:bold;' +
-            '">%s</span>'
+            f'<span style="font-family:{fixed_family};font-weight:bold;">%s</span>'
         )
 
         self.strokes.setValidator(StenoValidator())

--- a/plover/gui_qt/info_browser.py
+++ b/plover/gui_qt/info_browser.py
@@ -14,7 +14,7 @@ class InfoBrowser(QTextBrowser):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         # Regex to remove any explicit font-family attribute
-        self._font_family_re = re.compile(r'\s*font-family\s*=\s*["\'][^"\']*["\']', re.I)
+        self._font_family_re = re.compile(r'\s*font-family\s*=\s*["\'][^"\']*["\']', re.IGNORECASE)
         self.setOpenExternalLinks(True)
         self._images = {}
         self._session = CachedSession()

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -7,7 +7,6 @@ from PySide6.QtCore import (
     QLibraryInfo,
     QTimer,
     QTranslator,
-    Qt,
     QtMsgType,
     qInstallMessageHandler,
 )

--- a/plover/gui_qt/main_window.py
+++ b/plover/gui_qt/main_window.py
@@ -9,7 +9,6 @@ from PySide6.QtGui import QCursor, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QMainWindow,
     QMenu,
-    QApplication,
 )
 
 from plover import _, log
@@ -17,13 +16,13 @@ from plover.oslayer import wmctrl
 from plover.oslayer.config import CONFIG_DIR, PLATFORM
 from plover.registry import registry
 
+from plover.gui_qt import utils
 from plover.gui_qt.log_qt import NotificationHandler
 from plover.gui_qt.main_window_ui import Ui_MainWindow
 from plover.gui_qt.config_window import ConfigWindow
 from plover.gui_qt.about_dialog import AboutDialog
 from plover.gui_qt.trayicon import TrayIcon
-from plover.gui_qt.utils import WindowStateMixin, find_menu_actions
-
+from plover.gui_qt.utils import WindowStateMixin
 
 class MainWindow(QMainWindow, Ui_MainWindow, WindowStateMixin):
 
@@ -40,7 +39,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowStateMixin):
             'about'             : AboutDialog,
             'configuration'     : ConfigWindow,
         }
-        all_actions = find_menu_actions(self.menubar)
+        all_actions = utils.find_menu_actions(self.menubar)
         # Dictionaries.
         self.dictionaries.signal_add_translation.connect(self._add_translation)
         self.dictionaries.setup(engine)
@@ -147,8 +146,6 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowStateMixin):
             else:
                 self.showMinimized()
 
-    def _is_wayland(self):
-        return "wayland" in QApplication.platformName().lower()
 
     def _activate_dialog(self, name, args=(), manage_windows=False):
         if manage_windows:
@@ -165,7 +162,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowStateMixin):
                     wmctrl.SetForegroundWindow(previous_window)
             dialog.finished.connect(on_finished)
         dialog.showNormal()
-        if not self._is_wayland():
+        if not utils.is_wayland():
             # Otherwise gives this warning:
             # Qt: Wayland does not support QWindow::requestActivate()
             dialog.activateWindow()
@@ -179,7 +176,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, WindowStateMixin):
 
     def _focus(self):
         self.showNormal()
-        if not self._is_wayland():
+        if not utils.is_wayland():
             self.activateWindow()
         self.raise_()
 

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -218,8 +218,7 @@ class PaperTape(Tool, Ui_PaperTape):
 
     @Slot()
     def select_font(self):
-        ok, font = QFontDialog.getFont(self.tape.font(), self, '',
-                                       QFontDialog.FontDialogOption.MonospacedFonts)
+        ok, font = QFontDialog.getFont(self.tape.font(), self, '')
         if ok:
             self.header.setFont(font)
             self.tape.setFont(font)

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -19,9 +19,10 @@ from wcwidth import wcwidth
 from plover import _, system
 from plover.steno import Stroke
 
-from .paper_tape_ui import Ui_PaperTape
-from .utils import ActionCopyViewSelectionToClipboard, ToolBar
-from .tool import Tool
+from plover.gui_qt import utils
+from plover.gui_qt.paper_tape_ui import Ui_PaperTape
+from plover.gui_qt.utils import ActionCopyViewSelectionToClipboard, ToolBar
+from plover.gui_qt.tool import Tool
 
 
 STYLE_PAPER, STYLE_RAW = (
@@ -141,12 +142,16 @@ class PaperTape(Tool, Ui_PaperTape):
         self._copy_action = ActionCopyViewSelectionToClipboard(self.tape)
         self.tape.addAction(self._copy_action)
         # Toolbar.
-        self.layout().addWidget(ToolBar(
-            self.action_ToggleOnTop,
+        actions = [
             self.action_SelectFont,
             self.action_Clear,
             self.action_Save,
-        ))
+        ]
+        if not utils.is_wayland:            
+            # Wayland does not support window on top.
+            actions.insert(0, self.action_ToggleOnTop)
+
+        self.layout().addWidget(ToolBar(*actions))
         self.action_Clear.setEnabled(False)
         self.action_Save.setEnabled(False)
         engine.signal_connect('config_changed', self.on_config_changed)

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -221,12 +221,7 @@ class PaperTape(Tool, Ui_PaperTape):
 
     @Slot(bool)
     def toggle_ontop(self, ontop):
-        flags = self.windowFlags()
-        if ontop:
-            flags |= Qt.WindowType.WindowStaysOnTopHint
-        else:
-            flags &= ~Qt.WindowType.WindowStaysOnTopHint
-        self.setWindowFlags(flags)
+        self.setWindowFlag(Qt.WindowStaysOnTopHint, ontop)
         self.show()
 
     @Slot()

--- a/plover/gui_qt/paper_tape.py
+++ b/plover/gui_qt/paper_tape.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import (
     Qt,
     Slot,
 )
-from PySide6.QtGui import QFont
+from PySide6.QtGui import QFont, QFontDatabase
 from PySide6.QtWidgets import (
     QFileDialog,
     QFontDialog,
@@ -130,6 +130,13 @@ class PaperTape(Tool, Ui_PaperTape):
         self.header.setContentsMargins(4, 0, 0, 0)
         self.styles.addItems(TAPE_STYLES)
         self.tape.setModel(self._model)
+
+        # Set a OS‑native fixed‑width (monospace) font.
+        fixed_font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+        fixed_font.setPointSize(fixed_font.pointSize() + 4)
+        self.header.setFont(fixed_font)
+        self.tape.setFont(fixed_font)
+
         self.tape.setSelectionMode(self.tape.SelectionMode.ExtendedSelection)
         self._copy_action = ActionCopyViewSelectionToClipboard(self.tape)
         self.tape.addAction(self._copy_action)

--- a/plover/gui_qt/paper_tape.ui
+++ b/plover/gui_qt/paper_tape.ui
@@ -10,11 +10,6 @@
     <height>430</height>
    </rect>
   </property>
-  <property name="font">
-   <font>
-    <family>Monospace</family>
-   </font>
-  </property>
   <property name="windowTitle">
    <string notr="true"/>
   </property>

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -155,12 +155,10 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
             return
         if action == self._font_menu_text:
             name = 'text_font'
-            font_options = ()
         elif action == self._font_menu_strokes:
             name = 'strokes_font'
-            font_options = (QFontDialog.FontDialogOption.MonospacedFonts,)
         font = self._get_font(name)
-        ok, font = QFontDialog.getFont(font, self, '', *font_options)
+        ok, font = QFontDialog.getFont(font, self, '')
         if ok:
             self._set_font(name, font)
 

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -160,12 +160,7 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
 
     @Slot(bool)
     def toggle_ontop(self, ontop):
-        flags = self.windowFlags()
-        if ontop:
-            flags |= Qt.WindowType.WindowStaysOnTopHint
-        else:
-            flags &= ~Qt.WindowType.WindowStaysOnTopHint
-        self.setWindowFlags(flags)
+        self.setWindowFlag(Qt.WindowStaysOnTopHint, ontop)
         self.show()
 
     @Slot()

--- a/plover/gui_qt/suggestions_dialog.py
+++ b/plover/gui_qt/suggestions_dialog.py
@@ -16,6 +16,7 @@ from plover import _
 from plover.suggestions import Suggestion
 from plover.formatting import RetroFormatter
 
+from plover.gui_qt import utils
 from plover.gui_qt.suggestions_dialog_ui import Ui_SuggestionsDialog
 from plover.gui_qt.utils import ToolBar
 from plover.gui_qt.tool import Tool
@@ -46,11 +47,16 @@ class SuggestionsDialog(Tool, Ui_SuggestionsDialog):
         self.setupUi(self)
         self._last_suggestions = None
         # Toolbar.
-        self.layout().addWidget(ToolBar(
-            self.action_ToggleOnTop,
+        actions = [
             self.action_SelectFont,
             self.action_Clear,
-        ))
+        ]
+        if not utils.is_wayland:            
+            # Wayland does not support window on top.
+            actions.insert(0, self.action_ToggleOnTop)
+
+        self.layout().addWidget(ToolBar(*actions))
+
         self.action_Clear.setEnabled(False)
         # Font popup menu.
         self._font_menu = QMenu()

--- a/plover/gui_qt/utils.py
+++ b/plover/gui_qt/utils.py
@@ -9,11 +9,14 @@ from PySide6.QtWidgets import (
     QToolBar,
     QToolButton,
     QWidget,
+    QApplication,
 )
 import importlib.resources
 
 from plover import _
 
+def is_wayland():
+    return "wayland" in QApplication.platformName().lower()
 
 def ActionCopyViewSelectionToClipboard(view):
     def copy_selection_to_clipboard():

--- a/plover/system/__init__.py
+++ b/plover/system/__init__.py
@@ -53,7 +53,7 @@ _EXPORTS = {
     'IMPLICIT_HYPHENS'         : lambda mod: {l.replace('-', '')
                                               for l in mod.IMPLICIT_HYPHEN_KEYS},
     'ORTHOGRAPHY_WORDS'        : lambda mod: _load_wordlist(mod.ORTHOGRAPHY_WORDLIST, mod.DICTIONARIES_ROOT),
-    'ORTHOGRAPHY_RULES'        : lambda mod: [(re.compile(pattern, re.I), replacement)
+    'ORTHOGRAPHY_RULES'        : lambda mod: [(re.compile(pattern, re.IGNORECASE), replacement)
                                               for pattern, replacement in mod.ORTHOGRAPHY_RULES],
     'ORTHOGRAPHY_RULES_ALIASES': lambda mod: dict(mod.ORTHOGRAPHY_RULES_ALIASES),
     'KEYMAPS'                  : lambda mod: mod.KEYMAPS,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fixes warnings similar to this one: `WARNING: Qt: Populating font family aliases took 67 ms. Replace uses of missing font family "Verdana,Geneva,DejaVu Sans,sans-serif" with one that exists to avoid this cost. `

Affected are:
* Add Translation (default font)
* Paper Tape (default font)
* Info Browser of the Plugins Manager (fonts specified in SVG images that are linked in the plugin README)

Also disables the "pin window to the top" functionality on Wayland since it's not supported there.

Tested on macOS, Windows, and Linux.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
