### PR TITLE
Fix readthedocs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ __pycache__/
 .DS_Store
 
 # Virtual environments
-/.venv/
+/.venv*/
 /venv/
 
-
-# vim: ft=cfg
+# Doc
+/doc/_build/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,15 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
+  jobs:
+    post_install:
+      - python -m pip install -c reqs/constraints.txt -r reqs/dist.txt
+  apt_packages:
+    - python3-dev
+    - build-essential
 
 python:
   install:

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -17,7 +17,7 @@ You also need [CMake](https://cmake.org) to build [hidapi](https://github.com/li
 
 A typical development setup looks like this, assuming that `python` has the correct version:
 
-### Linux/macOS (Bash):
+## Linux/macOS (Bash):
 
 ```bash
 cd path/to/plover
@@ -30,7 +30,7 @@ tox
 tox -e launch -- -l debug
 ```
 
-### Windows (PowerShell):
+## Windows (PowerShell):
 
 This assumes that you installed a Git version that includes Git Bash.
 
@@ -46,6 +46,26 @@ pre-commit run --all-files
 ```
 
 Some features require a Bash shell, which is why on Windows you need to run commands through Git Bash or similar.
+
+## Read the Docs build (Docker)
+
+To reproduce the Read the Docs build locally, use the official RTD build image.
+The image defaults to a non-root user, so run as root to install packages.
+
+```bash
+docker run --rm -it --platform=linux/amd64 -u root -v "$PWD":/work -w /work readthedocs/build:ubuntu-24.04-2024.06.17 bash
+
+apt-get update
+apt-get install -y python3 python3-venv python3-dev build-essential
+python3 -m venv .venv-rtd
+. .venv-rtd/bin/activate
+python -m pip install --upgrade pip setuptools
+python -m pip install -c reqs/constraints.txt -r reqs/dist.txt
+python -m pip install -r doc/requirements.txt
+python -m sphinx -b html -W doc doc/_build/html
+```
+
+The HTML output is in `doc/_build/html/index.html`.
 
 ## Tox
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 sphinx-plover==0.3
 furo==2025.12.19
-myst-parser==2.0.0
+myst-parser==5.0.0
+appdirs==1.4.4


### PR DESCRIPTION
This is needed because the [readthedocs builds](https://app.readthedocs.org/projects/plover/builds/) are failing since #1813.

autodoc was also causing issues which requires the `reqs/dist.txt` dependencies to be installed or otherwise we get errors like this:

```
Warning, treated as error:
autodoc: failed to import module 'engine' from module 'plover'; the following exception was raised:
No module named 'plover_stroke'
```

Also added instructions on how to run this locally.

I didn't find a way to properly test the `.readthedocs.yml` so I guess we'll have to test in production.

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
