### PR TITLE
Fix python dependencies for plugins manager

### DIFF
--- a/news.d/bugfix/1750.core.md
+++ b/news.d/bugfix/1750.core.md
@@ -1,0 +1,1 @@
+Update plover-plugins-manager and related Python dependencies.

--- a/reqs/constraints.txt
+++ b/reqs/constraints.txt
@@ -1,10 +1,10 @@
 appdirs==1.4.4
 appnope==0.1.2
-attrs==21.2.0
+attrs==24.3.0
 Babel==2.9.1
 bleach==4.1.0
 build==0.7.0
-cattrs==1.8.0
+cattrs==25.1.1
 certifi==2021.10.8
 cffi==1.15.0
 chardet==4.0.0
@@ -30,11 +30,11 @@ keyring==23.2.1
 mac-alias==2.2.0
 MarkupSafe==2.0.1
 mock==4.0.3
-packaging==21.0
+packaging==25.0
 pep517==0.12.0
 pip==21.3.1
-pkginfo==1.8.1
-plover-plugins-manager==0.7.2
+pkginfo==1.12.1.2
+plover-plugins-manager==0.7.9
 plover-stroke==1.1.0
 plover-treal==1.0.1
 pluggy==1.0.0
@@ -55,8 +55,8 @@ python-xlib==0.31
 pytz==2021.3
 PyYAML==6.0
 readme-renderer==30.0
-requests==2.26.0
-requests-cache==0.9.1
+requests==2.32.3
+requests-cache==1.2.1
 requests-futures==1.0.0
 requests-toolbelt==0.9.1
 rfc3986==1.5.0
@@ -70,7 +70,7 @@ towncrier==24.8.0
 tqdm==4.62.3
 twine==3.7.0
 url-normalize==1.4.3
-urllib3==1.26.7
+urllib3==1.26.18
 wcwidth==0.2.5
 webencodings==0.5.1
 wheel==0.37.0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Updates the plugins manager to version 0.7.9 as well as other Python dependencies that are needed to make the plugins manager work, mainly regarding the parsing of plugin version numbers.

Tested successfully on Windows, Linux, and macOS.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
