### PR TITLE
Avoid passing str to os._exit

### DIFF
--- a/news.d/bugfix/1803.core.md
+++ b/news.d/bugfix/1803.core.md
@@ -1,0 +1,1 @@
+Fix a corner case in `plover -s (script)`.

--- a/plover/scripts/main.py
+++ b/plover/scripts/main.py
@@ -115,8 +115,11 @@ def main():
                         code = entrypoint.load()()
                     except SystemExit as e:
                         code = e.code
-                if code is None:
-                    code = 0
+                    if code is None:
+                        code = 0
+                    elif not isinstance(code, int):  # sys.exit() also takes a string
+                        log.error(code)
+                        code = 1
             else:
                 print("available script(s):")
                 dist = None


### PR DESCRIPTION
## Summary of changes

As explained in https://github.com/opensteno/plover/issues/1522 and the code comment.

I haven't tried reproducing the original issue, but I try hacking in a `sys.exit("a")` in the `try:` block and run `plover -s pip`.

Closes https://github.com/opensteno/plover/issues/1522

### Pull Request Checklist
- [ ] ~Changes have tests~ (looks hard to unit test)
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
