### PR TITLE
Uinput: Refactor initialization and cleanup

### DIFF
--- a/news.d/feature/1765.linux.md
+++ b/news.d/feature/1765.linux.md
@@ -1,0 +1,1 @@
+Uinput: refactor initialization and cleanup.

--- a/plover/oslayer/linux/keyboardcontrol_uinput.py
+++ b/plover/oslayer/linux/keyboardcontrol_uinput.py
@@ -499,10 +499,13 @@ class KeyboardCapture(Capture):
             raise
 
     def cancel(self):
-        if self._device_thread_read_pipe is None or self._device_thread_write_pipe is None:
+        if (
+            self._device_thread_read_pipe is None
+            or self._device_thread_write_pipe is None
+        ):
             # The only way for these pipes to be None is if pipe creation in start() failed
             # In that case, no other code after pipe creation would have run such as selectors.register or thread creation,
-            # so no cleanup is required
+            # and no cleanup is required
             return
         # Write some arbitrary data to the pipe to signal the _run thread to stop
         os.write(self._device_thread_write_pipe, b"a")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Refactor UInput start and cancel code to simplify error handling and remove the unused `_running` variable.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
