### PR TITLE
Hook up modifier aliases for wayland output

### DIFF
--- a/news.d/bugfix/1838.linux.md
+++ b/news.d/bugfix/1838.linux.md
@@ -1,0 +1,1 @@
+Fix modifier alias keys in wayland.

--- a/plover/oslayer/linux/keyboardlayout_wayland.py
+++ b/plover/oslayer/linux/keyboardlayout_wayland.py
@@ -9,6 +9,7 @@ import threading
 from xkbcommon import xkb
 from evdev import ecodes as e, util
 
+from plover.key_combo import add_modifiers_aliases
 from plover.oslayer.linux.wayland_connection import (
     WaylandConnection,
     wayland_keymap_event_loop,
@@ -198,6 +199,8 @@ def generate_plover_keymap_from_xkb_keymap_and_modifiers(
     # Ensures that "\n" is mapped to the enter/return key instead of Linefeed.
     if "return" in plover_key_to_keycode:
         plover_key_to_keycode["\n"] = plover_key_to_keycode["return"]
+
+    add_modifiers_aliases(plover_key_to_keycode)
 
     return plover_key_to_keycode
 


### PR DESCRIPTION
Without this, aliases like "control" don't work.

## Summary of changes

Without this, aliases like "control" don't work, resulting in an error message like: "Key control is not valid!".

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
