### PR TITLE
Update furo version in doc/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx-plover==0.3
-furo==2023.05.20
+furo==2025.12.19
 myst-parser==2.0.0


### PR DESCRIPTION
## Summary of changes

The old version gives me the error

```
Extension error (furo):
Handler <function _html_page_context at 0x72a385eddcf0> for event 'html-page-context' threw an exception (exception: _CascadingStyleSheet is immutable)
```

Admittedly, I haven't investigated why exactly this happens (probably Sphinx version update incompatible with old furo? This `requirements.txt` file does not pin down the exact Sphinx version needed after all) but the fix is simple enough, so why not.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
