### PR TITLE
Fix plugin manager handling of editable packages

### DIFF
--- a/news.d/bugfix/1802.ui.md
+++ b/news.d/bugfix/1802.ui.md
@@ -1,0 +1,1 @@
+Make the plugin manager handle some exceptional cases.

--- a/plover/plugins_manager/registry.py
+++ b/plover/plugins_manager/registry.py
@@ -143,6 +143,7 @@ class Registry:
                 pkg.available = metadata
                 if (
                     pkg.current
+                    and pkg.current.version is not None
                     and pkg.current.parsed_version < pkg.latest.parsed_version
                 ):
                     pkg.status = "outdated"


### PR DESCRIPTION
## Summary of changes

Sometimes `pkg.current.version` or `metadata.name` can be `None`.

Reproducing this is somewhat nontrivial, but I believe it has something to do with editable package.

- unzip [a.zip](https://github.com/user-attachments/files/24419625/a.zip) into some folder say `~/plover_retro_transform` (I can't remember why I wrote this, it was a long time ago, probably `plover_retro_stringop` nowadays can do the same)
- in the virtual environment containing Plover, run `pip install -e ~/plover_retro_transform`
- open Plover
- open the plugin manager
- see error

```
.../site-packages/pkginfo/distribution.py:187: UnknownMetadataVersion: Unknown metadata version: None
  warnings.warn(UnknownMetadataVersion(self.metadata_version))
2026-01-04 08:59:23,367 [Thread-71 (_update_packages)] ERROR: Error in updating packages
Traceback (most recent call last):
  File ".../plover/gui_qt/plugins_manager.py", line 150, in _update_packages
    self._packages.update()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File ".../plover/plugins_manager/registry.py", line 146, in update
    and pkg.current.parsed_version < pkg.latest.parsed_version
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../plover/plugins_manager/plugin_metadata.py", line 31, in parsed_version
    return parse(self.version)
  File ".../venv/lib/python3.13/site-packages/packaging/version.py", line 56, in parse
    return Version(version)
  File ".../venv/lib/python3.13/site-packages/packaging/version.py", line 200, in __init__
    match = self._regex.search(version)
TypeError: expected string or bytes-like object, got 'NoneType'
```

the blanket catch now cannot be hit (as far as I can tell) after the underlying is fixed, but _just in case_ there's some other bug lurking there, then the user get an error message instead of "buggy-looking" GUI (e.g. progress bar loads indefinitely)

Looking at the code, there can't be any behavioral difference in cases where previously there's no error.

### Pull Request Checklist
- [ ] ~Changes have tests~ (looks hard to unit test)
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
