### PR TITLE
Update PyPI release to trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1014,6 +1014,9 @@ jobs:
     name: Release
     environment: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     needs: [analyze, test_linux, test_macos, test_windows, test_python_latest_supported, test_python_312, test_python_311, test_python_310, test_qt_gui, test_packaging, test_code_quality, build_linux, build_macos, build_windows]
     if: >-
       !cancelled()
@@ -1059,15 +1062,16 @@ jobs:
           RELEASE_VERSION: ${{ needs.test_packaging.outputs.version }}
         run: publish_github_release
 
-      - name: Publish PyPI release
-        if: needs.analyze.outputs.release_type == 'tagged'
-        env:
-          TWINE_NON_INTERACTIVE: 1
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          # Optional: twine will fallback to default if empty.
-          TWINE_REPOSITORY_URL: ${{ secrets.PYPI_URL }}
-        run: publish_pypi_release
-  # }}}
+      - name: Collect Python distributions for PyPI
+        run: |
+          mkdir -p dist/pypi
+          cp dist/Source/*.tar.gz dist/pypi/
+          cp dist/Wheel/*.whl dist/pypi/
 
-# vim: foldmethod=marker foldlevel=0
+      - name: Publish release to PyPI (Trusted Publishing)
+        if: needs.analyze.outputs.release_type == 'tagged'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/pypi
+          skip-existing: true
+  # }}}

--- a/.github/workflows/ci/helpers.sh
+++ b/.github/workflows/ci/helpers.sh
@@ -190,11 +190,6 @@ EOF
     "$tag" "${assets[@]}"
 }
 
-publish_pypi_release()
-{
-  run "$python" -m twine upload dist/Source/* dist/Wheel/*
-}
-
 analyze_set_release_info()
 {
   info "GITHUB_REF: $GITHUB_REF"

--- a/.github/workflows/ci/workflow_template.yml
+++ b/.github/workflows/ci/workflow_template.yml
@@ -274,6 +274,9 @@ jobs:
     name: Release
     environment: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     needs: [analyze, <@ jobs|join(', ', attribute='id') @>]
     if: >-
       !cancelled()
@@ -309,15 +312,16 @@ jobs:
           RELEASE_VERSION: ${{ needs.test_packaging.outputs.version }}
         run: publish_github_release
 
-      - name: Publish PyPI release
-        if: needs.analyze.outputs.release_type == 'tagged'
-        env:
-          TWINE_NON_INTERACTIVE: 1
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          # Optional: twine will fallback to default if empty.
-          TWINE_REPOSITORY_URL: ${{ secrets.PYPI_URL }}
-        run: publish_pypi_release
-  # }}}
+      - name: Collect Python distributions for PyPI
+        run: |
+          mkdir -p dist/pypi
+          cp dist/Source/*.tar.gz dist/pypi/
+          cp dist/Wheel/*.whl dist/pypi/
 
-# vim: foldmethod=marker foldlevel=0
+      - name: Publish release to PyPI (Trusted Publishing)
+        if: needs.analyze.outputs.release_type == 'tagged'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/pypi
+          skip-existing: true
+  # }}}


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Updates the PyPI release to [trusted publishing](https://docs.pypi.org/trusted-publishers/). This way, we don't need to store a PyPI token in our secrets. This is both more convenient and secure.

This was already tested during the v4.0.3 release.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
