### PR TITLE
Add dvorak keyboard layout

### DIFF
--- a/news.d/feature/1746.linux.md
+++ b/news.d/feature/1746.linux.md
@@ -1,0 +1,1 @@
+Add dvorak keymap support for uinput users.

--- a/plover/config.py
+++ b/plover/config.py
@@ -338,7 +338,7 @@ class Config:
         boolean_option('start_capitalized', False, OUTPUT_CONFIG_SECTION),
         int_option('undo_levels', DEFAULT_UNDO_LEVELS, MINIMUM_UNDO_LEVELS, None, OUTPUT_CONFIG_SECTION),
         int_option('time_between_key_presses', DEFAULT_TIME_BETWEEN_KEY_PRESSES, MINIMUM_TIME_BETWEEN_KEY_PRESSES, None, OUTPUT_CONFIG_SECTION),
-        choice_option("keyboard_layout", ("qwerty", "qwertz", "colemak", "colemak-dh"), OUTPUT_CONFIG_SECTION),
+        choice_option("keyboard_layout", ("qwerty", "qwertz", "colemak", "colemak-dh", "dvorak"), OUTPUT_CONFIG_SECTION),
         # Logging.
         path_option('log_file_name', expand_path('strokes.log'), LOGGING_CONFIG_SECTION, 'log_file'),
         boolean_option('enable_stroke_logging', False, LOGGING_CONFIG_SECTION),

--- a/plover/gui_qt/config_window.py
+++ b/plover/gui_qt/config_window.py
@@ -400,6 +400,7 @@ class ConfigWindow(QDialog, Ui_ConfigWindow, WindowStateMixin):
                                 "qwertz": "qwertz",
                                 "colemak": "colemak",
                                 "colemak-dh": "colemak-dh",
+                                "dvorak": "dvorak",
                             }),
                             _("Set the keyboard layout configurad in your system.\n"
                               "This only applies when using Linux/BSD and not using X11."))

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -275,6 +275,46 @@ LAYOUTS = {
         "k": e.KEY_N,
         "h": e.KEY_M,
     },
+    "dvorak": {
+        **BASE_LAYOUT,
+        # Symbols
+        "/": e.KEY_LEFTBRACE,
+        "=": e.KEY_RIGHTBRACE,
+        "-": e.KEY_APOSTROPHE,
+        # Top row
+        "'": e.KEY_Q,
+        ",": e.KEY_W,
+        ".": e.KEY_E,
+        "p": e.KEY_R,
+        "y": e.KEY_T,
+        "f": e.KEY_Y,
+        "g": e.KEY_U,
+        "c": e.KEY_I,
+        "r": e.KEY_O,
+        "l": e.KEY_P,
+        # Middle row
+        "a": e.KEY_A,
+        "o": e.KEY_S,
+        "e": e.KEY_D,
+        "u": e.KEY_F,
+        "i": e.KEY_G,
+        "d": e.KEY_H,
+        "h": e.KEY_J,
+        "t": e.KEY_K,
+        "n": e.KEY_L,
+        "s": e.KEY_SEMICOLON,
+        # Bottom row
+        ";": e.KEY_Z,
+        "q": e.KEY_X,
+        "j": e.KEY_C,
+        "k": e.KEY_V,
+        "x": e.KEY_B,
+        "b": e.KEY_N,
+        "m": e.KEY_M,
+        "w": e.KEY_COMMA,
+        "v": e.KEY_DOT,
+        "z": e.KEY_SLASH,
+    },
 }
 
 KEYCODE_TO_KEY = dict(zip(LAYOUTS[DEFAULT_LAYOUT].values(), LAYOUTS[DEFAULT_LAYOUT].keys()))

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -277,10 +277,6 @@ LAYOUTS = {
     },
     "dvorak": {
         **BASE_LAYOUT,
-        # Symbols
-        "/": e.KEY_LEFTBRACE,
-        "=": e.KEY_RIGHTBRACE,
-        "-": e.KEY_APOSTROPHE,
         # Top row
         "'": e.KEY_Q,
         ",": e.KEY_W,
@@ -292,6 +288,8 @@ LAYOUTS = {
         "c": e.KEY_I,
         "r": e.KEY_O,
         "l": e.KEY_P,
+        "/": e.KEY_LEFTBRACE,
+        "=": e.KEY_RIGHTBRACE,
         # Middle row
         "a": e.KEY_A,
         "o": e.KEY_S,
@@ -303,6 +301,7 @@ LAYOUTS = {
         "t": e.KEY_K,
         "n": e.KEY_L,
         "s": e.KEY_SEMICOLON,
+        "-": e.KEY_APOSTROPHE,
         # Bottom row
         ";": e.KEY_Z,
         "q": e.KEY_X,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Adds `dvorak` as a choice in the keyboard layouts dropdown in the options screen for uinput users.

Provides a temporary workaround until a proper solution emerges for #1726.

### Pull Request Checklist
- [ ] ~~Changes have tests~~ _I couldn't find any tests for colemak, so I haven't added any new ones. Let me know if I missed something._

- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
