### PR TITLE
Avoid modifier release immediately followed by modifier press

### DIFF
--- a/news.d/feature/1810.linux.md
+++ b/news.d/feature/1810.linux.md
@@ -1,0 +1,1 @@
+Avoid unnecessary rapid modifier key press/release while typing.


### PR DESCRIPTION

## Summary of changes

If the user wants to type an all-uppercase string e.g. `ABC`,

before this change, the following events will be sent

```
+shift
+A
-A
-shift
sync
(delay)
+shift
+B
-B
-shift
sync
(delay)
+shift
+C
-C
-shift
sync
(delay)
```

now we get the following, which is much more reasonable

```
+shift
+A
-A
sync
(delay)
+B
-B
sync
(delay)
+C
-C
-shift
sync
(delay)
```

I recall some issues (laggy Discord on Firefox?) that is suspected to be caused by this behavior (which is likely enough if some heavy logic are executed on shift key press/release), but I can't find the bug report anymore.

Caveat: not sure if news entry should go into linux or core, since I've only implemented it for linux.

### Pull Request Checklist
- [ ] Changes have tests (this part isn't easy to unit test)
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
