### PR TITLE
Add babel to dev requirement

### DIFF
--- a/reqs/dev.txt
+++ b/reqs/dev.txt
@@ -3,5 +3,6 @@
 -r dist.txt
 -r dist_extra_gui_qt.txt
 -r test.txt
+babel
 pre-commit
 tox


### PR DESCRIPTION


## Summary of changes

As in the title. I think this is reasonable enough, you need `babel` to build the package (but mostly if I want to `pip install -e . --verbose --no-build-isolation`, even though the official development guide recommend `tox`)

note that it's already included in `setup.txt`, so an alternative is to add ` -r setup.txt`. I don't know what `wheel` package is for though.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] ~News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details~ (no new feature, should be unimportant)
