### PR TITLE
Make Plover HID not fail on startup

### DIFF
--- a/news.d/bugfix/1808.core.md
+++ b/news.d/bugfix/1808.core.md
@@ -1,0 +1,1 @@
+Avoid error at startup if `hidapi` library is not available.

--- a/plover/machine/plover_hid.py
+++ b/plover/machine/plover_hid.py
@@ -7,12 +7,12 @@ https://github.com/dnaq/plover-machine-hid
 Plover HID is a simple HID-based protocol that sends the current state
 of the steno machine every time that state changes.
 """
+from __future__ import annotations
 
 from plover.machine.base import ThreadedStenotypeBase
 from plover.misc import boolean
 from plover import log
 
-import hid
 import time
 import platform
 import ctypes
@@ -21,6 +21,10 @@ from queue import Queue, Empty
 from typing import Dict
 from dataclasses import dataclass
 
+try:
+    import hid
+except ImportError:
+    hid = None
 
 def _darwin_disable_exclusive_open():
     lib = getattr(hid, "hidapi", None)
@@ -36,7 +40,7 @@ def _darwin_disable_exclusive_open():
 
 
 # Invoke once at import time (before any devices are opened)
-if platform.system() == "Darwin":
+if platform.system() == "Darwin" and hid is not None:
     _darwin_disable_exclusive_open()
 
 USAGE_PAGE: int = 0xFF50
@@ -82,7 +86,7 @@ class PloverHid(ThreadedStenotypeBase):
                   A- O-       -E -U
         X1  X2  X3  X4  X5  X6  X7  X8  X9  X10
         X11 X12 X13 X14 X15 X16 X17 X18 X19 X20
-        X21 X22 X23 X24 X25 X26 
+        X21 X22 X23 X24 X25 X26
     '''
     # fmt: on
 
@@ -250,6 +254,9 @@ class PloverHid(ThreadedStenotypeBase):
 
     def start_capture(self):
         self.finished.clear()
+        global hid
+        if hid is None:
+            import hid  # likely raises ImportError
         self._initializing()
         # Enumerate all hid devices on the machine and if we find one with our
         # usage page and usage we try to connect to it.


### PR DESCRIPTION
## Summary of changes

From the [documentation of `hid`](https://pypi.org/project/hid/) (typo not mine):

> pyhidapi is dependant upon the [hidapi library](https://github.com/libusb/hidapi), which must be installed separately.

This may not be [installed](https://github.com/libusb/hidapi?tab=readme-ov-file#installing-hidapi), which means the import may raise `ImportError`.

For me, if that library is not installed, `import hid` fails with

```
ImportError: Unable to load any of the following libraries:libhidapi-hidraw.so libhidapi-hidraw.so.0 libhidapi-libusb.so libhidapi-libusb.so.0 libhidapi-iohidmanager.so libhidapi-iohidmanager.so.0 lib hidapi.dylib hidapi.dll libhidapi-0.dll
```

at startup. This change makes it so that it only fail when the user tries to select `Plover HID` as the input source.

Note: we don't actually need to depend on `hid`, that can be left as an optional dependency.

The `from __future__ import annotations` is just in case, because there are several type annotations that use `hid.something`, and on sufficiently-old Python versions they will actually be evaluated and raise errors (depends on what is the minimum-supported version this may not be necessary)

Note: only tested on Linux.

Note: I consider the case where the first `import hid` fails but the second succeed _extremely_ unlikely, but it may look cleaner to capture the error message in the first import and `log.error()` it when started.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
